### PR TITLE
Make docker-workflow an optional dependency

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -100,6 +100,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>docker-workflow</artifactId>
       <version>1.9</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipeline.java
@@ -66,7 +66,7 @@ public class DockerPipeline extends DeclarativeAgent {
         return docker;
     }
 
-    @Extension(ordinal = 1000) @Symbol("docker")
+    @Extension(ordinal = 1000, optional = true) @Symbol("docker")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
@@ -74,7 +74,7 @@ public class DockerPipelineFromDockerfile extends DeclarativeAgent {
         }
     }
 
-    @Extension(ordinal = 999) @Symbol("dockerfile")
+    @Extension(ordinal = 999, optional = true) @Symbol("dockerfile")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor {
     }
 }


### PR DESCRIPTION
Prompted by [JENKINS-39723](https://issues.jenkins-ci.org/browse/JENKINS-39723)

Allow installing `pipeline-model-definition` without autoinstalling `docker-workflow` as well. Also makes the `DockerPipeline` and `DockerPipelineFromDockerfile` `Extension`s `optional`, so that they won't have classloading errors if `docker-workflow` isn't installed, and attempts to use `agent docker:...` or `agent dockerfile:...` will error out at validation time.

cc @reviewbybees esp @rsandell @michaelneale 