### PR TITLE
[FIXED JENKINS-37828] Properly reject parallel

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -97,10 +97,14 @@ stages {
 
 stages {
     stage('parallel-stage') {
-        parallel([
-            firstBlock: 'echo "First block of the parallel"',
-            secondBlock: 'echo "Second block of the parallel"'
-        ])
+        parallel(
+            firstBlock: {
+                echo "First block of the parallel"
+            },
+            secondBlock: {
+                echo "Second block of the parallel"
+            }
+        )
     }
 }
 ```

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -70,6 +70,7 @@ to-be-released block-scoped `stage` syntax in base Pipeline.
 * *Takes a Closure*: Yes
 * *Closure Contents*: One or more Pipeline steps, including block-scoped steps and the special `script` block described below.
     * *NOTE*: Only the "declarative subset" of Groovy is allowed by default. See below for details on that subset.
+    * *NOTE*: The `parallel` step is a special case - it can only be used if it's the sole step in the `stage`.
 * *Examples*:
 
 ```
@@ -91,6 +92,15 @@ stages {
             checkout scm
             sh "mvn clean install"
         }
+    }
+}
+
+stages {
+    stage('parallel-stage') {
+        parallel([
+            firstBlock: 'echo "First block of the parallel"',
+            secondBlock: 'echo "Second block of the parallel"'
+        ])
     }
 }
 ```

--- a/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.groovy
@@ -17,7 +17,11 @@ public class ModelASTStep extends ModelASTElement {
     /**
      * A list of step names which are banned from being executed within a step block.
      */
-    public final List<String> blockedSteps = ["stage", "properties"]
+    public final Map<String, String> blockedSteps = [
+        "stage":      "The stage step cannot be used in step blocks in Pipeline Config",
+        "properties": "The properties step cannot be used in step blocks in Pipeline Config",
+        "parallel":   "The parallel step can only be used as the only top-level step in a stage's step block"
+    ]
 
     String name;
     ModelASTArgumentList args;

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -113,7 +113,8 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"emptyPostBuild", "At /pipeline/postBuild/conditions: Array has 0 entries, requires minimum of 1"});
         result.add(new Object[]{"emptyNotifications", "At /pipeline/notifications/conditions: Array has 0 entries, requires minimum of 1"});
 
-        result.add(new Object[]{"rejectStageInSteps", "Invalid step 'stage' used - not allowed in this context"});
+        result.add(new Object[]{"rejectStageInSteps", "Invalid step 'stage' used - not allowed in this context - The stage step cannot be used in step blocks in Pipeline Config"});
+        result.add(new Object[]{"rejectParallelMixedInSteps", "Invalid step 'parallel' used - not allowed in this context - The parallel step can only be used as the only top-level step in a stage's step block"});
 
         result.add(new Object[]{"stageWithoutName", "At /pipeline/stages/0: Missing one or more required properties: 'name'"});
 

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -40,7 +40,14 @@ public class ValidatorTest extends AbstractModelDefTest {
     public void rejectStageInSteps() throws Exception {
         prepRepoWithJenkinsfile("errors", "rejectStageInSteps");
 
-        failWithError("Invalid step 'stage' used - not allowed in this context @ line");
+        failWithError("Invalid step 'stage' used - not allowed in this context - The stage step cannot be used in step blocks in Pipeline Config");
+    }
+
+    @Test
+    public void rejectParallelMixedInSteps() throws Exception {
+        prepRepoWithJenkinsfile("errors", "rejectParallelMixedInSteps");
+
+        failWithError("Invalid step 'parallel' used - not allowed in this context - The parallel step can only be used as the only top-level step in a stage's step block");
     }
 
     @Ignore("I still want to block parallel, but I'm not sure it's worth it, ignoring for now.")

--- a/src/test/resources/errors/rejectParallelMixedInSteps.groovy
+++ b/src/test/resources/errors/rejectParallelMixedInSteps.groovy
@@ -27,8 +27,12 @@ pipeline {
     stages {
         stage("foo") {
             echo "hello"
-            parallel([a: "echo '1'",
-                      b: "echo '2'"])
+            parallel(a: {
+                        echo '1'
+                     },
+                     b: {
+                         echo '2'
+                     })
         }
     }
 }

--- a/src/test/resources/errors/rejectParallelMixedInSteps.groovy
+++ b/src/test/resources/errors/rejectParallelMixedInSteps.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            echo "hello"
+            parallel([a: "echo '1'",
+                      b: "echo '2'"])
+        }
+    }
+}
+
+
+

--- a/src/test/resources/json/errors/rejectParallelMixedInSteps.json
+++ b/src/test/resources/json/errors/rejectParallelMixedInSteps.json
@@ -1,0 +1,40 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps":       [
+        {
+          "name": "echo",
+          "arguments":           {
+            "isConstant": true,
+            "value": "hello"
+          }
+        },
+        {
+          "name": "parallel",
+          "arguments":           [
+            {
+              "key": "a",
+              "value":               {
+                "isConstant": true,
+                "value": "echo '1'"
+              }
+            },
+            {
+              "key": "b",
+              "value":               {
+                "isConstant": true,
+                "value": "echo '2'"
+              }
+            }
+          ]
+        }
+      ]
+    }]
+  }],
+  "agent":   {
+    "isConstant": true,
+    "value": "none"
+  }
+}}


### PR DESCRIPTION
[JENKINS-37828](https://issues.jenkins-ci.org/browse/JENKINS-37828)

More notably, reject it when it's not the only step in a block. In the
JSON representation, we don't even use the term parallel - we just
have multiple branches. In the groovy parsing, we look for parallel as
the only step in a stage and treat it differently (resulting in
multiple branches). So any time we see parallel as a step by the time
we get to validation, well, it's wrong. So, yeah.

Also, tweaks to make sure we don't end up doing validation of steps we've already blacklisted, because that's silly.

cc @reviewbybees @i386 @michaelneale @oleg-nenashev 