### PR TITLE
Explain that steps section is needed in stages.

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -336,7 +336,7 @@ class ModelParser {
                             stage.environment = parseEnvironment(s)
                             break
                         default:
-                            errorCollector.error(stage, "Unknown stage section '${name}'")
+                            errorCollector.error(stage, "Unknown stage section '${name}'. Starting with version 0.5, steps in a stage must be in a 'steps' block.")
                     }
                 }
             }


### PR DESCRIPTION
We're not supporting backwards compatibility for syntax that we change
before 1.0, but we should give clear error messages explaining what
has changed. At this point, this is the only compatibility-breaking
syntactic change.

cc @reviewbybees esp @rsandell @HRMPW @michaelneale 