### PR TITLE
Switch to requiring no Launcher in getRequiredContext() for wrappers

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-basic-steps</artifactId>
-      <version>2.2</version>
+      <version>2.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Wrappers.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Wrappers.groovy
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import hudson.ExtensionList
+import hudson.FilePath
 import hudson.Launcher
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
@@ -51,7 +52,8 @@ public class Wrappers extends MappedClosure<String, Wrappers> implements Wrapper
         ExtensionList.lookup(StepDescriptor.class).each { s ->
             if (s.takesImplicitBlockArgument()
                 && !(s.getFunctionName() in ModelASTStep.blockedSteps.keySet())
-                && !(Launcher.class in s.getRequiredContext())) {
+                && !(Launcher.class in s.getRequiredContext())
+                && !(FilePath.class in s.getRequiredContext())) {
                 stepNames.add(s.getFunctionName())
             }
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Wrappers.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Wrappers.groovy
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import hudson.ExtensionList
+import hudson.Launcher
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
@@ -50,7 +51,7 @@ public class Wrappers extends MappedClosure<String, Wrappers> implements Wrapper
         ExtensionList.lookup(StepDescriptor.class).each { s ->
             if (s.takesImplicitBlockArgument()
                 && !(s.getFunctionName() in ModelASTStep.blockedSteps.keySet())
-                && s.getRequiredContext().isEmpty()) {
+                && !(Launcher.class in s.getRequiredContext())) {
                 stepNames.add(s.getFunctionName())
             }
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -166,7 +166,7 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"perStageConfigUnknownSection", "At /pipeline/stages/0: additional properties are not allowed"});
 
         result.add(new Object[]{"unknownAgentType", "No agent type specified. Must contain one of [otherField, docker, dockerfile, label, any, none]"});
-        result.add(new Object[]{"invalidWrapperType", "Invalid wrapper type 'echo'. Valid wrapper types: [retry, script, timeout, withEnv]"});
+        result.add(new Object[]{"invalidWrapperType", "Invalid wrapper type 'echo'. Valid wrapper types: [catchError, node, retry, script, timeout, waitUntil, withContext, withEnv, ws]"});
 
         result.add(new Object[]{"unknownBareAgentType", "Invalid argument for agent - 'foo' - must be map of config options or bare [any, none]."});
         result.add(new Object[]{"agentMissingRequiredParam", "Missing required parameter for agent type 'otherField': label"});


### PR DESCRIPTION
More narrowly scoped than the previous requiring it to be empty. That
ended up bugging out with TimeoutStep from workflow-basic-steps 2.3
(probably due to some other change elsewhere in the dependency tree,
since TimeoutStep itself didn't change between 2.2 and 2.3, though
TimeoutStepExecution did). So switching!

cc @reviewbybees esp @rsandell