### PR TITLE
Use repo.jenkins-ci.org in parent POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,4 +87,24 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>
+


### PR DESCRIPTION
Have seen problems with the default Maven central repo on Azure for
some reason, so hey.

cc @reviewbybees esp @stephenc @rsandell 