### PR TITLE
[FIXED JENKINS-39923] Add a CLI endpoint for the linter

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -149,6 +149,13 @@
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-auth</artifactId>
+      <version>1.0.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <version>2.6.0</version>
       <classifier>tests</classifier>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -149,13 +149,6 @@
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-auth</artifactId>
-      <version>1.0.2</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <version>2.6.0</version>
       <classifier>tests</classifier>

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.Extension;
 import hudson.cli.CLICommand;
+import hudson.cli.util.ScriptLoader;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
@@ -47,32 +48,16 @@ import java.util.List;
 
 @Extension
 public class DeclarativeLinterCommand extends CLICommand {
-    @Argument(metaVar="JENKINSFILE", usage="Path to the Jenkinsfile to validate", required=true)
-    String jenkinsfile;
-
     @Override
     public String getShortDescription() {
         return Messages.DeclarativeLinterCommand_ShortDescription();
     }
 
     protected int run() throws Exception {
-        File jf = new File(jenkinsfile);
-
         int retVal = 0;
         List<String> output = new ArrayList<>();
 
-        String script = null;
-
-        try {
-            FileInputStream fif = new FileInputStream(jf);
-            script = IOUtils.toString(fif);
-        } catch (FileNotFoundException e) {
-            retVal = 1;
-            output.add("Jenkinsfile '" + jenkinsfile + "' does not exist or cannot be read.");
-        } catch (IOException e) {
-            retVal = 1;
-            output.add("IOException reading Jenkinsfile '" + jenkinsfile + "': " + e.getMessage());
-        }
+        String script = script = IOUtils.toString(stdin);
 
         if (script != null) {
             try {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
@@ -57,7 +57,7 @@ public class DeclarativeLinterCommand extends CLICommand {
         int retVal = 0;
         List<String> output = new ArrayList<>();
 
-        String script = script = IOUtils.toString(stdin);
+        String script = IOUtils.toString(stdin);
 
         if (script != null) {
             try {
@@ -67,21 +67,7 @@ public class DeclarativeLinterCommand extends CLICommand {
             } catch (Exception e) {
                 output.add("Errors encountered validating Jenkinsfile:");
                 retVal = 1;
-                if (e instanceof MultipleCompilationErrorsException) {
-                    MultipleCompilationErrorsException ce = (MultipleCompilationErrorsException) e;
-                    for (Object o : ce.getErrorCollector().getErrors()) {
-                        if (o instanceof SyntaxErrorMessage) {
-                            SyntaxErrorMessage s = (SyntaxErrorMessage) o;
-                            StringWriter sw = new StringWriter();
-                            PrintWriter pw = new PrintWriter(sw);
-                            s.write(pw);
-                            pw.close();
-                            output.add(sw.toString());
-                        }
-                    }
-                } else {
-                    output.add(e.getMessage());
-                }
+                output.addAll(ModelConverterAction.errorToStrings(e));
             }
         }
         

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 import hudson.Extension;
 import hudson.cli.CLICommand;
 import hudson.cli.util.ScriptLoader;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
@@ -46,6 +47,8 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static hudson.security.Permission.READ;
+
 @Extension
 public class DeclarativeLinterCommand extends CLICommand {
     @Override
@@ -54,6 +57,7 @@ public class DeclarativeLinterCommand extends CLICommand {
     }
 
     protected int run() throws Exception {
+        Jenkins.getInstance().checkPermission(READ);
         int retVal = 0;
         List<String> output = new ArrayList<>();
 

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition;
+
+import hudson.Extension;
+import hudson.cli.CLICommand;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.codehaus.groovy.control.Janitor;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.endpoints.ModelConverterAction;
+import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Extension
+public class DeclarativeLinterCommand extends CLICommand {
+    @Override
+    public String getShortDescription() {
+        return Messages.DeclarativeLinterCommand_ShortDescription();
+    }
+
+    protected int run() throws Exception {
+        StringWriter w = new StringWriter();
+        IOUtils.copy(stdin, w);
+
+        int retVal = 0;
+        List<String> output = new ArrayList<>();
+
+        try {
+            Converter.scriptToPipelineDef(w.toString());
+            output.add("Jenkinsfile successfully validated.");
+            retVal = 0;
+        } catch (Exception e) {
+            output.add("Errors encountered validating Jenkinsfile:");
+            retVal = 1;
+            if (e instanceof MultipleCompilationErrorsException) {
+                MultipleCompilationErrorsException ce = (MultipleCompilationErrorsException)e;
+                for (Object o : ce.getErrorCollector().getErrors()) {
+                    if (o instanceof SyntaxErrorMessage) {
+                        SyntaxErrorMessage s = (SyntaxErrorMessage)o;
+                        StringWriter sw = new StringWriter();
+                        PrintWriter pw = new PrintWriter(sw);
+                        s.write(pw);
+                        pw.close();
+                        output.add(sw.toString());
+                    }
+                }
+            } else {
+                output.add(e.getMessage());
+            }
+        }
+
+        IOUtils.writeLines(output, null, stdout);
+
+        return retVal;
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -24,3 +24,4 @@
 #
 
 PipelineModelDefinition.DisplayName=Pipeline Model Definition
+DeclarativeLinterCommand.ShortDescription=Validate a Jenkinsfile containing a Declarative Pipeline

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
@@ -25,12 +25,15 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.cli.CLICommandInvoker;
+import hudson.model.Item;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
+import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
 import java.io.File;
 import java.io.IOException;
@@ -83,7 +86,12 @@ public class DeclarativeLinterCommandTest extends AbstractModelDefTest {
     public void invalidUser() throws Exception {
         File testPath = writeJenkinsfileToTmpFile("simplePipeline");
 
-        j.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().to("bob")
+                .grant(Jenkins.READ,
+                        Item.READ,
+                        Item.EXTENDED_READ).everywhere().to("alice"));
 
         final CLICommandInvoker.Result result = command.withStdin(FileUtils.openInputStream(testPath)).invoke();
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
@@ -54,9 +54,9 @@ public class DeclarativeLinterCommandTest extends AbstractModelDefTest {
 
     @Test
     public void validJenkinsfile() throws Exception {
-        String testPath = writeJenkinsfileToTmpFile("simplePipeline");
+        File testPath = writeJenkinsfileToTmpFile("simplePipeline");
 
-        final CLICommandInvoker.Result result = command.invokeWithArgs(testPath);
+        final CLICommandInvoker.Result result = command.withStdin(FileUtils.openInputStream(testPath)).invoke();
 
         assertThat(result, succeeded());
         assertThat(result, hasNoErrorOutput());
@@ -65,9 +65,9 @@ public class DeclarativeLinterCommandTest extends AbstractModelDefTest {
 
     @Test
     public void invalidJenkinsfile() throws Exception {
-        String testPath = writeJenkinsfileToTmpFile("errors", "emptyAgent");
+        File testPath = writeJenkinsfileToTmpFile("errors", "emptyAgent");
 
-        final CLICommandInvoker.Result result = command.invokeWithArgs(testPath);
+        final CLICommandInvoker.Result result = command.withStdin(FileUtils.openInputStream(testPath)).invoke();
 
         assertThat(result, failedWith(1));
         assertThat(result, hasNoErrorOutput());
@@ -75,29 +75,17 @@ public class DeclarativeLinterCommandTest extends AbstractModelDefTest {
         assertThat(result.stdout(), containsString("Not a valid section definition: 'agent'. Some extra configuration is required"));
     }
 
-    @Test
-    public void notFoundJenkinsfile() throws Exception {
-        File tempFile = tmp.newFile();
-        String badPath = tempFile.getAbsolutePath();
-        tempFile.delete();
-
-        final CLICommandInvoker.Result result = command.invokeWithArgs(badPath);
-
-        assertThat(result, failedWith(1));
-        assertThat(result.stdout(), containsString("does not exist or cannot be read"));
-    }
-
-    private String writeJenkinsfileToTmpFile(String dir, String testName) throws IOException {
+    private File writeJenkinsfileToTmpFile(String dir, String testName) throws IOException {
         return writeJenkinsfileToTmpFile(dir + "/" + testName);
     }
 
-    private String writeJenkinsfileToTmpFile(String testName) throws IOException {
+    private File writeJenkinsfileToTmpFile(String testName) throws IOException {
         File jf = tmp.newFile();
 
         String contents = pipelineSourceFromResources(testName);
 
         FileUtils.writeStringToFile(jf, contents);
 
-        return jf.getAbsolutePath();
+        return jf;
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.cli.CLICommandInvoker;
 import hudson.model.Item;
-import hudson.security.GlobalMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition;
+
+import hudson.cli.CLICommandInvoker;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static hudson.cli.CLICommandInvoker.Matcher.failedWith;
+import static hudson.cli.CLICommandInvoker.Matcher.hasNoErrorOutput;
+import static hudson.cli.CLICommandInvoker.Matcher.succeeded;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class DeclarativeLinterCommandTest extends AbstractModelDefTest {
+
+    private CLICommandInvoker command;
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        command = new CLICommandInvoker(j, "declarative-linter");
+    }
+
+    @Test
+    public void validJenkinsfile() throws Exception {
+        String testPath = writeJenkinsfileToTmpFile("simplePipeline");
+
+        final CLICommandInvoker.Result result = command.invokeWithArgs(testPath);
+
+        assertThat(result, succeeded());
+        assertThat(result, hasNoErrorOutput());
+        assertThat(result.stdout(), containsString("Jenkinsfile successfully validated."));
+    }
+
+    @Test
+    public void invalidJenkinsfile() throws Exception {
+        String testPath = writeJenkinsfileToTmpFile("errors", "emptyAgent");
+
+        final CLICommandInvoker.Result result = command.invokeWithArgs(testPath);
+
+        assertThat(result, failedWith(1));
+        assertThat(result, hasNoErrorOutput());
+        assertThat(result.stdout(), containsString("Errors encountered validating Jenkinsfile:"));
+        assertThat(result.stdout(), containsString("Not a valid section definition: 'agent'. Some extra configuration is required"));
+    }
+
+    @Test
+    public void notFoundJenkinsfile() throws Exception {
+        File tempFile = tmp.newFile();
+        String badPath = tempFile.getAbsolutePath();
+        tempFile.delete();
+
+        final CLICommandInvoker.Result result = command.invokeWithArgs(badPath);
+
+        assertThat(result, failedWith(1));
+        assertThat(result.stdout(), containsString("does not exist or cannot be read"));
+    }
+
+    private String writeJenkinsfileToTmpFile(String dir, String testName) throws IOException {
+        return writeJenkinsfileToTmpFile(dir + "/" + testName);
+    }
+
+    private String writeJenkinsfileToTmpFile(String testName) throws IOException {
+        File jf = tmp.newFile();
+
+        String contents = pipelineSourceFromResources(testName);
+
+        FileUtils.writeStringToFile(jf, contents);
+
+        return jf.getAbsolutePath();
+    }
+}


### PR DESCRIPTION
[JENKINS-39923](https://issues.jenkins-ci.org/browse/JENKINS-39923)

Can be used like:

```
ssh -p [sshd port on master] localhost declarative-linter < Jenkinsfile
```

or

```
curl -X POST -H `curl 'JENKINS_URL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'` -F 'jenkinsfile="@Jenkinsfile"' JENKINS_URL/pipeline-model-converter/validate
```
(the `crumbIssuer` bit is needed if your Jenkins master has CRSF enabled, as it should)

- [x] Write the guts.
- [x] Switch to taking a file path as parameter. 
- [x] Decide on permissions.
- [x] Add tests.

Example output:

Invalid:
```
ssh -p 8675 localhost declarative-linter < src/test/resources/errors/emptyAgent.groovy
Errors encountered validating Jenkinsfile:
WorkflowScript: 25: Not a valid section definition: 'agent'. Some extra configuration is required. @ line 25, column 1.
   pipeline {
   ^

WorkflowScript: 25: Missing required section 'agent' @ line 25, column 1.
   pipeline {
   ^
```

Valid:
```
ssh -p 8675 localhost declarative-linter < src/test/resources/basicWhen.groovy
Jenkinsfile successfully validated.
```

cc @reviewbybees esp @rsandell @HRPMW @i386 @michaelneale 