### PR TITLE
JENKINS-40337 - add top-level `options` section and `skipCheckout` option

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTOptions.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTOptions.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
+
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
+/**
+ * Represents a map of possible top-level options.
+ *
+ * @author Andrew Bayer
+ */
+public final class ModelASTOptions extends ModelASTElement {
+    private Boolean skipCheckout;
+
+    public ModelASTOptions(Object sourceLocation) {
+        super(sourceLocation);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        final JSONObject o = new JSONObject();
+        o.accumulate("skipCheckout", skipCheckout);
+
+        return o;
+    }
+
+    @Override
+    public void validate(final ModelValidator validator) {
+        validator.validateElement(this);
+    }
+
+    @Override
+    public String toGroovy() {
+        StringBuilder result = new StringBuilder("options {\n");
+        if (skipCheckout != null) {
+            result.append("skipCheckout " + skipCheckout);
+        }
+        result.append("}\n");
+        return result.toString();
+    }
+
+    public Boolean getSkipCheckout() {
+        return skipCheckout;
+    }
+
+    public void setSkipCheckout(Boolean b) {
+        this.skipCheckout = b;
+    }
+
+    @Override
+    public String toString() {
+        return "ModelASTOptions{" +
+                "skipCheckout=" + skipCheckout +
+                "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ModelASTOptions that = (ModelASTOptions) o;
+
+        return getSkipCheckout() != null ? getSkipCheckout().equals(that.getSkipCheckout()) : that.getSkipCheckout() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getSkipCheckout() != null ? getSkipCheckout().hashCode() : 0);
+        return result;
+    }
+}

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
@@ -20,6 +20,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
     private ModelASTBuildParameters parameters;
     private ModelASTTriggers triggers;
     private ModelASTWrappers wrappers;
+    private ModelASTOptions options;
 
     public ModelASTPipelineDef(Object sourceLocation) {
         super(sourceLocation);
@@ -52,6 +53,11 @@ public final class ModelASTPipelineDef extends ModelASTElement {
             a.put("wrappers", wrappers.toJSON());
         } else {
             a.put("wrappers", null);
+        }
+        if (options != null && !options.equals(new ModelASTOptions(null))) {
+            a.put("options", options.toJSON());
+        } else {
+            a.put("options", null);
         }
         return new JSONObject().accumulate("pipeline", a);
     }
@@ -87,6 +93,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         if (wrappers != null) {
             wrappers.validate(validator);
         }
+        if (options != null) {
+            options.validate(validator);
+        }
     }
 
     @Override
@@ -119,6 +128,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         }
         if (wrappers != null && !wrappers.getWrappers().isEmpty()) {
             result.append(wrappers.toGroovy()).append('\n');
+        }
+        if (options != null && !options.equals(new ModelASTOptions(null))) {
+            result.append(options.toGroovy()).append('\n');
         }
 
         result.append("}\n");
@@ -193,6 +205,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         }
         if (wrappers != null) {
             wrappers.removeSourceLocation();
+        }
+        if (options != null) {
+            options.removeSourceLocation();
         }
     }
 
@@ -272,6 +287,14 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         this.wrappers = wrappers;
     }
 
+    public ModelASTOptions getOptions() {
+        return options;
+    }
+
+    public void setOptions(ModelASTOptions options) {
+        this.options = options;
+    }
+
     @Override
     public String toString() {
         return "ModelASTPipelineDef{" +
@@ -284,6 +307,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
                 ", parameters=" + parameters +
                 ", triggers=" + triggers +
                 ", wrappers=" + wrappers +
+                ", options=" + options +
                 "}";
     }
 
@@ -329,6 +353,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         if (getTriggers() != null ? !getTriggers().equals(that.getTriggers()) : that.getTriggers() != null) {
             return false;
         }
+        if (getOptions() != null ? !getOptions().equals(that.getOptions()) : that.getOptions() != null) {
+            return false;
+        }
         return getWrappers() != null ? getWrappers().equals(that.getWrappers()) : that.getWrappers() == null;
 
     }
@@ -345,6 +372,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         result = 31 * result + (getParameters() != null ? getParameters().hashCode() : 0);
         result = 31 * result + (getTriggers() != null ? getTriggers().hashCode() : 0);
         result = 31 * result + (getWrappers() != null ? getWrappers().hashCode() : 0);
+        result = 31 * result + (getOptions() != null ? getOptions().hashCode() : 0);
         return result;
     }
 }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTEnvironment;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTJobProperties;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTJobProperty;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostBuild;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostStage;
@@ -93,4 +94,6 @@ public interface ModelValidator {
     boolean validateElement(ModelASTWrapper wrapper);
 
     boolean validateElement(ModelASTWrappers wrappers);
+
+    boolean validateElement(ModelASTOptions options);
 }

--- a/pipeline-model-api/src/main/resources/ast-schema.json
+++ b/pipeline-model-api/src/main/resources/ast-schema.json
@@ -365,6 +365,16 @@
         "$ref": "#/definitions/stage"
       }
     },
+    "options": {
+      "description": "Top level section containing global configuration options",
+      "type": "object",
+      "properties": {
+        "skipCheckout": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "pipeline": {
       "type": "object",
       "properties": {
@@ -394,6 +404,9 @@
         },
         "wrappers": {
           "$ref": "#/definitions/wrappers"
+        },
+        "options": {
+          "$ref": "#/definitions/options"
         }
       },
       "required": [

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.model
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+
+
+/**
+ * Root level section to define global configuration options
+ */
+@ToString
+@EqualsAndHashCode
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
+class Options implements NestedModel, Serializable {
+    Boolean skipCheckout
+
+    Options skipCheckout(Boolean b) {
+        this.skipCheckout = b
+        return this
+    }
+
+    @Override
+    public void modelFromMap(Map<String,Object> m) {
+        m.each { k, v ->
+            this."${k}"(v)
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -57,6 +57,8 @@ public class Root implements NestedModel, Serializable {
 
     Wrappers wrappers
 
+    Options options
+
     Root stages(Stages s) {
         this.stages = s
         return this
@@ -104,6 +106,11 @@ public class Root implements NestedModel, Serializable {
 
     Root wrappers(Wrappers w) {
         this.wrappers = w
+        return this
+    }
+
+    Root options(Options o) {
+        this.options = o
         return this
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -39,6 +39,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidatorIm
 
 import javax.annotation.CheckForNull
 import javax.annotation.Nonnull
+import java.lang.reflect.Field
 
 /**
  * Parses input JSON into a {@link ModelASTPipelineDef}.
@@ -114,6 +115,9 @@ class JSONParser {
                     break
                 case 'wrappers':
                     pipelineDef.wrappers = parseWrappers(pipelineJson.getJSONObject("wrappers"))
+                    break
+                case 'options':
+                    pipelineDef.options = parseOptions(pipelineJson.getJSONObject("options"))
                     break
                 default:
                     errorCollector.error(pipelineDef, "Undefined section '${sectionName}'")
@@ -469,6 +473,27 @@ class JSONParser {
             tools.tools.put(key, value)
         }
         return tools
+    }
+
+    public @CheckForNull ModelASTOptions parseOptions(JSONObject j) {
+        ModelASTOptions options = new ModelASTOptions(j)
+
+        j.keySet().each { String k ->
+            Field f = ModelASTOptions.class.getDeclaredField(k)
+            if (f == null) {
+                errorCollector.error(options, "Unknown global configuration option '${k}'")
+            } else {
+                Object o = j.get(k)
+
+                if (!f.getType().isInstance(o)) {
+                    errorCollector.error(options, "Expected a ${f.getType().name} for option '${k}'")
+                } else {
+                    f.set(options, o)
+                }
+            }
+        }
+
+        return options
     }
 
     public @CheckForNull ModelASTAgent parseAgent(Object j) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -479,17 +479,17 @@ class JSONParser {
         ModelASTOptions options = new ModelASTOptions(j)
 
         j.keySet().each { String k ->
-            Field f = ModelASTOptions.class.getDeclaredField(k)
-            if (f == null) {
-                errorCollector.error(options, "Unknown global configuration option '${k}'")
-            } else {
+            try {
+                Field f = ModelASTOptions.class.getDeclaredField(k)
                 Object o = j.get(k)
 
                 if (!f.getType().isInstance(o)) {
-                    errorCollector.error(options, "Expected a ${f.getType().name} for option '${k}'")
+                    errorCollector.error(options, "Expected a ${f.getType().simpleName} for option '${k}'")
                 } else {
-                    f.set(options, o)
+                    options."${k}" = o
                 }
+            } catch (NoSuchFieldException e) {
+                errorCollector.error(options, "Unknown global configuration option '${k}'")
             }
         }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -755,10 +755,8 @@ class ModelParser {
 
                 def optionKey = parseKey(mc.method);
 
-                Field f = ModelASTOptions.class.getDeclaredField(optionKey.key)
-                if (f == null) {
-                    errorCollector.error(optionKey, "Unknown global configuration option '${optionKey.key}'")
-                } else {
+                try {
+                    Field f = ModelASTOptions.class.getDeclaredField(optionKey.key)
                     List<Expression> args = ((TupleExpression) mc.arguments).expressions
                     if (args.isEmpty()) {
                         errorCollector.error(optionKey, "No argument for option '${optionKey.key}'")
@@ -767,11 +765,13 @@ class ModelParser {
                     } else {
                         ConstantExpression exp = castOrNull(ConstantExpression.class, args[0])
                         if (exp == null || !(f.getType().isInstance(exp.value))) {
-                            errorCollector.error(optionKey, "Expected a ${f.getType().name} for option '${optionKey.key}'")
+                            errorCollector.error(optionKey, "Expected a ${f.getType().simpleName} for option '${optionKey.key}'")
                         } else {
-                            f.set(r, exp.value)
+                            r."${optionKey.key}" = exp.value
                         }
                     }
+                } catch (NoSuchFieldException e) {
+                    errorCollector.error(optionKey, "Unknown global configuration option '${optionKey.key}'")
                 }
             }
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -585,6 +585,11 @@ class ModelValidatorImpl implements ModelValidator {
         return valid
     }
 
+    public boolean validateElement(@Nonnull ModelASTOptions options) {
+        // no-op for now since the actual "validation" is at parse-time
+        return true
+    }
+
     private DescribableModel<? extends Step> modelForStep(String n) {
         if (!modelMap.containsKey(n)) {
             Class<? extends Step> c = lookupStepDescriptor(n)?.clazz

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -76,7 +76,7 @@ public class ModelInterpreter implements Serializable {
                             withCredentialsBlock(root.getEnvCredentials()) {
                                 toolsBlock(root.agent, root.tools) {
                                     // If we have an agent and script.scm isn't null, run checkout scm
-                                    if (root.agent.hasAgent() && Utils.hasScmContext(script)) {
+                                    if (root.agent.hasAgent() && Utils.hasScmContext(script) && !(root.options?.skipCheckout)) {
                                         script.stage(SyntheticStageNames.checkout()) {
                                             Utils.markSyntheticStage(SyntheticStageNames.checkout(), Utils.getSyntheticStageMetadata().pre)
                                             script.checkout script.scm

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -130,7 +130,8 @@ public abstract class AbstractModelDefTest {
             "environmentInStage",
             "basicWhen",
             "skippedWhen",
-            "parallelPipelineWithFailFast"
+            "parallelPipelineWithFailFast",
+            "optionsSkipCheckout"
     );
 
     public static Iterable<Object[]> configsWithErrors() {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition;
+
+import hudson.model.Result;
+import hudson.model.Slave;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Andrew Bayer
+ */
+public class OptionsTest extends AbstractModelDefTest {
+    private static Slave s;
+
+    @BeforeClass
+    public static void setUpAgent() throws Exception {
+        s = j.createOnlineSlave();
+        s.setLabelString("some-label docker");
+    }
+
+    @Test
+    public void optionsSkipCheckout() throws Exception {
+        expect(Result.FAILURE, "optionsSkipCheckout")
+                .logContains("[Pipeline] { (foo)", "THIS WORKS")
+                .logNotContains("Should never get here")
+                .go();
+    }
+
+
+}

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -417,4 +417,18 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .logNotContains("Caused by: java.lang.NullPointerException")
                 .go();
     }
+
+    @Test
+    public void optionsUnknownOption() throws Exception {
+        expect(Result.FAILURE, "errors", "optionsUnknownOption")
+                .logContains("Unknown global configuration option 'banana'")
+                .go();
+    }
+
+    @Test
+    public void optionsWrongType() throws Exception {
+        expect(Result.FAILURE, "errors", "optionsWrongType")
+                .logContains("Expected a Boolean for option 'skipCheckout'")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/errors/optionsUnknownOption.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/optionsUnknownOption.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    options {
+        banana true
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo "THIS WORKS"')
+                sh('test -f Jenkinsfile')
+                echo 'Should never get here'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/optionsWrongType.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/optionsWrongType.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    options {
+        skipCheckout "banana"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo "THIS WORKS"')
+                sh('test -f Jenkinsfile')
+                echo 'Should never get here'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/json/optionsSkipCheckout.json
+++ b/pipeline-model-definition/src/test/resources/json/optionsSkipCheckout.json
@@ -1,0 +1,36 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps":       [
+        {
+          "name": "sh",
+          "arguments":           {
+            "isLiteral": true,
+            "value": "echo \"THIS WORKS\""
+          }
+        },
+        {
+          "name": "sh",
+          "arguments":           {
+            "isLiteral": true,
+            "value": "test -f Jenkinsfile"
+          }
+        },
+        {
+          "name": "echo",
+          "arguments":           {
+            "isLiteral": true,
+            "value": "Should never get here"
+          }
+        }
+      ]
+    }]
+  }],
+  "agent":   {
+    "isLiteral": true,
+    "value": "any"
+  },
+  "options": {"skipCheckout": true}
+}}

--- a/pipeline-model-definition/src/test/resources/optionsSkipCheckout.groovy
+++ b/pipeline-model-definition/src/test/resources/optionsSkipCheckout.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    options {
+        skipCheckout true
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo "THIS WORKS"')
+                sh('test -f Jenkinsfile')
+                echo 'Should never get here'
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
[JENKINS-40337](https://issues.jenkins-ci.org/browse/JENKINS-40337)

Right now, there's just the one possible thing that can go in `options`, but I have a feeling there could well be more. I opted to not go with a `Map` underlying the `options` (unlike `tools`, `environment`, et al) because this way, it'll be a *lot* easier in the future if we need to add a complex option - i.e., a nested map, etc - while still getting good type and name validation. That said, if there's a better way to do it, I'm not saying no!

cc @reviewbybees esp @rsandell @michaelneale @HRMPW @i386