### PR TITLE
[FIXED JENKINS-38426] Allow non-literal expressions in env vars.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/MethodMissingWrapperWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/MethodMissingWrapperWhitelist.java
@@ -41,7 +41,9 @@ import java.lang.reflect.Method;
 public class MethodMissingWrapperWhitelist extends Whitelist {
     @Override
     public boolean permitsMethod(@Nonnull Method method, @Nonnull Object receiver, @Nonnull Object[] args) {
-        return (method.getName().equals("invokeMethod") || method.getName().equals("setProperty"))
+        return (method.getName().equals("invokeMethod") ||
+                method.getName().equals("setProperty") ||
+                method.getName().equals("getProperty"))
                 && MethodMissingWrapper.class.isAssignableFrom(receiver.getClass());
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
@@ -195,7 +195,7 @@ public class ClosureModelTranslator implements MethodMissingWrapper, Serializabl
     private void resolveClosure(Object closureObj, Object translator) {
         Closure argClosure = closureObj
         argClosure.delegate = translator
-        argClosure.resolveStrategy = Closure.DELEGATE_ONLY
+        argClosure.resolveStrategy = Closure.DELEGATE_FIRST
         argClosure.call()
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
@@ -30,6 +30,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.NestedModel
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.PropertiesToMap
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepBlockWithOtherArgs
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepsBlock
+import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 /**
  * CPS-transformed code for translating from the closure argument to the pipeline step into the runtime model.
@@ -39,6 +40,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepsBlock
 public class ClosureModelTranslator implements MethodMissingWrapper, Serializable {
     Map<String,Object> actualMap = [:]
     Class<NestedModel> actualClass
+    CpsScript script
 
     /**
      * Placeholder to make sure 'agent none' works.
@@ -50,8 +52,9 @@ public class ClosureModelTranslator implements MethodMissingWrapper, Serializabl
      */
     boolean any = true
 
-    ClosureModelTranslator(Class clazz) {
+    ClosureModelTranslator(Class clazz, CpsScript s) {
         actualClass = clazz
+        this.script = s
     }
 
     NestedModel toNestedModel() {
@@ -84,7 +87,7 @@ public class ClosureModelTranslator implements MethodMissingWrapper, Serializabl
                 if (Utils.assignableFromWrapper(AbstractBuildConditionResponder.class, actualClass)) {
                     actualMap[methodName] = createStepsBlock(argValue)
                 } else {
-                    def ctm = new ClosureModelTranslator(MappedClosure.class)
+                    def ctm = new ClosureModelTranslator(MappedClosure.class, script)
 
                     resolveClosure(argValue, ctm)
 
@@ -129,13 +132,13 @@ public class ClosureModelTranslator implements MethodMissingWrapper, Serializabl
                     }
                     // if it's a PropertiesToMap, we use PropertiesToMapTranslator to translate it into the right form.
                     else if (Utils.assignableFromWrapper(PropertiesToMap.class, actualType)) {
-                        def ptm = new PropertiesToMapTranslator()
+                        def ptm = new PropertiesToMapTranslator(script)
                         resolveClosure(argValue, ptm)
                         resultValue = ptm.toNestedModel(actualType)
                     }
                     // And lastly, recurse - this must be another container block.
                     else {
-                        def ctm = new ClosureModelTranslator(actualType)
+                        def ctm = new ClosureModelTranslator(actualType, script)
 
                         resolveClosure(argValue, ctm)
                         // If it's a ModelForm, the result value is the ModelForm equivalent of the Map.

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -53,7 +53,7 @@ public class ModelInterpreter implements Serializable {
         ClosureModelTranslator m = new ClosureModelTranslator(Root.class)
 
         closure.delegate = m
-        closure.resolveStrategy = Closure.DELEGATE_ONLY
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
         closure.call()
 
         Root root = m.toNestedModel()

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -50,7 +50,7 @@ public class ModelInterpreter implements Serializable {
         // Attach the stages model to the run for introspection etc.
         Utils.attachExecutionModel(script)
 
-        ClosureModelTranslator m = new ClosureModelTranslator(Root.class)
+        ClosureModelTranslator m = new ClosureModelTranslator(Root.class, script)
 
         closure.delegate = m
         closure.resolveStrategy = Closure.DELEGATE_FIRST

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
@@ -33,7 +33,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.NestedModel
 public class PropertiesToMapTranslator implements MethodMissingWrapper, Serializable {
     Map<String,Object> actualMap = [:]
 
-    void setProperty(String s, args) {
+    void propertyMissing(String s, args) {
         actualMap.put(s, args)
     }
 

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.MethodMissingWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.NestedModel
+import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 /**
  * Translates a closure containing one or more "foo = 'bar'" statements into a map.
@@ -32,6 +33,16 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.NestedModel
  */
 public class PropertiesToMapTranslator implements MethodMissingWrapper, Serializable {
     Map<String,Object> actualMap = [:]
+    CpsScript script
+
+    PropertiesToMapTranslator(CpsScript script) {
+        this.script = script
+    }
+
+    def methodMissing(String s, args) {
+        return script."${s}"(args)
+    }
+
 
     void propertyMissing(String s, args) {
         actualMap.put(s, args)

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -283,6 +283,9 @@ public abstract class AbstractModelDefTest {
                 "def bar() { return x+'-get' }",
                 "def baz() { return 'nothing here' }")
                 , "\n"));
+        FileUtils.writeStringToFile(new File(vars, "returnAThing.groovy"), StringUtils.join(Arrays.asList(
+                "def call(a) { return \"${a} tada\" }"), "\n"
+        ));
         FileUtils.writeStringToFile(new File(vars, "acmeFunc.groovy"), StringUtils.join(Arrays.asList(
                 "def call(a,b) { echo \"call($a,$b)\" }")
                 , "\n"));

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -58,6 +58,7 @@ public class EnvironmentTest extends AbstractModelDefTest {
         j.assertLogContains("FOO is BAR", b);
         j.assertLogContains("BUILD_NUM_ENV is 1", b);
         j.assertLogContains("ANOTHER_ENV is 1", b);
+        j.assertLogContains("INHERITED_ENV is 1 is inherited", b);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -45,4 +45,19 @@ public class EnvironmentTest extends AbstractModelDefTest {
         j.assertLogContains("FOO is BAR", b);
     }
 
+    @Test
+    public void nonLiteralEnvironment() throws Exception {
+        prepRepoWithJenkinsfile("nonLiteralEnvironment");
+
+        DumbSlave s = j.createOnlineSlave();
+        s.setLabelString("some-label");
+
+        WorkflowRun b = getAndStartBuild();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+        j.assertLogContains("[Pipeline] { (foo)", b);
+        j.assertLogContains("FOO is BAR", b);
+        j.assertLogContains("BUILD_NUM_ENV is 1", b);
+        j.assertLogContains("ANOTHER_ENV is 1", b);
+    }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -59,6 +59,7 @@ public class EnvironmentTest extends AbstractModelDefTest {
         j.assertLogContains("BUILD_NUM_ENV is 1", b);
         j.assertLogContains("ANOTHER_ENV is 1", b);
         j.assertLogContains("INHERITED_ENV is 1 is inherited", b);
+        j.assertLogContains("ACME_FUNC is [banana] tada", b);
     }
 
 }

--- a/src/test/resources/nonLiteralEnvironment.groovy
+++ b/src/test/resources/nonLiteralEnvironment.groovy
@@ -28,6 +28,7 @@ pipeline {
         BUILD_NUM_ENV = currentBuild.getNumber()
         ANOTHER_ENV = "${currentBuild.getNumber()}"
         INHERITED_ENV = "\${BUILD_NUM_ENV} is inherited"
+        ACME_FUNC = returnAThing("banana")
     }
 
     agent label:"some-label"
@@ -38,6 +39,7 @@ pipeline {
             sh 'echo "BUILD_NUM_ENV is $BUILD_NUM_ENV"'
             sh 'echo "ANOTHER_ENV is $ANOTHER_ENV"'
             sh 'echo "INHERITED_ENV is $INHERITED_ENV"'
+            sh 'echo "ACME_FUNC is $ACME_FUNC"'
         }
     }
 }

--- a/src/test/resources/nonLiteralEnvironment.groovy
+++ b/src/test/resources/nonLiteralEnvironment.groovy
@@ -27,6 +27,7 @@ pipeline {
         FOO = "BAR"
         BUILD_NUM_ENV = currentBuild.getNumber()
         ANOTHER_ENV = "${currentBuild.getNumber()}"
+        INHERITED_ENV = "\${BUILD_NUM_ENV} is inherited"
     }
 
     agent label:"some-label"
@@ -36,6 +37,7 @@ pipeline {
             sh 'echo "FOO is $FOO"'
             sh 'echo "BUILD_NUM_ENV is $BUILD_NUM_ENV"'
             sh 'echo "ANOTHER_ENV is $ANOTHER_ENV"'
+            sh 'echo "INHERITED_ENV is $INHERITED_ENV"'
         }
     }
 }

--- a/src/test/resources/nonLiteralEnvironment.groovy
+++ b/src/test/resources/nonLiteralEnvironment.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO = "BAR"
+        BUILD_NUM_ENV = currentBuild.getNumber()
+        ANOTHER_ENV = "${currentBuild.getNumber()}"
+    }
+
+    agent label:"some-label"
+
+    stages {
+        stage("foo") {
+            sh 'echo "FOO is $FOO"'
+            sh 'echo "BUILD_NUM_ENV is $BUILD_NUM_ENV"'
+            sh 'echo "ANOTHER_ENV is $ANOTHER_ENV"'
+        }
+    }
+}
+
+


### PR DESCRIPTION
[JENKINS-38426](https://issues.jenkins-ci.org/browse/JENKINS-38426)

Allowing fall-through delegation and whitelisting getProperty(s) on
ClosureModelTranslator and PropertiesToMapTranslator lets us do env
vars with values like:
- "${currentBuild.getNumber()}"
- currentBuild.getNumber()

Can't do "${PREVIOUSLY_DEFINED_ENV}_something" yet, though. Still
trying to figure that one out.

This replaces #20 

cc @reviewbybees esp @rsandell @i386 @michaelneale @HRMPW