### PR TITLE
Use default GMaven plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@
       <plugin>
         <groupId>org.codehaus.gmaven</groupId>
         <artifactId>gmaven-plugin</artifactId>
-        <version>1.4</version>
         <configuration>
           <providerSelection>1.8</providerSelection>
         </configuration>


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/gmaven/commit/cd59639ce48c9f62e08b6808b724e280fdb63e2d.

I had thought this would solve the NPE from `ClosureModelTranslator` during compile-on-save test runs, but it does not. From

```diff
diff --git a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
index 011bf17..abcd6d3 100644
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
@@ -63,6 +63,7 @@ public class ClosureModelTranslator implements MethodMissingWrapper, Serializabl
 
     NestedModel toNestedModel() {
         NestedModel m = actualClass.newInstance()
+        script.echo "actualClass=${actualClass} m=${m}"
         m.modelFromMap(actualMap)
         return m
     }
```

I found that the bogus `pipeline-model-definition/target/generated-sources/groovy-stubs/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.java` rather than `pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy` was being processed into `pipeline-model-definition/target/classes/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.class`. But not sure how to solve this.

@reviewbybees