### PR TITLE
[FIXED JENKINS-38426] Require non-literal env vars to be single-quoted.

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -103,12 +103,12 @@ public class Root implements NestedModel, Serializable {
      * Helper method for translating the key/value pairs in the {@link Environment} into a list of "key=value" strings
      * suitable for use with the withEnv step.
      *
-     * @return a list of "key=value" strings.
+     * @return a list of [key,value] lists.
      */
     @Whitelisted
-    List<String> getEnvVars() {
+    List<List<Object>> getEnvVars() {
         return environment.collect { k, v ->
-            "${k}=${v}"
+            [k, v]
         }
     }
 

--- a/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -196,6 +196,10 @@ class ModelParser {
                                 errorCollector.error(key, "Duplicate environment variable name: '${key.key}'")
                                 return
                             } else {
+                                if (exp.rightExpression instanceof GStringExpression) {
+                                    errorCollector.error(key, "Non-literal environment variable ${getSourceText(exp.rightExpression)} must be in single-quotes")
+                                    return
+                                }
                                 r.variables[parseKey(exp.leftExpression)] = parseArgument(exp.rightExpression)
                                 return
                             }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -61,7 +61,7 @@ public class ModelInterpreter implements Serializable {
 
         if (root != null) {
             // Entire build, including notifications, runs in the withEnv.
-            script.withEnv(root.getEnvVars()) {
+            script.withEnv(getEnvVars(root)) {
                 // Stage execution and post-build actions run in try/catch blocks, so we still run post-build actions
                 // even if the build fails, and we still send notifications if the build and/or post-build actions fail.
                 // We save the caught error, if any, for throwing at the end of the build.
@@ -242,5 +242,17 @@ public class ModelInterpreter implements Serializable {
                 }
             }
         }
+    }
+
+    def getEnvVars(Root r) {
+        List<String> envList = []
+        List<List<String>> rawEnv = r.getEnvVars()
+        for (int i = 0; i < rawEnv.size(); i++) {
+            def k = rawEnv.get(i).get(0)
+            def v = rawEnv.get(i).get(1)
+
+            envList.add("${k}=${script.evaluate("\"${v}\"")}")
+        }
+        return envList
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -102,6 +102,7 @@ public abstract class AbstractModelDefTest {
             "simplePostBuild",
             "simpleTools",
             "legacyMetaStepSyntax",
+            "nonLiteralEnvironment",
             "globalLibrarySuccess"
     );
 

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -251,6 +251,13 @@ public class ValidatorTest extends AbstractModelDefTest {
         failWithError("Missing required section 'agent'");
     }
 
+    @Test
+    public void doubleQuotedNonLiteralEnvironment() throws Exception {
+        prepRepoWithJenkinsfile("errors", "doubleQuotedNonLiteralEnvironment");
+
+        failWithError("Non-literal environment variable \"${currentBuild.getNumber()}\" must be in single-quotes");
+    }
+
     private void failWithError(final String... errors) throws Exception {
         failWithErrorAndPossiblySlave(false, errors);
     }

--- a/src/test/resources/errors/doubleQuotedNonLiteralEnvironment.groovy
+++ b/src/test/resources/errors/doubleQuotedNonLiteralEnvironment.groovy
@@ -21,41 +21,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugins.pipeline.modeldefinition;
 
-import hudson.slaves.DumbSlave;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Test;
-
-/**
- * @author Andrew Bayer
- */
-public class EnvironmentTest extends AbstractModelDefTest {
-
-    @Test
-    public void simpleEnvironment() throws Exception {
-        prepRepoWithJenkinsfile("simpleEnvironment");
-
-        DumbSlave s = j.createOnlineSlave();
-        s.setLabelString("some-label");
-
-        WorkflowRun b = getAndStartBuild();
-        j.assertBuildStatusSuccess(j.waitForCompletion(b));
-        j.assertLogContains("[Pipeline] { (foo)", b);
-        j.assertLogContains("FOO is BAR", b);
+pipeline {
+    environment {
+        FOO = "BAR"
+        BUILD_NUM_ENV = "${currentBuild.getNumber()}"
     }
 
-    @Test
-    public void nonLiteralEnvironment() throws Exception {
-        prepRepoWithJenkinsfile("nonLiteralEnvironment");
+    agent label:"some-label"
 
-        DumbSlave s = j.createOnlineSlave();
-        s.setLabelString("some-label");
-
-        WorkflowRun b = getAndStartBuild();
-        j.assertBuildStatusSuccess(j.waitForCompletion(b));
-        j.assertLogContains("[Pipeline] { (foo)", b);
-        j.assertLogContains("FOO is BAR", b);
-        j.assertLogContains("BUILD_NUM_ENV is 1", b);
+    stages {
+        stage("foo") {
+            sh 'echo "FOO is $FOO"'
+            sh 'echo "BUILD_NUM_ENV is $BUILD_NUM_ENV"'
+        }
     }
 }
+
+

--- a/src/test/resources/json/nonLiteralEnvironment.json
+++ b/src/test/resources/json/nonLiteralEnvironment.json
@@ -1,0 +1,47 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps":       [
+        {
+          "name": "sh",
+          "arguments":           {
+            "isConstant": true,
+            "value": "echo \"FOO is $FOO\""
+          }
+        },
+        {
+          "name": "sh",
+          "arguments":           {
+            "isConstant": true,
+            "value": "echo \"BUILD_NUM_ENV is $BUILD_NUM_ENV\""
+          }
+        }
+      ]
+    }]
+  }],
+  "environment":   [
+    {
+      "key": "FOO",
+      "value":       {
+        "isConstant": true,
+        "value": "BAR"
+      }
+    },
+    {
+      "key": "BUILD_NUM_ENV",
+      "value":       {
+        "isConstant": true,
+        "value": "${currentBuild.getNumber()}"
+      }
+    }
+  ],
+  "agent": [  {
+    "key": "label",
+    "value":     {
+      "isConstant": true,
+      "value": "some-label"
+    }
+  }]
+}}

--- a/src/test/resources/nonLiteralEnvironment.groovy
+++ b/src/test/resources/nonLiteralEnvironment.groovy
@@ -21,41 +21,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugins.pipeline.modeldefinition;
 
-import hudson.slaves.DumbSlave;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Test;
-
-/**
- * @author Andrew Bayer
- */
-public class EnvironmentTest extends AbstractModelDefTest {
-
-    @Test
-    public void simpleEnvironment() throws Exception {
-        prepRepoWithJenkinsfile("simpleEnvironment");
-
-        DumbSlave s = j.createOnlineSlave();
-        s.setLabelString("some-label");
-
-        WorkflowRun b = getAndStartBuild();
-        j.assertBuildStatusSuccess(j.waitForCompletion(b));
-        j.assertLogContains("[Pipeline] { (foo)", b);
-        j.assertLogContains("FOO is BAR", b);
+pipeline {
+    environment {
+        FOO = "BAR"
+        BUILD_NUM_ENV = '${currentBuild.getNumber()}'
     }
 
-    @Test
-    public void nonLiteralEnvironment() throws Exception {
-        prepRepoWithJenkinsfile("nonLiteralEnvironment");
+    agent label:"some-label"
 
-        DumbSlave s = j.createOnlineSlave();
-        s.setLabelString("some-label");
-
-        WorkflowRun b = getAndStartBuild();
-        j.assertBuildStatusSuccess(j.waitForCompletion(b));
-        j.assertLogContains("[Pipeline] { (foo)", b);
-        j.assertLogContains("FOO is BAR", b);
-        j.assertLogContains("BUILD_NUM_ENV is 1", b);
+    stages {
+        stage("foo") {
+            sh 'echo "FOO is $FOO"'
+            sh 'echo "BUILD_NUM_ENV is $BUILD_NUM_ENV"'
+        }
     }
 }
+
+


### PR DESCRIPTION
[JENKINS-38426](https://issues.jenkins-ci.org/browse/JENKINS-38426)

This way, we can delay evaluation until runtime in the right context
and get the right values without any security exception etc.

This may not be ideal - but as of right now, it's the best approach
I've got.

cc @reviewbybees esp @vivek @rsandell @HRMPW @michaelneale @i386