### PR TITLE
Make internal-only steps advanced.

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/DockerLabelStep.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/DockerLabelStep.java
@@ -58,6 +58,11 @@ public class DockerLabelStep extends AbstractStepImpl implements Serializable {
         }
 
         @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
+        @Override
         public String getFunctionName() {
             return "dockerLabel";
         }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/EnvVarsForToolStep.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/EnvVarsForToolStep.java
@@ -82,6 +82,11 @@ public final class EnvVarsForToolStep extends AbstractStepImpl implements Serial
             super(EnvVarsForToolStepExecution.class);
         }
 
+        @Override
+        public boolean isAdvanced() {
+            return true;
+        }
+
         @Override public String getFunctionName() {
             return "envVarsForTool";
         }


### PR DESCRIPTION
This is so they don't show up in the Snippet Generator or the eventual
Pipeline Editor step choice UI, since they only exist for internal purposes.

@kzantow - this covers one of the things we talked about today.

cc @reviewbybees esp @rsandell 