### PR TITLE
A secret step

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep.java
@@ -94,7 +94,7 @@ public class SecretStep extends AbstractStepImpl implements Serializable {
 
         @Override
         public Step newInstance(@CheckForNull StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
-            if (req.findAncestor(Snippetizer.class) != null) {
+            if (req != null && req.findAncestor(Snippetizer.class) != null) {
                 String text = formData.optString("text");
                 if (text != null) {
                     try {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.steps;
+
+import com.google.inject.Inject;
+import com.trilead.ssh2.crypto.Base64;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import jenkins.security.ConfidentialKey;
+import jenkins.security.ConfidentialStore;
+import jenkins.security.CryptoConfidentialKey;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.ArrayUtils;
+import org.jenkinsci.plugins.workflow.cps.Snippetizer;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.StreamCorruptedException;
+import java.util.Map;
+
+/**
+ * Provides a step to decrypt an encrypted string literal
+ */
+public class SecretStep extends AbstractStepImpl implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String text;
+
+    @DataBoundConstructor
+    public SecretStep(String text) {
+        this.text = text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        private static final int SALT_LENGTH = 8;
+        private static final CryptoConfidentialKey KEY = new CryptoConfidentialKey(SecretStep.class.getName());
+
+        public DescriptorImpl() {
+            super(StepExecutionImpl.class);
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "secret";
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Provide an encrypted secret that will be decrypted in runtime";
+        }
+
+        @Override
+        public Step newInstance(@CheckForNull StaplerRequest req, @Nonnull JSONObject formData) throws FormException {
+            if (req.findAncestor(Snippetizer.class) != null) {
+                String text = formData.optString("text");
+                if (text != null) {
+                    try {
+                        formData.put("text", encrypt(text));
+                    } catch (Exception e) {
+                        throw new FormException("Could not encrypt the text: " + e.getMessage(), e, "text");
+                    }
+                }
+            }
+            return super.newInstance(req, formData);
+        }
+
+        @Restricted(NoExternalUse.class)
+        public static String decrypt(String secret) throws IOException, BadPaddingException, IllegalBlockSizeException {
+            byte[] bytes = Base64.decode(secret.toCharArray());
+            byte[] both = KEY.decrypt().doFinal(bytes);
+            byte[] prefix = new byte[SALT_LENGTH];
+            System.arraycopy(both, 0, prefix, 0, prefix.length);
+            byte[] suffix = new byte[SALT_LENGTH];
+            System.arraycopy(both, both.length - suffix.length, suffix, 0, suffix.length);
+            byte[] actual = new byte[both.length - (SALT_LENGTH*2) - 6];
+            System.arraycopy(both, SALT_LENGTH + 3, actual, 0, actual.length);
+            ArrayUtils.reverse(suffix);
+            if (!ArrayUtils.isEquals(prefix, suffix)) {
+                throw new StreamCorruptedException("Salt check differs! Are you using the original key?");
+            }
+            return new String(actual, "UTF-8");
+        }
+
+        @Restricted(NoExternalUse.class)
+        public static String encrypt(String plainText) throws IOException, BadPaddingException, IllegalBlockSizeException {
+            byte[] bytes = (":::" + plainText + ":::").getBytes("UTF-8");
+            byte[] salt = ConfidentialStore.get().randomBytes(SALT_LENGTH);
+            byte[] both = new byte[bytes.length + salt.length + salt.length];
+            System.arraycopy(salt, 0, both, 0, salt.length);
+            System.arraycopy(bytes, 0, both, salt.length, bytes.length);
+            ArrayUtils.reverse(salt);
+            System.arraycopy(salt, 0, both, salt.length + bytes.length, salt.length);
+
+            return new String(Base64.encode(KEY.encrypt().doFinal(both)));
+        }
+    }
+
+    public static final class StepExecutionImpl extends AbstractSynchronousNonBlockingStepExecution<String> {
+        private static final long serialVersionUID = 1L;
+
+        @Inject
+        private SecretStep step;
+
+        @Override
+        public String run() throws Exception {
+            return DescriptorImpl.decrypt(step.getText());
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
@@ -40,7 +40,14 @@ public class PropertiesToMapTranslator implements MethodMissingWrapper, Serializ
     }
 
     def methodMissing(String s, args) {
-        return script."${s}"(args)
+        def argValue
+        if (args.length > 1) {
+            argValue = args
+        } else if (args.length == 1) {
+            argValue = args[0]
+        }
+
+        return script."${s}"(argValue)
     }
 
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep/config.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep/config.groovy
@@ -1,0 +1,31 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+
+def f = namespace(lib.FormTagLib)
+
+f.entry(title: _("Text"), field: "text") {
+    f.password()
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep/help-text.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStep/help-text.html
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2016, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  ~
+  -->
+
+<p>
+    The unencrypted plain text you want to protect. The generated groovy will be with the encrypted version of this text.
+</p>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -67,7 +67,7 @@ public class EnvironmentTest extends AbstractModelDefTest {
         j.assertLogContains("BUILD_NUM_ENV is 1", b);
         j.assertLogContains("ANOTHER_ENV is 1", b);
         j.assertLogContains("INHERITED_ENV is 1 is inherited", b);
-        j.assertLogContains("ACME_FUNC is [banana] tada", b);
+        j.assertLogContains("ACME_FUNC is banana tada", b);
     }
 
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStepTest.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.steps;
+
+import org.hamcrest.core.StringContains;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.jenkinsci.plugins.pipeline.modeldefinition.steps.SecretStep.DescriptorImpl.decrypt;
+import static org.jenkinsci.plugins.pipeline.modeldefinition.steps.SecretStep.DescriptorImpl.encrypt;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link SecretStep}.
+ */
+public class SecretStepTest extends AbstractModelDefTest {
+
+    @Test
+    public void decryptEncrypt() throws Exception {
+        String expected = "Hello World";
+        String s = encrypt(expected);
+        assertEquals(expected, decrypt(s));
+    }
+
+    @Test
+    public void consecutiveEncryptionNotEqual() throws Exception {
+        String plain = "Hello World";
+        String s1 = encrypt(plain);
+        String s2 = encrypt(plain);
+        String s3 = encrypt(plain);
+
+        assertNotEquals(s1, s2);
+        assertNotEquals(s1, s3);
+        assertNotEquals(s2, s3);
+
+        assertEquals(decrypt(s1), decrypt(s2));
+        assertEquals(decrypt(s1), decrypt(s3));
+        assertEquals(decrypt(s2), decrypt(s3));
+    }
+
+    @Test
+    public void worksInVanillaPipelineWithEnv() throws Exception {
+        String plainText = "Bobby`s lil secret";
+        String script = "node {\n" +
+                "    withEnv([\"FOO=${secret('"+encrypt(plainText)+"')}\"]) {\n" +
+                "        sh 'echo \"FOO is $FOO\"'\n" +
+                "    }\n" +
+                "}\n";
+        assertThat(script, not(containsString(plainText)));
+        prepRepoWithJenkinsfileFromString(script);
+        WorkflowRun build = getAndStartBuild();
+        j.assertBuildStatusSuccess(j.waitForCompletion(build));
+        j.assertLogContains("FOO is " + plainText, build);
+    }
+
+    @Test
+    public void worksInEnvironment() throws Exception {
+        String plainText = "Bobby`s lil secret";
+        String script = "pipeline {\n" +
+                "    environment {\n" +
+                "        FOO = secret('"+encrypt(plainText)+"')\n" +
+                "    }\n" +
+                "\n" +
+                "    agent label:\"some-label\"\n" +
+                "\n" +
+                "    stages {\n" +
+                "        stage(\"foo\") {\n" +
+                "            steps {\n" +
+                "                sh 'echo \"FOO is $FOO\"'\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        assertThat(script, not(containsString(plainText)));
+        prepRepoWithJenkinsfileFromString(script);
+        WorkflowRun build = getAndStartBuild();
+        j.assertBuildStatusSuccess(j.waitForCompletion(build));
+        j.assertLogContains("FOO is " + plainText, build);
+    }
+}

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/SecretStepTest.java
@@ -25,6 +25,8 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.steps;
 
+import hudson.slaves.DumbSlave;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
 import org.hamcrest.core.StringContains;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -81,6 +83,10 @@ public class SecretStepTest extends AbstractModelDefTest {
 
     @Test
     public void worksInEnvironment() throws Exception {
+        DumbSlave s = j.createOnlineSlave();
+        s.setLabelString("some-label docker");
+        s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONSLAVE", "true")));
+
         String plainText = "Bobby`s lil secret";
         String script = "pipeline {\n" +
                 "    environment {\n" +


### PR DESCRIPTION
That can decrypt a string literal.
The Snippetizer page provides a way to encrypt a plain text string.

This can be considered a PoC for how I interpreted the examples of this step.

@reviewbybees 

The test case `worksInEnvironment` currently fails, I'm trying to figure out why. Somehow the descriptor is complaining that the parameter is of the wrong type when called from inside `environment {}`
