### PR TITLE
[JENKINS-38433] Make the agent section pluggable.

### DIFF
--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
     <version>0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.13</version>
+    <version>2.17</version>
     <relativePath/>
   </parent>
 
@@ -36,7 +36,7 @@
   <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Model API</name>
-  <description>An opinionated, declarative Pipeline</description>
+  <description>Model API for Declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 
   <licenses>
@@ -90,23 +90,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemProperties>
-            <property>
-              <name>hudson.udp</name>
-              <value>33849</value>
-            </property>
-          </systemProperties>
-          <argLine>-Xmx4g -XX:MaxPermSize=256m</argLine>
-          <reuseForks>true</reuseForks>
-          <forkCount>0.5C</forkCount>
-          <!-- TODO: I hate the retrying tests but given the nondeterministic whackiness of JENKINS-37101... -->
-          <rerunFailingTestsCount>3</rerunFailingTestsCount>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -25,41 +25,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>2.17</version>
-    <relativePath/>
+    <groupId>org.jenkinsci.plugins</groupId>
+    <artifactId>pipeline-model-parent</artifactId>
+    <version>0.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>
   <artifactId>pipeline-model-api</artifactId>
-  <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Model API</name>
   <description>Model API for Declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
-
-  <licenses>
-    <license>
-        <name>MIT</name>
-        <url>http://opensource.org/licenses/MIT</url>
-        <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <id>abayer</id>
-      <name>Andrew Bayer</name>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git://git@github.com/jenkinsci/pipeline-config-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-config-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-config-plugin</url>
-    <tag>HEAD</tag>
-  </scm>
 
   <dependencies>
     <dependency>
@@ -69,53 +46,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <version>1.4</version>
-        <configuration>
-          <providerSelection>1.8</providerSelection>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generateStubs</goal>
-              <goal>compile</goal>
-              <goal>generateTestStubs</goal>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
-  <properties>
-    <jenkins.version>2.7.1</jenkins.version>
-    <java.level>7</java.level>
-    <groovy.version>2.4.7</groovy.version>
-  </properties>
-  
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
   
 </project>

--- a/pipeline-model-declarative-agent/pom.xml
+++ b/pipeline-model-declarative-agent/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
     <version>0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-declarative-agent/pom.xml
+++ b/pipeline-model-declarative-agent/pom.xml
@@ -36,7 +36,7 @@
   <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Declarative Agent API</name>
-  <description>An opinionated, declarative Pipeline</description>
+  <description>API for declarative agents in Declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 
   <licenses>
@@ -89,23 +89,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemProperties>
-            <property>
-              <name>hudson.udp</name>
-              <value>33849</value>
-            </property>
-          </systemProperties>
-          <argLine>-Xmx4g -XX:MaxPermSize=256m</argLine>
-          <reuseForks>true</reuseForks>
-          <forkCount>0.5C</forkCount>
-          <!-- TODO: I hate the retrying tests but given the nondeterministic whackiness of JENKINS-37101... -->
-          <rerunFailingTestsCount>3</rerunFailingTestsCount>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/pipeline-model-declarative-agent/pom.xml
+++ b/pipeline-model-declarative-agent/pom.xml
@@ -25,41 +25,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>2.13</version>
-    <relativePath/>
+    <groupId>org.jenkinsci.plugins</groupId>
+    <artifactId>pipeline-model-parent</artifactId>
+    <version>0.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>
   <artifactId>pipeline-model-declarative-agent</artifactId>
-  <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Declarative Agent API</name>
   <description>API for declarative agents in Declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 
-  <licenses>
-    <license>
-        <name>MIT</name>
-        <url>http://opensource.org/licenses/MIT</url>
-        <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <id>abayer</id>
-      <name>Andrew Bayer</name>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git://git@github.com/jenkinsci/pipeline-config-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-config-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-config-plugin</url>
-    <tag>HEAD</tag>
-  </scm>
 
   <dependencies>
     <dependency>
@@ -68,53 +46,5 @@
       <version>2.18</version>
     </dependency>
   </dependencies>
-  
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <version>1.4</version>
-        <configuration>
-          <providerSelection>1.8</providerSelection>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generateStubs</goal>
-              <goal>compile</goal>
-              <goal>generateTestStubs</goal>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
-  <properties>
-    <jenkins.version>2.7.1</jenkins.version>
-    <java.level>7</java.level>
-    <groovy.version>2.4.7</groovy.version>
-  </properties>
-  
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
-  
+    
 </project>

--- a/pipeline-model-declarative-agent/pom.xml
+++ b/pipeline-model-declarative-agent/pom.xml
@@ -32,10 +32,10 @@
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>
-  <artifactId>pipeline-model-definition</artifactId>
+  <artifactId>pipeline-model-declarative-agent</artifactId>
   <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
-  <name>Pipeline: Model Definition</name>
+  <name>Pipeline: Declarative Agent API</name>
   <description>An opinionated, declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 
@@ -60,6 +60,14 @@
     <url>https://github.com/jenkinsci/pipeline-config-plugin</url>
     <tag>HEAD</tag>
   </scm>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.18</version>
+    </dependency>
+  </dependencies>
   
   <build>
     <plugins>
@@ -100,135 +108,7 @@
 
     </plugins>
   </build>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-declarative-agent</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-job</artifactId>
-      <version>2.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-multibranch</artifactId>
-      <version>2.8</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-scm-step</artifactId>
-      <version>2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-basic-steps</artifactId>
-      <version>2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>pipeline-stage-step</artifactId>
-      <version>2.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>docker-workflow</artifactId>
-      <version>1.8</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-      <version>1.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>script-security</artifactId>
-      <version>1.22</version>
-    </dependency>
 
-    <!-- JSON schema stuff -->
-    <dependency>
-      <groupId>com.github.fge</groupId>
-      <artifactId>json-schema-validator</artifactId>
-      <version>2.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-json-org</artifactId>
-      <version>2.2.3</version>
-    </dependency>
-
-    <!-- TEST deps --> 
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git</artifactId>
-      <version>2.6.0</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness-tools</artifactId>
-      <version>2.0</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps-global-lib</artifactId>
-      <version>2.3</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>git</artifactId>
-      <version>2.6.0</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-scm-step</artifactId>
-      <version>2.2</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-support</artifactId>
-        <version>2.2</version>
-        <classifier>tests</classifier>
-        <scope>test</scope>
-    </dependency>
-    
-  </dependencies>
-  
   <properties>
     <jenkins.version>2.7.1</jenkins.version>
     <java.level>7</java.level>

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -24,21 +24,19 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
 
-import groovy.lang.GroovyCodeSource;
-import groovy.lang.GroovyShell;
 import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
-import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.CpsThread;
 
-import javax.annotation.Nonnull;
 import java.io.Serializable;
-import java.net.URL;
 
-import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
-
+/**
+ * Implementations for {@link DeclarativeAgentDescriptor} - pluggable agent backends for Declarative Pipelines.
+ *
+ * @author Andrew Bayer
+ */
 public abstract class DeclarativeAgent extends AbstractDescribableImpl<DeclarativeAgent> implements Serializable, ExtensionPoint {
 
     /**

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
+
+import groovy.lang.GroovyCodeSource;
+import groovy.lang.GroovyShell;
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+import org.jenkinsci.plugins.workflow.cps.CpsThread;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.net.URL;
+
+import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
+
+public abstract class DeclarativeAgent extends AbstractDescribableImpl<DeclarativeAgent> implements Serializable, ExtensionPoint {
+
+    /**
+     * ONLY TO BE RUN FROM WITHIN A CPS THREAD. Parses the script source and loads it.
+     * TODO: Decide if we want to cache the resulting objects or just *shrug* and re-parse them every time.
+     *
+     * @return The script object for this declarative agent.
+     * @throws Exception if the script source cannot be loaded or we're called from outside a CpsThread.
+     */
+    @SuppressWarnings("unchecked")
+    @Whitelisted
+    public DeclarativeAgentScript getScript(CpsScript cpsScript) throws Exception {
+        CpsThread c = CpsThread.current();
+        if (c == null)
+            throw new IllegalStateException("Expected to be called from CpsThread");
+
+        return (DeclarativeAgentScript) cpsScript.getClass().getClassLoader()
+                .loadClass(getDescriptor().getDeclarativeAgentScriptClass())
+                .getConstructor(CpsScript.class, DeclarativeAgent.class)
+                .newInstance(cpsScript, this);
+    }
+
+    @Override
+    public DeclarativeAgentDescriptor getDescriptor() {
+        return (DeclarativeAgentDescriptor) super.getDescriptor();
+    }
+}

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
@@ -130,6 +130,24 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
     }
 
     /**
+     * An ordered list of all descriptor names.
+     *
+     * @return A list of names
+     */
+    public static List<String> getOrderedNames() {
+        List<String> orderedNames = new ArrayList<>();
+
+        for (DeclarativeAgentDescriptor d : getOrderedDescriptors()) {
+            Set<String> symbolValues = SymbolLookup.getSymbolValue(d);
+            if (symbolValues != null && !symbolValues.isEmpty()) {
+                orderedNames.add(symbolValues.iterator().next());
+            }
+        }
+
+        return orderedNames;
+    }
+
+    /**
      * Get the descriptor for a given name or null if not found.
      *
      * @param name The name for the descriptor to look up

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
+
+import hudson.ExtensionComponent;
+import hudson.ExtensionList;
+import hudson.model.Descriptor;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.jenkinsci.plugins.structs.SymbolLookup;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeAgent> {
+
+    public abstract @Nonnull String getName();
+
+    public abstract @Nonnull String getDeclarativeAgentScriptClass();
+    
+    public DeclarativeAgent newInstance(Map<String,Object> arguments) throws Exception {
+        return new DescribableModel<>(clazz).instantiate(arguments);
+    }
+
+    public UninstantiatedDescribable uninstantiate(DeclarativeAgent declarativeAgent) throws UnsupportedOperationException {
+        return DescribableModel.uninstantiate2_(declarativeAgent);
+    }
+
+    public static ExtensionList<DeclarativeAgentDescriptor> all() {
+        return ExtensionList.lookup(DeclarativeAgentDescriptor.class);
+    }
+
+    public static Map<String,DescribableModel> getDescribableModels() {
+        Map<String,DescribableModel> models = new HashMap<>();
+
+        for (DeclarativeAgentDescriptor d : getOrderedDescriptors()) {
+            Set<String> symbolValues = SymbolLookup.getSymbolValue(d);
+
+            if (!symbolValues.isEmpty()) {
+                models.put(symbolValues.iterator().next(), new DescribableModel<>(d.clazz));
+            }
+
+        }
+
+        return models;
+    }
+
+    public static Map<String,DescribableModel> singleArgModels() {
+        Map<String,DescribableModel> models = new HashMap<>();
+
+        for (Map.Entry<String,DescribableModel> entry : getDescribableModels().entrySet()) {
+            if (entry.getValue().getParameters().isEmpty()) {
+                models.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return models;
+    }
+
+    public static List<DeclarativeAgentDescriptor> getOrderedDescriptors() {
+        List<DeclarativeAgentDescriptor> orderedDescriptors = new ArrayList<>();
+
+        List<ExtensionComponent<DeclarativeAgentDescriptor>> extensionComponents = new ArrayList<>(all().getComponents());
+        Collections.sort(extensionComponents);
+
+        for (ExtensionComponent<DeclarativeAgentDescriptor> extensionComponent: extensionComponents) {
+            orderedDescriptors.add(extensionComponent.getInstance());
+        }
+
+        return orderedDescriptors;
+    }
+
+    public static List<String> getOrderedNames() {
+        List<String> orderedNames = new ArrayList<>();
+
+        for (DeclarativeAgentDescriptor d : getOrderedDescriptors()) {
+            Set<String> symbolValues = SymbolLookup.getSymbolValue(d);
+
+            if (!symbolValues.isEmpty()) {
+                orderedNames.add(symbolValues.iterator().next());
+            }
+        }
+
+        return orderedNames;
+    }
+
+    @Whitelisted
+    public static @Nullable DeclarativeAgentDescriptor byName(@Nonnull String name) {
+        System.err.println("byName: " + name);
+        for (DeclarativeAgentDescriptor d : all()) {
+            System.err.println("d.n: " + d.getName());
+            if (d.getName().equals(name)) {
+                System.err.println("returning " + d);
+                return d;
+            }
+        }
+        return null;
+    }
+
+    @Whitelisted
+    public static @Nullable DeclarativeAgent instanceForName(@Nonnull String name,
+                                                             Map<String,Object> arguments) throws Exception {
+        DeclarativeAgentDescriptor descriptor = byName(name);
+
+        if (descriptor != null) {
+            if (singleArgModels().keySet().contains(name)) {
+                return descriptor.newInstance(new HashMap<String, Object>());
+            } else {
+                return descriptor.newInstance(arguments);
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
@@ -23,20 +23,15 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
 
-import hudson.ExtensionComponent;
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -127,7 +122,7 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
 
         return models;
     }
-    
+
     /**
      * Get the descriptor for a given name or null if not found.
      *
@@ -135,7 +130,7 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
      * @return The corresponding descriptor or null if not found.
      */
     @Whitelisted
-    public static @Nullable DeclarativeAgentDescriptor byName(@Nonnull String name) {
+    public static @CheckForNull DeclarativeAgentDescriptor byName(@Nonnull String name) {
         return (DeclarativeAgentDescriptor) SymbolLookup.get().findDescriptor(DeclarativeAgent.class, name);
     }
 
@@ -148,8 +143,8 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
      * @throws Exception
      */
     @Whitelisted
-    public static @Nullable DeclarativeAgent instanceForName(@Nonnull String name,
-                                                             Map<String,Object> arguments) throws Exception {
+    public static @CheckForNull DeclarativeAgent instanceForName(@Nonnull String name,
+                                                                 Map<String,Object> arguments) throws Exception {
         DeclarativeAgentDescriptor descriptor = byName(name);
 
         if (descriptor != null) {

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
@@ -40,24 +40,47 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Descriptor for {@link DeclarativeAgent}.
+ *
+ * @author Andrew Bayer
+ */
 public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeAgent> {
 
+    /**
+     * The name for this agent type. Should match the {@code Symbol} on the class.
+     *
+     * @return The name.
+     */
     public abstract @Nonnull String getName();
 
+    /**
+     * The full package and class name for the {@link DeclarativeAgentScript} class corresponding to this.
+     *
+     * @return The class name.
+     */
     public abstract @Nonnull String getDeclarativeAgentScriptClass();
-    
+
+    /**
+     * Creates an instance of the corresponding {@link DeclarativeAgent} from the given arguments.
+     *
+     * @param arguments A map of strings/objects to be passed to the constructor.
+     * @return An instantiated {@link DeclarativeAgent}
+     * @throws Exception
+     */
     public DeclarativeAgent newInstance(Map<String,Object> arguments) throws Exception {
         return new DescribableModel<>(clazz).instantiate(arguments);
-    }
-
-    public UninstantiatedDescribable uninstantiate(DeclarativeAgent declarativeAgent) throws UnsupportedOperationException {
-        return DescribableModel.uninstantiate2_(declarativeAgent);
     }
 
     public static ExtensionList<DeclarativeAgentDescriptor> all() {
         return ExtensionList.lookup(DeclarativeAgentDescriptor.class);
     }
 
+    /**
+     * Get a map of name-to-{@link DescribableModel} of all known/registered descriptors.
+     *
+     * @return A map of name-to-{@link DescribableModel}s
+     */
     public static Map<String,DescribableModel> getDescribableModels() {
         Map<String,DescribableModel> models = new HashMap<>();
 
@@ -73,6 +96,10 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
         return models;
     }
 
+    /**
+     * Get the map of the subset of descriptors with single-arguments - i.e., "none" and "any".
+     * @return A map of descriptors with just one argument.
+     */
     public static Map<String,DescribableModel> singleArgModels() {
         Map<String,DescribableModel> models = new HashMap<>();
 
@@ -85,6 +112,10 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
         return models;
     }
 
+    /**
+     * An ordered (by Extension ordinal, in descending order) list of all descriptors.
+     * @return A list of descriptors.
+     */
     public static List<DeclarativeAgentDescriptor> getOrderedDescriptors() {
         List<DeclarativeAgentDescriptor> orderedDescriptors = new ArrayList<>();
 
@@ -98,33 +129,30 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
         return orderedDescriptors;
     }
 
-    public static List<String> getOrderedNames() {
-        List<String> orderedNames = new ArrayList<>();
-
-        for (DeclarativeAgentDescriptor d : getOrderedDescriptors()) {
-            Set<String> symbolValues = SymbolLookup.getSymbolValue(d);
-
-            if (!symbolValues.isEmpty()) {
-                orderedNames.add(symbolValues.iterator().next());
-            }
-        }
-
-        return orderedNames;
-    }
-
+    /**
+     * Get the descriptor for a given name or null if not found.
+     *
+     * @param name The name for the descriptor to look up
+     * @return The corresponding descriptor or null if not found.
+     */
     @Whitelisted
     public static @Nullable DeclarativeAgentDescriptor byName(@Nonnull String name) {
-        System.err.println("byName: " + name);
         for (DeclarativeAgentDescriptor d : all()) {
-            System.err.println("d.n: " + d.getName());
             if (d.getName().equals(name)) {
-                System.err.println("returning " + d);
                 return d;
             }
         }
         return null;
     }
 
+    /**
+     * For a given name and map of arguments, find the corresponding descriptor and return an instance using those arguments.
+     *
+     * @param name The name of the descriptor
+     * @param arguments A map of arguments
+     * @return The instantiated {@link DeclarativeAgent} instance, or null if the name isn't found.
+     * @throws Exception
+     */
     @Whitelisted
     public static @Nullable DeclarativeAgent instanceForName(@Nonnull String name,
                                                              Map<String,Object> arguments) throws Exception {

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
@@ -127,24 +127,7 @@ public abstract class DeclarativeAgentDescriptor extends Descriptor<DeclarativeA
 
         return models;
     }
-
-    /**
-     * An ordered (by Extension ordinal, in descending order) list of all descriptors.
-     * @return A list of descriptors.
-     */
-    public static List<DeclarativeAgentDescriptor> getOrderedDescriptors() {
-        List<DeclarativeAgentDescriptor> orderedDescriptors = new ArrayList<>();
-
-        List<ExtensionComponent<DeclarativeAgentDescriptor>> extensionComponents = new ArrayList<>(all().getComponents());
-        Collections.sort(extensionComponents);
-
-        for (ExtensionComponent<DeclarativeAgentDescriptor> extensionComponent: extensionComponents) {
-            orderedDescriptors.add(extensionComponent.getInstance());
-        }
-
-        return orderedDescriptors;
-    }
-
+    
     /**
      * Get the descriptor for a given name or null if not found.
      *

--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
+
+import groovy.lang.Closure;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+
+import java.io.Serializable;
+
+public abstract class DeclarativeAgentScript implements Serializable {
+    protected CpsScript script;
+    protected DeclarativeAgent declarativeAgent;
+
+    public DeclarativeAgentScript(CpsScript s, DeclarativeAgent a) {
+        this.script = s;
+        this.declarativeAgent = a;
+    }
+
+    public abstract Closure run(Closure body);
+}

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
     <version>0.5-SNAPSHOT</version>
-    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -81,23 +81,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemProperties>
-            <property>
-              <name>hudson.udp</name>
-              <value>33849</value>
-            </property>
-          </systemProperties>
-          <argLine>-Xmx4g -XX:MaxPermSize=256m</argLine>
-          <reuseForks>true</reuseForks>
-          <forkCount>0.5C</forkCount>
-          <!-- TODO: I hate the retrying tests but given the nondeterministic whackiness of JENKINS-37101... -->
-          <rerunFailingTestsCount>3</rerunFailingTestsCount>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
   

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -114,6 +114,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.18</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
       <version>2.6</version>
     </dependency>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -25,65 +25,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>2.13</version>
-    <relativePath/>
+    <groupId>org.jenkinsci.plugins</groupId>
+    <artifactId>pipeline-model-parent</artifactId>
+    <version>0.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>
   <artifactId>pipeline-model-definition</artifactId>
-  <version>0.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Pipeline: Model Definition</name>
   <description>An opinionated, declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 
-  <licenses>
-    <license>
-        <name>MIT</name>
-        <url>http://opensource.org/licenses/MIT</url>
-        <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <id>abayer</id>
-      <name>Andrew Bayer</name>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git://git@github.com/jenkinsci/pipeline-config-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-config-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-config-plugin</url>
-    <tag>HEAD</tag>
-  </scm>
-  
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.gmaven</groupId>
-        <artifactId>gmaven-plugin</artifactId>
-        <version>1.4</version>
-        <configuration>
-          <providerSelection>1.8</providerSelection>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generateStubs</goal>
-              <goal>compile</goal>
-              <goal>generateTestStubs</goal>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-  
   <dependencies>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -216,30 +170,5 @@
     </dependency>
     
   </dependencies>
-  
-  <properties>
-    <jenkins.version>2.7.1</jenkins.version>
-    <java.level>7</java.level>
-    <groovy.version>2.4.7</groovy.version>
-  </properties>
-  
-  <repositories>
-    <repository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
-  
+    
 </project>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -65,7 +65,7 @@ public class Agent implements Serializable {
      */
     @Whitelisted
     public DeclarativeAgent getDeclarativeAgent() {
-        DeclarativeAgentDescriptor foundDescriptor = DeclarativeAgentDescriptor.orderedDescriptors.find { d ->
+        DeclarativeAgentDescriptor foundDescriptor = DeclarativeAgentDescriptor.all().find { d ->
             arguments.containsKey(d.getName())
         }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -65,9 +65,12 @@ public class Agent implements Serializable {
      */
     @Whitelisted
     public DeclarativeAgent getDeclarativeAgent() {
-        String foundType = DeclarativeAgentDescriptor.orderedNames.find { arguments.containsKey(it) }
-        if (foundType != null) {
-            return DeclarativeAgentDescriptor.instanceForName(foundType, arguments)
+        DeclarativeAgentDescriptor foundDescriptor = DeclarativeAgentDescriptor.orderedDescriptors.find { d ->
+            arguments.containsKey(d.getName())
+        }
+
+        if (foundDescriptor != null) {
+            return DeclarativeAgentDescriptor.instanceForDescriptor(foundDescriptor, arguments)
         } else {
             return null
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -58,6 +58,11 @@ public class Agent implements Serializable {
         this.arguments.put(s, "true")
     }
 
+    /**
+     * Get the appropriate instantiated {@link DeclarativeAgent} corresponding to our arguments.
+     *
+     * @return The instantiated declarative agent or null if not found.
+     */
     @Whitelisted
     public DeclarativeAgent getDeclarativeAgent() {
         String foundType = DeclarativeAgentDescriptor.orderedNames.find { arguments.containsKey(it) }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -91,8 +91,8 @@ public class Root implements NestedModel, Serializable {
     }
 
     @Whitelisted
-    Root agent(Boolean none) {
-        this.agent = new Agent(none)
+    Root agent(String s) {
+        this.agent = new Agent(s)
         return this
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -68,6 +68,11 @@ public class Stage implements NestedModel, Serializable {
         return this
     }
 
+    Stage agent(String s) {
+        this.agent = new Agent(s)
+        return this
+    }
+    
     @Whitelisted
     Stage steps(StepsBlock s) {
         this.steps = s

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -536,7 +536,7 @@ class ModelValidatorImpl implements ModelValidator {
             ModelASTSingleArgument singleArg = (ModelASTSingleArgument) agent.args
             Map<String,DescribableModel> singleArgModels = DeclarativeAgentDescriptor.singleArgModels()
             if (!singleArgModels.containsKey(singleArg.value.getValue())) {
-                errorCollector.error(agent.args, "Invalid argument for agent - '${singleArg.value.getValue()}' - must be map of config options or bare ${singleArgModels.keySet().join(', ')}.")
+                errorCollector.error(agent.args, "Invalid argument for agent - '${singleArg.value.toGroovy()}' - must be map of config options or bare ${singleArgModels.keySet().sort()}.")
                 valid = false
             }
         } else if (agent.args instanceof ModelASTNamedArgumentList) {
@@ -546,7 +546,8 @@ class ModelValidatorImpl implements ModelValidator {
             }
 
             Map<String,DescribableModel> possibleModels = DeclarativeAgentDescriptor.describableModels
-            String typeName = possibleModels.find { k, v -> k in argKeys }.key
+
+            String typeName = DeclarativeAgentDescriptor.orderedNames.find { it in argKeys }
 
             if (typeName == null) {
                 errorCollector.error(agent, "No agent type specified. Must contain one of ${DeclarativeAgentDescriptor.orderedNames}")
@@ -562,7 +563,7 @@ class ModelValidatorImpl implements ModelValidator {
                 namedArgs.arguments.each { k, v ->
                     List<String> validParamNames = model.parameters.collect { it.name }
                     if (!validParamNames.contains(k.key)) {
-                        errorCollector.error(k, "Invalid config option '${k.key}' for agent type '${typeName}. Valid config options are ${validParamNames}")
+                        errorCollector.error(k, "Invalid config option '${k.key}' for agent type '${typeName}'. Valid config options are ${validParamNames}")
                         valid = false
                     }
                 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -534,9 +534,9 @@ class ModelValidatorImpl implements ModelValidator {
 
         if (agent.args instanceof ModelASTSingleArgument) {
             ModelASTSingleArgument singleArg = (ModelASTSingleArgument) agent.args
-            Map<String,DescribableModel> singleArgModels = DeclarativeAgentDescriptor.singleArgModels()
-            if (!singleArgModels.containsKey(singleArg.value.getValue())) {
-                errorCollector.error(agent.args, "Invalid argument for agent - '${singleArg.value.toGroovy()}' - must be map of config options or bare ${singleArgModels.keySet().sort()}.")
+            Map<String,DescribableModel> zeroArgModels = DeclarativeAgentDescriptor.zeroArgModels()
+            if (!zeroArgModels.containsKey(singleArg.value.getValue())) {
+                errorCollector.error(agent.args, "Invalid argument for agent - '${singleArg.value.toGroovy()}' - must be map of config options or bare ${zeroArgModels.keySet().sort()}.")
                 valid = false
             }
         } else if (agent.args instanceof ModelASTNamedArgumentList) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -547,7 +547,7 @@ class ModelValidatorImpl implements ModelValidator {
 
             Map<String,DescribableModel> possibleModels = DeclarativeAgentDescriptor.describableModels
 
-            List<String> orderedNames = DeclarativeAgentDescriptor.orderedDescriptors.collect { it.name }
+            List<String> orderedNames = DeclarativeAgentDescriptor.all().collect { it.name }
             String typeName = orderedNames.find { it in argKeys }
 
             if (typeName == null) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -547,10 +547,11 @@ class ModelValidatorImpl implements ModelValidator {
 
             Map<String,DescribableModel> possibleModels = DeclarativeAgentDescriptor.describableModels
 
-            String typeName = DeclarativeAgentDescriptor.orderedNames.find { it in argKeys }
+            List<String> orderedNames = DeclarativeAgentDescriptor.orderedDescriptors.collect { it.name }
+            String typeName = orderedNames.find { it in argKeys }
 
             if (typeName == null) {
-                errorCollector.error(agent, "No agent type specified. Must contain one of ${DeclarativeAgentDescriptor.orderedNames}")
+                errorCollector.error(agent, "No agent type specified. Must contain one of ${orderedNames}")
                 valid = false
             } else {
                 DescribableModel model = possibleModels.get(typeName)

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Any.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Any.java
@@ -40,11 +40,6 @@ public class Any extends Label {
 
     @Extension(ordinal = -900) @Symbol("any")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
-        @Override
-        public @Nonnull String getName() {
-            return "any";
-        }
-
         public @Nonnull String getDeclarativeAgentScriptClass() {
             return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.LabelScript";
         }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Any.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Any.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+public class Any extends Label {
+
+    @DataBoundConstructor
+    public Any() {
+        super(null);
+    }
+
+    @Extension(ordinal = -900) @Symbol("any")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor {
+        @Override
+        public @Nonnull String getName() {
+            return "any";
+        }
+
+        public @Nonnull String getDeclarativeAgentScriptClass() {
+            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.LabelScript";
+        }
+
+    }
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
@@ -72,14 +72,5 @@ public class DockerPipeline extends DeclarativeAgent {
 
     @Extension(ordinal = 1000) @Symbol("docker")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
-        @Override
-        public @Nonnull String getName() {
-            return "docker";
-        }
-
-        public @Nonnull String getDeclarativeAgentScriptClass() {
-            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.DockerPipelineScript";
-        }
-
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
@@ -41,8 +41,8 @@ public class DockerPipeline extends DeclarativeAgent {
     private String dockerArgs = "";
 
     @DataBoundConstructor
-    public DockerPipeline(@Nonnull String d) {
-        this.docker = d;
+    public DockerPipeline(@Nonnull String docker) {
+        this.docker = docker;
     }
 
     @Whitelisted

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class DockerPipeline extends DeclarativeAgent {
+    private String label;
+    private String docker;
+    private String dockerArgs = "";
+
+    @DataBoundConstructor
+    public DockerPipeline(@Nonnull String d) {
+        this.docker = d;
+    }
+
+    @Whitelisted
+    public @Nullable String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    @Whitelisted
+    public @Nullable String getDockerArgs() {
+        return dockerArgs;
+    }
+
+    @DataBoundSetter
+    public void setDockerArgs(String dockerArgs) {
+        this.dockerArgs = dockerArgs;
+    }
+
+    @Whitelisted
+    public @Nonnull String getDocker() {
+        return docker;
+    }
+
+    @Extension(ordinal = 1000) @Symbol("docker")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor {
+        @Override
+        public @Nonnull String getName() {
+            return "docker";
+        }
+
+        public @Nonnull String getDeclarativeAgentScriptClass() {
+            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.DockerPipelineScript";
+        }
+
+    }
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class Label extends DeclarativeAgent {
+    private String label;
+
+    @DataBoundConstructor
+    public Label(String l) {
+        // Label *can* be null. That's fine.
+        this.label = l;
+    }
+
+    @Whitelisted
+    public @Nullable String getLabel() {
+        return label;
+    }
+
+    @Extension(ordinal = -800) @Symbol("label")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor {
+        @Override
+        public @Nonnull String getName() {
+            return "label";
+        }
+
+        public @Nonnull String getDeclarativeAgentScriptClass() {
+            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.LabelScript";
+        }
+
+    }
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
@@ -50,14 +50,5 @@ public class Label extends DeclarativeAgent {
 
     @Extension(ordinal = -800) @Symbol("label")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
-        @Override
-        public @Nonnull String getName() {
-            return "label";
-        }
-
-        public @Nonnull String getDeclarativeAgentScriptClass() {
-            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.LabelScript";
-        }
-
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
@@ -38,9 +38,9 @@ public class Label extends DeclarativeAgent {
     private String label;
 
     @DataBoundConstructor
-    public Label(String l) {
+    public Label(String label) {
         // Label *can* be null. That's fine.
-        this.label = l;
+        this.label = label;
     }
 
     @Whitelisted

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/None.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/None.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+public class None extends DeclarativeAgent {
+
+    @DataBoundConstructor
+    public None() {
+
+    }
+
+    @Extension(ordinal = -1000) @Symbol("none")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor {
+        @Override
+        public @Nonnull String getName() {
+            return "none";
+        }
+
+        public @Nonnull String getDeclarativeAgentScriptClass() {
+            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.NoneScript";
+        }
+
+    }
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/None.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/None.java
@@ -41,14 +41,5 @@ public class None extends DeclarativeAgent {
 
     @Extension(ordinal = -1000) @Symbol("none")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
-        @Override
-        public @Nonnull String getName() {
-            return "none";
-        }
-
-        public @Nonnull String getDeclarativeAgentScriptClass() {
-            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.NoneScript";
-        }
-
     }
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
@@ -47,12 +47,12 @@ public class ClosureModelTranslator implements MethodMissingWrapper, Serializabl
     /**
      * Placeholder to make sure 'agent none' works.
      */
-    boolean none = false
+    String none = "none"
 
     /**
      * Placeholder to make sure 'agent any' works.
      */
-    boolean any = true
+    String any = "any"
 
     ClosureModelTranslator(Class clazz, CpsScript s) {
         actualClass = clazz

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+public class DockerPipelineScript extends DeclarativeAgentScript {
+
+    public DockerPipelineScript(CpsScript s, DeclarativeAgent a) {
+        super(s, a)
+    }
+
+    @Override
+    public Closure run(Closure body) {
+        String targetLabel = declarativeAgent.label
+        if (targetLabel == null) {
+            targetLabel = script.dockerLabel()?.trim()
+        }
+        LabelScript labelScript = (LabelScript) Label.DescriptorImpl.instanceForName("label", [label: targetLabel]).getScript(script)
+        return labelScript.run {
+            script.getProperty("docker").image(declarativeAgent.docker).inside(declarativeAgent.dockerArgs, {
+                body.call()
+            })
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+public class LabelScript extends DeclarativeAgentScript {
+
+    public LabelScript(CpsScript s, DeclarativeAgent a) {
+        super(s, a)
+    }
+
+    @Override
+    public Closure run(Closure body) {
+        if (declarativeAgent?.label != null) {
+            return {
+                script.node(declarativeAgent.label) {
+                    body.call()
+                }
+            }
+        } else {
+            return {
+                script.node {
+                    body.call()
+                }
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -37,17 +37,9 @@ public class LabelScript extends DeclarativeAgentScript {
 
     @Override
     public Closure run(Closure body) {
-        if (declarativeAgent?.label != null) {
-            return {
-                script.node(declarativeAgent.label) {
-                    body.call()
-                }
-            }
-        } else {
-            return {
-                script.node {
-                    body.call()
-                }
+        return {
+            script.node(declarativeAgent?.label) {
+                body.call()
             }
         }
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NoneScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NoneScript.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+public class NoneScript extends DeclarativeAgentScript {
+
+    public NoneScript(CpsScript s, DeclarativeAgent a) {
+        super(s, a)
+    }
+
+    @Override
+    public Closure run(Closure body) {
+        return body
+    }
+}

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -302,7 +302,7 @@ public abstract class AbstractModelDefTest {
 
     protected WorkflowRun getAndStartNonRepoBuild(Folder folder, String pipelineScriptFile) throws Exception {
         WorkflowJob p = createWorkflowJob(folder);
-        p.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources(pipelineScriptFile)));
+        p.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources(pipelineScriptFile), true));
         return p.scheduleBuild2(0).waitForStart();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -118,7 +118,8 @@ public abstract class AbstractModelDefTest {
             "simpleJobProperties",
             "simpleTriggers",
             "simpleParameters",
-            "stringsNeedingEscapeLogic"
+            "stringsNeedingEscapeLogic",
+            "agentTypeOrdering"
     );
 
     public static Iterable<Object[]> configsWithErrors() {
@@ -153,6 +154,11 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"perStageConfigEmptySteps", "At /pipeline/stages/0/branches/0/steps: Array has 0 entries, requires minimum of 1"});
         result.add(new Object[]{"perStageConfigMissingSteps", "At /pipeline/stages/0/branches/0: Missing one or more required properties: 'steps'"});
         result.add(new Object[]{"perStageConfigUnknownSection", "At /pipeline/stages/0: additional properties are not allowed"});
+
+        result.add(new Object[]{"unknownAgentType", "No agent type specified. Must contain one of [otherField, docker, label, any, none]"});
+        result.add(new Object[]{"unknownBareAgentType", "Invalid argument for agent - 'foo' - must be map of config options or bare [any, none]."});
+        result.add(new Object[]{"agentMissingRequiredParam", "Missing required parameter for agent type 'otherField': label"});
+        result.add(new Object[]{"agentUnknownParamForType", "Invalid config option 'fruit' for agent type 'otherField'. Valid config options are [label, otherField]"});
 
         result.add(new Object[]{"malformed", "Expected a ',' or '}' at character 243 of {\"pipeline\": {\n" +
                 "  \"stages\": [  {\n" +

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -136,6 +136,16 @@ public class AgentTest extends AbstractModelDefTest {
         j.assertLogContains("ONSLAVE=true", b);
     }
 
+    @Test
+    public void agentAnyInStage() throws Exception {
+        prepRepoWithJenkinsfile("agentAnyInStage");
+
+        WorkflowRun b = getAndStartBuild();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+        j.assertLogContains("[Pipeline] { (foo)", b);
+        j.assertLogContains("THIS WORKS", b);
+    }
+
     private WorkflowRun agentDocker(final String jenkinsfile) throws Exception {
         assumeDocker();
         // Bind mounting /var on OS X doesn't work at the moment

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -27,7 +27,6 @@ import hudson.model.Result;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -122,6 +121,17 @@ public class AgentTest extends AbstractModelDefTest {
 
         WorkflowRun b = getAndStartBuild();
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
+        j.assertLogContains("[Pipeline] { (foo)", b);
+        j.assertLogContains("ONSLAVE=true", b);
+    }
+
+    @Test
+    public void agentTypeOrdering() throws Exception {
+        prepRepoWithJenkinsfile("agentTypeOrdering");
+
+        WorkflowRun b = getAndStartBuild();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+        j.assertLogContains("Running in labelAndOtherField with otherField = banana", b);
         j.assertLogContains("[Pipeline] { (foo)", b);
         j.assertLogContains("ONSLAVE=true", b);
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -369,6 +369,34 @@ public class ValidatorTest extends AbstractModelDefTest {
     }
 
     @Test
+    public void unknownAgentType() throws Exception {
+        prepRepoWithJenkinsfile("errors", "unknownAgentType");
+
+        assertFailWithError("No agent type specified. Must contain one of [otherField, docker, label, any, none]");
+    }
+
+    @Test
+    public void unknownBareAgentType() throws Exception {
+        prepRepoWithJenkinsfile("errors", "unknownBareAgentType");
+
+        assertFailWithError("Invalid argument for agent - 'foo' - must be map of config options or bare [any, none]");
+    }
+
+    @Test
+    public void agentMissingRequiredParam() throws Exception {
+        prepRepoWithJenkinsfile("errors", "agentMissingRequiredParam");
+
+        assertFailWithError("Missing required parameter for agent type 'otherField': label");
+    }
+
+    @Test
+    public void agentUnknownParamForType() throws Exception {
+        prepRepoWithJenkinsfile("errors", "agentUnknownParamForType");
+
+        assertFailWithError("Invalid config option 'fruit' for agent type 'otherField'. Valid config options are [label, otherField]");
+    }
+
+    @Test
     public void packageShouldNotSkipParsing() throws Exception {
         prepRepoWithJenkinsfile("errors", "packageShouldNotSkipParsing");
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgent.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgent.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+public class LabelAndOtherFieldAgent extends DeclarativeAgent {
+    private String label;
+    private String otherField;
+
+    @DataBoundConstructor
+    public LabelAndOtherFieldAgent(String label, String otherField) {
+        this.label = label;
+        this.otherField = otherField;
+    }
+
+    @Whitelisted
+    public String getLabel() {
+        return label;
+    }
+
+    @Whitelisted
+    public String getOtherField() {
+        return otherField;
+    }
+
+    @Extension(ordinal = 1100) @Symbol("otherField")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor {
+        @Override
+        public @Nonnull String getName() {
+            return "otherField";
+        }
+
+        @Override
+        public @Nonnull String getDeclarativeAgentScriptClass() {
+            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.LabelAndOtherFieldAgentScript";
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/agentAnyInStage.groovy
+++ b/pipeline-model-definition/src/test/resources/agentAnyInStage.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            agent any
+            steps {
+                sh('echo "THIS WORKS"')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/agentTypeOrdering.groovy
+++ b/pipeline-model-definition/src/test/resources/agentTypeOrdering.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent label:"some-label", otherField:"banana"
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo ONSLAVE=$ONSLAVE')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/agentMissingRequiredParam.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/agentMissingRequiredParam.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent otherField:"banana"
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo ONSLAVE=$ONSLAVE')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/agentUnknownParamForType.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/agentUnknownParamForType.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent label:"some-label", otherField:"banana", fruit:"apple"
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo ONSLAVE=$ONSLAVE')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/unknownAgentType.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/unknownAgentType.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent foo:"bar"
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/unknownBareAgentType.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/unknownBareAgentType.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent foo
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/json/agentTypeOrdering.json
+++ b/pipeline-model-definition/src/test/resources/json/agentTypeOrdering.json
@@ -1,0 +1,31 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "sh",
+        "arguments":         {
+          "isLiteral": true,
+          "value": "echo ONSLAVE=$ONSLAVE"
+        }
+      }]
+    }]
+  }],
+  "agent":   [
+    {
+      "key": "label",
+      "value":       {
+        "isLiteral": true,
+        "value": "some-label"
+      }
+    },
+    {
+      "key": "otherField",
+      "value":       {
+        "isLiteral": true,
+        "value": "banana"
+      }
+    }
+  ]
+}}

--- a/pipeline-model-definition/src/test/resources/json/errors/agentMissingRequiredParam.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/agentMissingRequiredParam.json
@@ -1,0 +1,22 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "sh",
+        "arguments":         {
+          "isLiteral": true,
+          "value": "echo ONSLAVE=$ONSLAVE"
+        }
+      }]
+    }]
+  }],
+  "agent": [  {
+    "key": "otherField",
+    "value":     {
+      "isLiteral": true,
+      "value": "banana"
+    }
+  }]
+}}

--- a/pipeline-model-definition/src/test/resources/json/errors/agentUnknownParamForType.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/agentUnknownParamForType.json
@@ -1,0 +1,38 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "sh",
+        "arguments":         {
+          "isLiteral": true,
+          "value": "echo ONSLAVE=$ONSLAVE"
+        }
+      }]
+    }]
+  }],
+  "agent":   [
+    {
+      "key": "label",
+      "value":       {
+        "isLiteral": true,
+        "value": "some-label"
+      }
+    },
+    {
+      "key": "otherField",
+      "value":       {
+        "isLiteral": true,
+        "value": "banana"
+      }
+    },
+    {
+      "key": "fruit",
+      "value":       {
+        "isLiteral": true,
+        "value": "apple"
+      }
+    }
+  ]
+}}

--- a/pipeline-model-definition/src/test/resources/json/errors/unknownAgentType.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/unknownAgentType.json
@@ -1,0 +1,22 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "echo",
+        "arguments":         {
+          "isLiteral": true,
+          "value": "hello"
+        }
+      }]
+    }]
+  }],
+  "agent": [  {
+    "key": "foo",
+    "value":     {
+      "isLiteral": true,
+      "value": "bar"
+    }
+  }]
+}}

--- a/pipeline-model-definition/src/test/resources/json/errors/unknownBareAgentType.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/unknownBareAgentType.json
@@ -1,0 +1,19 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "echo",
+        "arguments":         {
+          "isLiteral": true,
+          "value": "hello"
+        }
+      }]
+    }]
+  }],
+  "agent":   {
+    "isLiteral": false,
+    "value": "${foo}"
+  }
+}}

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+public class LabelAndOtherFieldAgentScript extends DeclarativeAgentScript {
+
+    public LabelAndOtherFieldAgentScript(CpsScript s, DeclarativeAgent a) {
+        super(s, a)
+    }
+
+    @Override
+    public Closure run(Closure body) {
+        script.echo "Running in labelAndOtherField with otherField = ${declarativeAgent.getOtherField()}"
+        LabelScript labelScript = (LabelScript) Label.DescriptorImpl.instanceForName("label", [label: declarativeAgent.label]).getScript(script)
+        return labelScript.run {
+            body.call()
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://git@github.com/jenkinsci/pipeline-config-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-config-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-config-plugin</url>
+    <connection>scm:git:git://git@github.com/jenkinsci/pipeline-model-definition-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
     <tag>HEAD</tag>
   </scm>
   
@@ -68,7 +68,6 @@
     <module>pipeline-model-definition</module>
   </modules>
 
-  <!-- project is just for aggregating, never as a parent, we force skip to ensure we never deploy or install it -->
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 
   <modules>
     <module>pipeline-model-api</module>
+    <module>pipeline-model-declarative-agent</module>
     <module>pipeline-model-definition</module>
   </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,13 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>2.17</version>
+    <relativePath/>
+  </parent>
+
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jenkinsci.plugins</groupId>
   <artifactId>pipeline-model-parent</artifactId>
@@ -65,18 +72,22 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>gmaven-plugin</artifactId>
+        <version>1.4</version>
         <configuration>
-          <skip>true</skip>
+          <providerSelection>1.8</providerSelection>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+              <goal>generateTestStubs</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
@@ -89,10 +100,16 @@
     </plugins>
   </build>
 
+  <properties>
+    <jenkins.version>2.7.1</jenkins.version>
+    <java.level>7</java.level>
+    <groovy.version>2.4.7</groovy.version>
+  </properties>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -104,7 +121,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 </project>


### PR DESCRIPTION
[JENKINS-38433](https://issues.jenkins-ci.org/browse/JENKINS-38433)
- [x] Actually get it working.
- [x] Split the `DeclarativeAgent*` classes into their own plugin.
- [x] Figure out if we can avoid the full `workflow-cps` dependency for `pipeline-model-declarative-agent`. (EDIT: Aaaaactually we need that dependency for writing the `DeclarativeAgentScript` implementations anyway, so, hey, we'll keep the dependency!)
- [x] Decide if we want to go with Snippetizer support for `DeclarativeAgent` (spoiler: probably not) (EDIT: Not. Doesn't make a lot of sense, does it?)
- [x] Javadocs! Lots of them. 
- [x] Tests - we've already got tests for basic agent functionality, so we just need to add new tests what's new - validation, ordering, a custom agent type...

The DeclarativeAgent\* classes are in a separate plugin so that
they can be depended on by other plugins with minimal transitive
dependencies in the process.

cc @reviewbybees - especially looking for input from @stephenc @rsandell and @jglick 
