### PR TITLE
[JENKINS-39216] Add "dockerfile" agent backend

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -32,6 +32,7 @@ import hudson.ExtensionList
 import hudson.model.Describable
 import hudson.model.Descriptor
 import hudson.triggers.TriggerDescriptor
+import org.apache.commons.codec.digest.DigestUtils
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages
@@ -196,6 +197,11 @@ public class Utils {
         stages.removeSourceLocation()
 
         r.addAction(new ExecutionModelAction(stages))
+    }
+
+    @Whitelisted
+    public static String stringToSHA1(String s) {
+        return DigestUtils.sha1Hex(s)
     }
 
     /**

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
@@ -28,25 +28,23 @@ import hudson.Extension;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public class DockerPipelineFromDockerfile extends DeclarativeAgent {
     private String label;
-    private String dockerfileImage;
+    private Object dockerfile;
     private String dockerArgs = "";
 
     @DataBoundConstructor
-    public DockerPipelineFromDockerfile(@Nonnull String dockerfileImage) {
-        this.dockerfileImage = dockerfileImage;
+    public DockerPipelineFromDockerfile(@Nonnull Object dockerfile) {
+        this.dockerfile = dockerfile;
     }
 
-    @Whitelisted
-    public @Nullable String getLabel() {
+    public @CheckForNull String getLabel() {
         return label;
     }
 
@@ -55,8 +53,7 @@ public class DockerPipelineFromDockerfile extends DeclarativeAgent {
         this.label = label;
     }
 
-    @Whitelisted
-    public @Nullable String getDockerArgs() {
+    public @CheckForNull String getDockerArgs() {
         return dockerArgs;
     }
 
@@ -65,21 +62,19 @@ public class DockerPipelineFromDockerfile extends DeclarativeAgent {
         this.dockerArgs = dockerArgs;
     }
 
-    @Whitelisted
-    public @Nonnull String getDockerfileImage() {
-        return dockerfileImage;
+    public @Nonnull Object getDockerfile() {
+        return dockerfile;
     }
 
-    @Extension(ordinal = 999) @Symbol("dockerfileImage")
+    public String getDockerfileAsString() {
+        if (dockerfile instanceof String) {
+            return (String)dockerfile;
+        } else {
+            return "Dockerfile";
+        }
+    }
+
+    @Extension(ordinal = 999) @Symbol("dockerfile")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
-        @Override
-        public @Nonnull String getName() {
-            return "dockerfileImage";
-        }
-
-        public @Nonnull String getDeclarativeAgentScriptClass() {
-            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.DockerPipelineFromDockerfileScript";
-        }
-
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
@@ -37,13 +37,12 @@ import javax.annotation.Nullable;
 
 public class DockerPipelineFromDockerfile extends DeclarativeAgent {
     private String label;
-    private String dockerfile;
-    private String name;
+    private String dockerfileImage;
     private String dockerArgs = "";
 
     @DataBoundConstructor
-    public DockerPipelineFromDockerfile(@Nonnull String name) {
-        this.name = name;
+    public DockerPipelineFromDockerfile(@Nonnull String dockerfileImage) {
+        this.dockerfileImage = dockerfileImage;
     }
 
     @Whitelisted
@@ -67,25 +66,15 @@ public class DockerPipelineFromDockerfile extends DeclarativeAgent {
     }
 
     @Whitelisted
-    public @Nonnull String getName() {
-        return name;
+    public @Nonnull String getDockerfileImage() {
+        return dockerfileImage;
     }
 
-    @Whitelisted
-    public @Nullable String getDockerfile() {
-        return dockerfile;
-    }
-
-    @DataBoundSetter
-    public void setDockerfile(String dockerfile) {
-        this.dockerfile = dockerfile;
-    }
-
-    @Extension(ordinal = 999) @Symbol("dockerfile")
+    @Extension(ordinal = 999) @Symbol("dockerfileImage")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
         @Override
         public @Nonnull String getName() {
-            return "dockerfile";
+            return "dockerfileImage";
         }
 
         public @Nonnull String getDeclarativeAgentScriptClass() {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class DockerPipelineFromDockerfile extends DeclarativeAgent {
+    private String label;
+    private String dockerfile;
+    private String name;
+    private String dockerArgs = "";
+
+    @DataBoundConstructor
+    public DockerPipelineFromDockerfile(@Nonnull String name) {
+        this.name = name;
+    }
+
+    @Whitelisted
+    public @Nullable String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    @Whitelisted
+    public @Nullable String getDockerArgs() {
+        return dockerArgs;
+    }
+
+    @DataBoundSetter
+    public void setDockerArgs(String dockerArgs) {
+        this.dockerArgs = dockerArgs;
+    }
+
+    @Whitelisted
+    public @Nonnull String getName() {
+        return name;
+    }
+
+    @Whitelisted
+    public @Nullable String getDockerfile() {
+        return dockerfile;
+    }
+
+    @DataBoundSetter
+    public void setDockerfile(String dockerfile) {
+        this.dockerfile = dockerfile;
+    }
+
+    @Extension(ordinal = 999) @Symbol("dockerfile")
+    public static class DescriptorImpl extends DeclarativeAgentDescriptor {
+        @Override
+        public @Nonnull String getName() {
+            return "dockerfile";
+        }
+
+        public @Nonnull String getDeclarativeAgentScriptClass() {
+            return "org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl.DockerPipelineFromDockerfileScript";
+        }
+
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -48,7 +48,7 @@ public class DockerPipelineFromDockerfileScript extends DeclarativeAgentScript {
             try {
                 def hash = Utils.stringToSHA1(script.readFile(declarativeAgent.getDockerfileAsString()))
                 def imgName = "${hash}"
-                def img = script.getProperty("docker").build(declarativeAgent.getDockerfileAsString())
+                def img = script.getProperty("docker").build(imgName, "-f ${declarativeAgent.getDockerfileAsString()}")
                 img.inside(declarativeAgent.dockerArgs, {
                     body.call()
                 })

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+public class DockerPipelineFromDockerfileScript extends DeclarativeAgentScript {
+
+    public DockerPipelineFromDockerfileScript(CpsScript s, DeclarativeAgent a) {
+        super(s, a)
+    }
+
+    @Override
+    public Closure run(Closure body) {
+        String targetLabel = declarativeAgent.label
+        if (targetLabel == null) {
+            targetLabel = script.dockerLabel()?.trim()
+        }
+        LabelScript labelScript = (LabelScript) Label.DescriptorImpl.instanceForName("label", [label: targetLabel]).getScript(script)
+        return labelScript.run {
+            script.checkout script.scm
+            try {
+                def hash = Utils.stringToSHA1(script.readFile("Dockerfile"))
+                def imgName = "${declarativeAgent.name}-${hash}"
+                def img = script.getProperty("docker").build(imgName)
+                img.inside(declarativeAgent.dockerArgs, {
+                    body.call()
+                })
+            } catch (FileNotFoundException f) {
+                script.error("No Dockerfile found at root of repository - failing.")
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -47,7 +47,7 @@ public class DockerPipelineFromDockerfileScript extends DeclarativeAgentScript {
             script.checkout script.scm
             try {
                 def hash = Utils.stringToSHA1(script.readFile("Dockerfile"))
-                def imgName = "${declarativeAgent.name}-${hash}"
+                def imgName = "${declarativeAgent.dockerfileImage}-${hash}"
                 def img = script.getProperty("docker").build(imgName)
                 img.inside(declarativeAgent.dockerArgs, {
                     body.call()

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -48,7 +48,7 @@ public class DockerPipelineFromDockerfileScript extends DeclarativeAgentScript {
             try {
                 def hash = Utils.stringToSHA1(script.readFile(declarativeAgent.getDockerfileAsString()))
                 def imgName = "${hash}"
-                def img = script.getProperty("docker").build(imgName, "-f ${declarativeAgent.getDockerfileAsString()}")
+                def img = script.getProperty("docker").build(imgName, "-f ${declarativeAgent.getDockerfileAsString()} .")
                 img.inside(declarativeAgent.dockerArgs, {
                     body.call()
                 })

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -48,7 +48,7 @@ public class DockerPipelineFromDockerfileScript extends DeclarativeAgentScript {
             try {
                 def hash = Utils.stringToSHA1(script.readFile(declarativeAgent.getDockerfileAsString()))
                 def imgName = "${hash}"
-                def img = script.getProperty("docker").build(imgName)
+                def img = script.getProperty("docker").build(declarativeAgent.getDockerfileAsString())
                 img.inside(declarativeAgent.dockerArgs, {
                     body.call()
                 })

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -46,8 +46,8 @@ public class DockerPipelineFromDockerfileScript extends DeclarativeAgentScript {
         return labelScript.run {
             script.checkout script.scm
             try {
-                def hash = Utils.stringToSHA1(script.readFile("Dockerfile"))
-                def imgName = "${declarativeAgent.dockerfileImage}-${hash}"
+                def hash = Utils.stringToSHA1(script.readFile(declarativeAgent.getDockerfileAsString()))
+                def imgName = "${hash}"
                 def img = script.getProperty("docker").build(imgName)
                 img.inside(declarativeAgent.dockerArgs, {
                     body.call()

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -158,7 +158,7 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"perStageConfigMissingSteps", "At /pipeline/stages/0/branches/0: Missing one or more required properties: 'steps'"});
         result.add(new Object[]{"perStageConfigUnknownSection", "At /pipeline/stages/0: additional properties are not allowed"});
 
-        result.add(new Object[]{"unknownAgentType", "No agent type specified. Must contain one of [otherField, docker, dockerfileImage, label, any, none]"});
+        result.add(new Object[]{"unknownAgentType", "No agent type specified. Must contain one of [otherField, docker, dockerfile, label, any, none]"});
         result.add(new Object[]{"invalidWrapperType", "Invalid wrapper type 'echo'. Valid wrapper types: [retry, script, timeout, withEnv]"});
         result.add(new Object[]{"unknownAgentType", "No agent type specified. Must contain one of [otherField, docker, label, any, none]"});
         result.add(new Object[]{"unknownBareAgentType", "Invalid argument for agent - 'foo' - must be map of config options or bare [any, none]."});

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -158,7 +158,7 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"perStageConfigMissingSteps", "At /pipeline/stages/0/branches/0: Missing one or more required properties: 'steps'"});
         result.add(new Object[]{"perStageConfigUnknownSection", "At /pipeline/stages/0: additional properties are not allowed"});
 
-        result.add(new Object[]{"unknownAgentType", "No agent type specified. Must contain one of [otherField, docker, label, any, none]"});
+        result.add(new Object[]{"unknownAgentType", "No agent type specified. Must contain one of [otherField, docker, dockerfileImage, label, any, none]"});
         result.add(new Object[]{"unknownBareAgentType", "Invalid argument for agent - 'foo' - must be map of config options or bare [any, none]."});
         result.add(new Object[]{"agentMissingRequiredParam", "Missing required parameter for agent type 'otherField': label"});
         result.add(new Object[]{"agentUnknownParamForType", "Invalid config option 'fruit' for agent type 'otherField'. Valid config options are [label, otherField]"});

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -160,7 +160,7 @@ public class AgentTest extends AbstractModelDefTest {
         j.assertBuildStatusSuccess(j.waitForCompletion(b));
         j.assertLogContains("[Pipeline] { (foo)", b);
         j.assertLogContains("The answer is 42", b);
-        j.assertLogContains("-v /tmp:/tmp -p 80:80", b);
+        j.assertLogContains("-v /tmp:/tmp -p 8000:8000", b);
         j.assertLogContains("HI THERE", b);
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -164,6 +164,25 @@ public class AgentTest extends AbstractModelDefTest {
         j.assertLogContains("HI THERE", b);
     }
 
+    @Test
+    public void fromAlternateDockerfile() throws Exception {
+        assumeDocker();
+        // Bind mounting /var on OS X doesn't work at the moment
+        onAllowedOS(PossibleOS.LINUX);
+
+        prepRepoWithJenkinsfile("fromAlternateDockerfile");
+        sampleRepo.write("Dockerfile.alternate", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("add", "Dockerfile.alternate");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        WorkflowRun b = getAndStartBuild();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+        j.assertLogContains("[Pipeline] { (foo)", b);
+        j.assertLogContains("The answer is 42", b);
+        j.assertLogContains("-v /tmp:/tmp -p 8000:8000", b);
+        j.assertLogContains("HI THERE", b);
+    }
+
     private WorkflowRun agentDocker(final String jenkinsfile) throws Exception {
         assumeDocker();
         // Bind mounting /var on OS X doesn't work at the moment

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -382,7 +382,7 @@ public class ValidatorTest extends AbstractModelDefTest {
     public void unknownAgentType() throws Exception {
         prepRepoWithJenkinsfile("errors", "unknownAgentType");
 
-        assertFailWithError("No agent type specified. Must contain one of [otherField, docker, dockerfileImage, label, any, none]");
+        assertFailWithError("No agent type specified. Must contain one of [otherField, docker, dockerfile, label, any, none]");
     }
 
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -381,7 +381,7 @@ public class ValidatorTest extends AbstractModelDefTest {
     public void unknownAgentType() throws Exception {
         prepRepoWithJenkinsfile("errors", "unknownAgentType");
 
-        assertFailWithError("No agent type specified. Must contain one of [otherField, docker, label, any, none]");
+        assertFailWithError("No agent type specified. Must contain one of [otherField, docker, dockerfileImage, label, any, none]");
     }
 
     @Test

--- a/pipeline-model-definition/src/test/resources/fromAlternateDockerfile.groovy
+++ b/pipeline-model-definition/src/test/resources/fromAlternateDockerfile.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent dockerfile:"Dockerfile.alternate", dockerArgs:"-v /tmp:/tmp -p 8000:8000"
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/fromDockerfile.groovy
+++ b/pipeline-model-definition/src/test/resources/fromDockerfile.groovy
@@ -23,7 +23,7 @@
  */
 
 pipeline {
-    agent dockerfileImage:"something", dockerArgs:"-v /tmp:/tmp -p 80:80"
+    agent dockerfileImage:"something", dockerArgs:"-v /tmp:/tmp -p 8000:8000"
     stages {
         stage("foo") {
             steps {

--- a/pipeline-model-definition/src/test/resources/fromDockerfile.groovy
+++ b/pipeline-model-definition/src/test/resources/fromDockerfile.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent dockerfileImage:"something", dockerArgs:"-v /tmp:/tmp -p 80:80"
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /hi-there'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/fromDockerfile.groovy
+++ b/pipeline-model-definition/src/test/resources/fromDockerfile.groovy
@@ -23,7 +23,7 @@
  */
 
 pipeline {
-    agent dockerfileImage:"something", dockerArgs:"-v /tmp:/tmp -p 8000:8000"
+    agent dockerfile:true, dockerArgs:"-v /tmp:/tmp -p 8000:8000"
     stages {
         stage("foo") {
             steps {


### PR DESCRIPTION
[JENKINS-39216](https://issues.jenkins-ci.org/browse/JENKINS-39216)

Not happy with the naming - but I needed a map key/value pair for this, so went with `dockerfileImage` as the unique identifier for this backend. The actual image name will be that string plus the `Dockerfile`'s sha1 hash. I'm open to better naming.

cc @reviewbybees esp @michaelneale @HRMPW @stephenc @rsandell 
