### PR TITLE
[JENKINS-38097] Run empty stages for post-failure stages.

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -26,13 +26,10 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.NestedModel
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepBlockWithOtherArgs
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
-import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction
-import org.jenkinsci.plugins.workflow.actions.StageAction
-import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution
 import org.jenkinsci.plugins.workflow.cps.CpsScript
-import org.jenkinsci.plugins.workflow.cps.CpsThread
-import org.jenkinsci.plugins.workflow.graph.FlowNode
 
 import java.lang.reflect.ParameterizedType;
 
@@ -56,7 +53,7 @@ public class Utils {
      * @return True if the field exists and is of the given type.
      */
     @Whitelisted
-    static boolean isFieldA(Class fieldType, Class actualClass, String fieldName) {
+    public static boolean isFieldA(Class fieldType, Class actualClass, String fieldName) {
         def actualFieldName = actualFieldName(actualClass, fieldName)
         def realFieldType = actualClass.metaClass.getMetaProperty(actualFieldName)?.type
 
@@ -75,7 +72,7 @@ public class Utils {
      * @return The real field name, pluralized if necessary, or null if not found.
      */
     @Whitelisted
-    static String actualFieldName(Class actualClass, String fieldName) {
+    public static String actualFieldName(Class actualClass, String fieldName) {
         if (actualClass.metaClass.getMetaProperty(fieldName) != null) {
             return fieldName
         } else if (actualClass.metaClass.getMetaProperty("${fieldName}s") != null) {
@@ -93,7 +90,7 @@ public class Utils {
      * @return The class of the field in the inspected class, or the class contained in the list or map.
      */
     @Whitelisted
-    static Class actualFieldType(Class actualClass, String fieldName) {
+    public static Class actualFieldType(Class actualClass, String fieldName) {
         def actualFieldName = actualFieldName(actualClass, fieldName)
         if (actualFieldName == null) {
             return null
@@ -122,7 +119,7 @@ public class Utils {
      * @return True if the object is an instance of the class, false otherwise
      */
     @Whitelisted
-    static boolean instanceOfWrapper(Class c, Object o) {
+    public static boolean instanceOfWrapper(Class c, Object o) {
         return c.isInstance(o)
     }
 
@@ -134,17 +131,17 @@ public class Utils {
      * @return True if o can be assigned to c, false otherwise
      */
     @Whitelisted
-    static boolean assignableFromWrapper(Class c, Class o) {
+    public static boolean assignableFromWrapper(Class c, Class o) {
         return c.isAssignableFrom(o)
     }
 
     @Whitelisted
-    static Object[] toObjectArray(List<Object> origList) {
+    public static Object[] toObjectArray(List<Object> origList) {
         return origList.toArray()
     }
 
     @Whitelisted
-    static boolean hasScmContext(CpsScript script) {
+    public static boolean hasScmContext(CpsScript script) {
         try {
             // Just rely on SCMVar's own context-checking (via CpsScript) rather than brewing our own.
             script.getProperty("scm")
@@ -153,17 +150,5 @@ public class Utils {
             // If we get an IllegalStateException, "checkout scm" isn't valid, so return false.
             return false
         }
-    }
-
-    @Whitelisted
-    static void setSkippedStage(String stageName) {
-        CpsThread thread = CpsThread.current()
-        CpsFlowExecution execution = thread.execution
-
-        FlowNode currentNode = execution.currentHeads.find { n ->
-            n?.displayName?.equals(stageName)
-        }
-
-        currentNode.actions.add(new NotExecutedNodeAction())
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -64,31 +64,33 @@ public class ModelInterpreter implements Serializable {
                 // We save the caught error, if any, for throwing at the end of the build.
                 nodeOrDockerOrNone(root.agent) {
                     toolsBlock(root.agent, root.tools) {
-                        try {
-                            catchRequiredContextForNode(root.agent) {
-                                // If we have an agent and script.scm isn't null, run checkout scm
-                                if (root.agent.hasAgent() && Utils.hasScmContext(script)) {
-                                    script.checkout script.scm
-                                }
+                            // If we have an agent and script.scm isn't null, run checkout scm
+                            if (root.agent.hasAgent() && Utils.hasScmContext(script)) {
+                                script.checkout script.scm
+                            }
 
-                                for (int i = 0; i < root.stages.getStages().size(); i++) {
-                                    Stage thisStage = root.stages.getStages().get(i)
+                            for (int i = 0; i < root.stages.getStages().size(); i++) {
+                                Stage thisStage = root.stages.getStages().get(i)
 
-                                    script.stage(thisStage.name) {
-                                        Closure closureToCall = thisStage.closureWrapper.closure
-                                        closureToCall.delegate = script
-                                        closureToCall.resolveStrategy = Closure.DELEGATE_FIRST
-                                        closureToCall.call()
+                                script.stage(thisStage.name) {
+                                    if (firstError == null) {
+                                        try {
+                                            catchRequiredContextForNode(root.agent) {
+                                                Closure closureToCall = thisStage.closureWrapper.closure
+                                                closureToCall.delegate = script
+                                                closureToCall.resolveStrategy = Closure.DELEGATE_FIRST
+                                                closureToCall.call()
+                                            }.call()
+                                        } catch (Exception e) {
+                                            script.echo "Error in stages execution: ${e.getMessage()}"
+                                            script.getProperty("currentBuild").result = Result.FAILURE
+                                            if (firstError == null) {
+                                                firstError = e
+                                            }
+                                        }
                                     }
                                 }
-                            }.call()
-                        } catch (Exception e) {
-                            script.echo "Error in stages execution: ${e.getMessage()}"
-                            script.getProperty("currentBuild").result = Result.FAILURE
-                            if (firstError == null) {
-                                firstError = e
                             }
-                        }
 
                         try {
                             catchRequiredContextForNode(root.agent) {

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -88,6 +88,8 @@ public class ModelInterpreter implements Serializable {
                                                 firstError = e
                                             }
                                         }
+                                    } else {
+                                        Utils.setSkippedStage(thisStage.name)
                                     }
                                 }
                             }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -88,8 +88,6 @@ public class ModelInterpreter implements Serializable {
                                                 firstError = e
                                             }
                                         }
-                                    } else {
-                                        Utils.setSkippedStage(thisStage.name)
                                     }
                                 }
                             }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -88,6 +88,8 @@ public class ModelInterpreter implements Serializable {
                                                 firstError = e
                                             }
                                         }
+                                    } else {
+                                        script.echo "Skipping stage due to earlier failure(s)"
                                     }
                                 }
                             }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -88,8 +88,6 @@ public class ModelInterpreter implements Serializable {
                                                 firstError = e
                                             }
                                         }
-                                    } else {
-                                        script.echo "Skipping stage due to earlier failure(s)"
                                     }
                                 }
                             }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -30,6 +30,7 @@ import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -106,6 +107,18 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         j.assertLogContains("hello", b);
         j.assertLogContains("[Pipeline] { (bar)", b);
         j.assertLogContains("goodbye", b);
+    }
+
+    @Issue("JENKINS-38097")
+    @Test
+    public void allStagesExist() throws Exception {
+        prepRepoWithJenkinsfile("allStagesExist");
+
+        WorkflowRun b = getAndStartBuild();
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b));
+        j.assertLogContains("[Pipeline] { (foo)", b);
+        j.assertLogContains("hello", b);
+        j.assertLogContains("[Pipeline] { (bar)", b);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -28,10 +28,6 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import jenkins.util.VirtualFile;
 import org.apache.commons.io.IOUtils;
-import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
-import org.jenkinsci.plugins.workflow.flow.FlowExecution;
-import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
-import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -123,22 +119,6 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         j.assertLogContains("[Pipeline] { (foo)", b);
         j.assertLogContains("hello", b);
         j.assertLogContains("[Pipeline] { (bar)", b);
-        FlowExecution execution = b.getExecution();
-        FlowGraphWalker walker = new FlowGraphWalker(execution);
-        boolean foundSkippedBar = false;
-        boolean foundExecutedFoo = false;
-
-        for (FlowNode node : walker) {
-            if (node.getDisplayName().equals("bar") && node.getAction(NotExecutedNodeAction.class) != null) {
-                foundSkippedBar = true;
-            }
-            if (node.getDisplayName().equals("foo") && node.getAction(NotExecutedNodeAction.class) == null) {
-                foundExecutedFoo = true;
-            }
-        }
-
-        assertTrue("Executed stage foo either doesn't exist or is marked as skipped", foundExecutedFoo);
-        assertTrue("Post-failure stage bar either doesn't exist or isn't marked as skipped", foundSkippedBar);
     }
 
     @Test

--- a/src/test/resources/allStagesExist.groovy
+++ b/src/test/resources/allStagesExist.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            error "hello"
+        }
+        stage("bar") {
+            echo "goodbye"
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
[JENKINS-38097](https://issues.jenkins-ci.org/browse/JENKINS-38097)

To ensure that we always have the same stage execution order
(including the synthetic postBuild/notification stages), we now switch
to still running stages after a failure, but not running anything *in*
them. I don't know if there's some way we can set those post-failure
stages as "skipped"?

cc @reviewbybees esp @michaelneale @i386 and @vivek - if you've got any ideas on how to mark a stage skipped, that'd be great. =)