### PR TITLE
[FIXED JENKINS-40418] Fix validation for a number of extended types

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildParameter.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildParameter.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import groovy.transform.EqualsAndHashCode;
 import groovy.transform.ToString;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
 
 /**
  * A single parameter definition, eventually corresponding to a {@code ParameterDefinition}
@@ -12,6 +13,12 @@ import groovy.transform.ToString;
 public class ModelASTBuildParameter extends ModelASTMethodCall {
     public ModelASTBuildParameter(Object sourceLocation) {
         super(sourceLocation);
+    }
+
+    @Override
+    public void validate(final ModelValidator validator) {
+        validator.validateElement(this);
+        super.validate(validator);
     }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTJobProperty.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTJobProperty.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
 /**
  * A single job property, corresponding eventually to {@code JobProperty}
  *
@@ -8,6 +10,12 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 public class ModelASTJobProperty extends ModelASTMethodCall {
     public ModelASTJobProperty(Object sourceLocation) {
         super(sourceLocation);
+    }
+
+    @Override
+    public void validate(final ModelValidator validator) {
+        validator.validateElement(this);
+        super.validate(validator);
     }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTScriptBlock.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTScriptBlock.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
 /**
  * Represents the special step for {@code ScriptStep}, which are executed without validation against the declarative subset.
  *
@@ -8,5 +10,10 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 public class ModelASTScriptBlock extends AbstractModelASTCodeBlock {
     public ModelASTScriptBlock(Object sourceLocation) {
         super(sourceLocation, "script");
+    }
+
+    @Override
+    public void validate(final ModelValidator validator) {
+        // no-op - we don't do validation of script blocks
     }
 }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTrigger.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTrigger.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
 /**
  * A single trigger, corresponding eventually to a {@code Trigger}
  *
@@ -8,6 +10,12 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 public class ModelASTTrigger extends ModelASTMethodCall {
     public ModelASTTrigger(Object sourceLocation) {
         super(sourceLocation);
+    }
+
+    @Override
+    public void validate(final ModelValidator validator) {
+        validator.validateElement(this);
+        super.validate(validator);
     }
 
     @Override

--- a/pipeline-model-api/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorTest.java
+++ b/pipeline-model-api/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorTest.java
@@ -4,8 +4,12 @@ import java.util.Collections;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildCondition;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildConditionsContainer;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodArg;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostBuild;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTrigger;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -42,6 +46,20 @@ public class ModelValidatorTest {
         inOrder.verify(validator, Mockito.times(1)).validateElement((ModelASTBuildConditionsContainer) instance);
         inOrder.verify(validator, Mockito.times(1)).validateElement(condition);
         inOrder.verify(validator, Mockito.times(1)).validateElement(branch);
+    }
+
+    @Test
+    public void triggerValidateCallsRightMethod() throws Exception {
+        ModelValidator validator = Mockito.mock(ModelValidator.class);
+
+        ModelASTTrigger trigger = new ModelASTTrigger(null);
+        ModelASTMethodArg arg = ModelASTValue.fromConstant("bar", null);
+        trigger.setArgs(Collections.singletonList(arg));
+        trigger.setName("foo");
+        trigger.validate(validator);
+        InOrder inOrder = Mockito.inOrder(validator);
+        inOrder.verify(validator, Mockito.times(1)).validateElement(trigger);
+        inOrder.verify(validator, Mockito.times(1)).validateElement((ModelASTMethodCall)trigger);
     }
 
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -342,7 +342,6 @@ class ModelValidatorImpl implements ModelValidator {
 
     public boolean validateElement(@Nonnull ModelASTTrigger trig) {
         boolean valid = true
-
         if (trig.name == null) {
             // This means that we failed at compilation time so can move on.
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -404,6 +404,10 @@ public abstract class AbstractModelDefTest {
         return new ExpectationsBuilder(resourceParent, resource);
     }
 
+    protected ExpectationsBuilder expectError(String resource) {
+        return expect(Result.FAILURE, "errors", resource);
+    }
+
     protected ExpectationsBuilder expect(Result result, String resourceParent, String resource) {
         return new ExpectationsBuilder(result, resourceParent, resource);
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -26,7 +26,10 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 import hudson.model.Result;
 import hudson.slaves.DumbSlave;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.JobProperties;
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Parameters;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Tools;
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Triggers;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Wrappers;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -48,252 +51,275 @@ public class ValidatorTest extends AbstractModelDefTest {
     @Issue("JENKINS-39011")
     @Test
     public void pipelineStepWithinOtherBlockFailure() throws Exception {
-        expect(Result.FAILURE, "errors", "pipelineStepWithinOtherBlocksFailure")
+        expectError("pipelineStepWithinOtherBlocksFailure")
                 .logContains("pipeline block must be at the top-level, not within another block")
                 .go();
     }
 
     @Test
     public void rejectStageInSteps() throws Exception {
-        expect(Result.FAILURE, "errors", "rejectStageInSteps")
+        expectError("rejectStageInSteps")
                 .logContains("Invalid step 'stage' used - not allowed in this context - The stage step cannot be used in Declarative Pipelines")
                 .go();
     }
 
     @Test
     public void rejectParallelMixedInSteps() throws Exception {
-        expect(Result.FAILURE, "errors", "rejectParallelMixedInSteps")
+        expectError("rejectParallelMixedInSteps")
                 .logContains("Invalid step 'parallel' used - not allowed in this context - The parallel step can only be used as the only top-level step in a stage's step block")
                 .go();
     }
 
     @Test
     public void emptyStages() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyStages")
+        expectError("emptyStages")
                 .logContains("No stages specified")
                 .go();
     }
 
     @Test
     public void emptyJobProperties() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyJobProperties")
+        expectError("emptyJobProperties")
                 .logContains("Cannot have empty properties section")
                 .go();
     }
 
     @Test
     public void emptyParameters() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyParameters")
+        expectError("emptyParameters")
                 .logContains("Cannot have empty parameters section")
                 .go();
     }
 
     @Test
     public void emptyTriggers() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyTriggers")
+        expectError("emptyTriggers")
                 .logContains("Cannot have empty triggers section")
                 .go();
     }
 
     @Test
     public void blockInJobProperties() throws Exception {
-        expect(Result.FAILURE, "errors", "blockInJobProperties")
+        expectError("blockInJobProperties")
                 .logContains("Job property definitions cannot have blocks")
                 .go();
     }
 
     @Test
     public void blockInParameters() throws Exception {
-        expect(Result.FAILURE, "errors", "blockInParameters")
+        expectError("blockInParameters")
                 .logContains("Build parameter definitions cannot have blocks")
                 .go();
     }
 
     @Test
     public void blockInTriggers() throws Exception {
-        expect(Result.FAILURE, "errors", "blockInTriggers")
+        expectError("blockInTriggers")
                 .logContains("Trigger definitions cannot have blocks")
                 .go();
     }
 
     @Test
     public void mixedMethodArgs() throws Exception {
-        expect(Result.FAILURE, "errors", "mixedMethodArgs")
+        expectError("mixedMethodArgs")
                 .logContains("Can't mix named and unnamed parameter definition arguments")
                 .go();
     }
 
     @Test
     public void closureAsMethodCallArg() throws Exception {
-        expect(Result.FAILURE, "errors", "closureAsMethodCallArg")
+        expectError("closureAsMethodCallArg")
                 .logContains("Method call arguments cannot use closures")
                 .go();
     }
 
     @Test
     public void tooFewMethodCallArgs() throws Exception {
-        expect(Result.FAILURE, "errors", "tooFewMethodCallArgs")
+        expectError("tooFewMethodCallArgs")
                 .logContains("'cron' should have 1 arguments but has 0 arguments instead")
                 .go();
     }
 
     @Test
     public void wrongParameterNameMethodCall() throws Exception {
-        expect(Result.FAILURE, "errors", "wrongParameterNameMethodCall")
+        expectError("wrongParameterNameMethodCall")
                 .logContains("Invalid parameter 'namd', did you mean 'name'?")
                 .go();
     }
 
     @Test
     public void invalidParameterTypeMethodCall() throws Exception {
-        expect(Result.FAILURE, "errors", "invalidParameterTypeMethodCall")
+        expectError("invalidParameterTypeMethodCall")
                 .logContains("Expecting class java.lang.String for parameter 'name' but got '1234' instead")
                 .go();
     }
 
     @Test
     public void rejectPropertiesStepInMethodCall() throws Exception {
-        expect(Result.FAILURE, "errors", "rejectPropertiesStepInMethodCall")
+        expectError("rejectPropertiesStepInMethodCall")
                 .logContains("Invalid step 'properties' used - not allowed in this context - The properties step cannot be used in Declarative Pipelines")
                 .go();
     }
 
     @Test
     public void rejectMapsForTriggerDefinition() throws Exception {
-        expect(Result.FAILURE, "errors", "rejectMapsForTriggerDefinition")
+        expectError("rejectMapsForTriggerDefinition")
                 .logContains("Triggers cannot be defined as maps")
                 .go();
     }
 
     @Test
     public void emptyParallel() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyParallel")
+        expectError("emptyParallel")
                 .logContains("Nothing to execute within stage 'foo'")
                 .go();
     }
 
     @Test
     public void parallelPipelineWithInvalidFailFast() throws Exception {
-        expect(Result.FAILURE, "errors", "parallelPipelineWithInvalidFailFast")
+        expectError("parallelPipelineWithInvalidFailFast")
                 .logContains("Expected a boolean with failFast")
                 .go();
     }
 
     @Test
     public void parallelPipelineWithInvalidExtraKey() throws Exception {
-        expect(Result.FAILURE, "errors", "parallelPipelineWithInvalidExtraKey")
+        expectError("parallelPipelineWithInvalidExtraKey")
                 .logContains("Expected closure or failFast")
                 .go();
     }
 
     @Test
     public void missingAgent() throws Exception {
-        expect(Result.FAILURE, "errors", "missingAgent")
+        expectError("missingAgent")
                 .logContains("Missing required section 'agent'")
                 .go();
     }
 
     @Test
     public void missingStages() throws Exception {
-        expect(Result.FAILURE, "errors", "missingStages")
+        expectError("missingStages")
                 .logContains("Missing required section 'stages'")
                 .go();
     }
 
     @Test
     public void missingRequiredStepParameters() throws Exception {
-        expect(Result.FAILURE, "errors", "missingRequiredStepParameters")
+        expectError("missingRequiredStepParameters")
                 .logContains("Missing required parameter: 'time'")
                 .go();
     }
 
     @Test
     public void invalidStepParameterType() throws Exception {
-        expect(Result.FAILURE, "errors", "invalidStepParameterType")
+        expectError("invalidStepParameterType")
                 .logContains("Expecting int for parameter 'time' but got 'someTime' instead")
                 .go();
     }
 
     @Test
+    public void invalidTriggerType() throws Exception {
+        expectError("invalidTriggerType")
+                .logContains("Invalid trigger type 'banana'. Valid trigger types: " + Triggers.getAllowedTriggerTypes().keySet())
+                .go();
+    }
+
+    @Test
+    public void invalidParameterType() throws Exception {
+        expectError("invalidParameterType")
+                .logContains("Invalid parameter definition type 'bananaParam'. Valid parameter definition types: "
+                        + Parameters.getAllowedParameterTypes().keySet())
+                .go();
+    }
+
+    @Test
+    public void invalidPropertiesType() throws Exception {
+        expectError("invalidPropertiesType")
+                .logContains("Invalid job property type 'banana'. Valid job property types: "
+                        + JobProperties.getAllowedPropertyTypes().keySet())
+                .go();
+    }
+
+    @Test
     public void unknownStepParameter() throws Exception {
-        expect(Result.FAILURE, "errors", "unknownStepParameter")
+        expectError("unknownStepParameter")
                 .logContains("Invalid parameter 'banana', did you mean 'unit'?")
                 .go();
     }
 
     @Test
     public void perStageConfigEmptySteps() throws Exception {
-        expect(Result.FAILURE, "errors", "perStageConfigEmptySteps")
+        expectError("perStageConfigEmptySteps")
                 .logContains("No steps specified for branch")
                 .go();
     }
 
     @Test
     public void perStageConfigMissingSteps() throws Exception {
-        expect(Result.FAILURE, "errors", "perStageConfigMissingSteps")
+        expectError("perStageConfigMissingSteps")
                 .logContains("Nothing to execute within stage")
                 .go();
     }
 
     @Test
     public void perStageConfigUnknownSection() throws Exception {
-        expect(Result.FAILURE, "errors", "perStageConfigUnknownSection")
+        expectError("perStageConfigUnknownSection")
                 .logContains("Unknown stage section 'banana'")
                 .go();
     }
 
     @Test
     public void invalidMetaStepSyntax() throws Exception {
-        expect(Result.FAILURE, "errors", "invalidMetaStepSyntax")
+        expectError("invalidMetaStepSyntax")
                 .logContains("Invalid parameter 'someRandomField', did you mean 'caseSensitive'?")
                 .go();
     }
 
     @Test
     public void duplicateStageNames() throws Exception {
-        expect(Result.FAILURE, "errors", "duplicateStageNames")
+        expectError("duplicateStageNames")
                 .logContains("Duplicate stage name: 'foo'", "Nothing to execute within stage 'bar'")
                 .go();
     }
 
     @Test
     public void duplicateEnvironment() throws Exception {
-        expect(Result.FAILURE, "errors", "duplicateEnvironment")
+        expectError("duplicateEnvironment")
                 .logContains("Duplicate environment variable name: 'FOO'")
                 .go();
     }
 
     @Test
     public void duplicateStepParameter() throws Exception {
-        expect(Result.FAILURE, "errors", "duplicateStepParameter")
+        expectError("duplicateStepParameter")
                 .logContains("Duplicate named parameter 'time' found")
                 .go();
     }
 
     @Test
     public void emptyEnvironment() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyEnvironment")
+        expectError("emptyEnvironment")
                 .logContains("No variables specified for environment")
                 .go();
     }
 
     @Test
     public void emptyAgent() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyAgent")
+        expectError("emptyAgent")
                 .logContains("Not a valid section definition: 'agent'. Some extra configuration is required.")
                 .go();
     }
 
     @Test
     public void perStageConfigEmptyAgent() throws Exception {
-        expect(Result.FAILURE, "errors", "perStageConfigEmptyAgent")
+        expectError("perStageConfigEmptyAgent")
                 .logContains("Not a valid stage section definition: 'agent'. Some extra configuration is required.")
                 .go();
     }
 
     @Test
     public void invalidBuildCondition() throws Exception {
-        expect(Result.FAILURE, "errors", "invalidBuildCondition")
+        expectError("invalidBuildCondition")
                 .logContains("MultipleCompilationErrorsException: startup failed:",
                         "Invalid condition 'banana' - valid conditions are " + BuildCondition.getOrderedConditionNames())
                 .go();
@@ -301,21 +327,21 @@ public class ValidatorTest extends AbstractModelDefTest {
 
     @Test
     public void emptyPostBuild() throws Exception {
-        expect(Result.FAILURE, "errors", "emptyPostBuild")
+        expectError("emptyPostBuild")
                 .logContains("post can not be empty")
                 .go();
     }
 
     @Test
     public void duplicatePostBuildConditions() throws Exception {
-        expect(Result.FAILURE, "errors", "duplicatePostBuildConditions")
+        expectError("duplicatePostBuildConditions")
                 .logContains("Duplicate build condition name: 'always'")
                 .go();
     }
 
     @Test
     public void unlistedToolType() throws Exception {
-        expect(Result.FAILURE, "errors", "unlistedToolType")
+        expectError("unlistedToolType")
                 .logContains("MultipleCompilationErrorsException: startup failed:",
                         "Invalid tool type 'banana'. Valid tool types: " + Tools.getAllowedToolTypes().keySet())
                 .go();
@@ -323,7 +349,7 @@ public class ValidatorTest extends AbstractModelDefTest {
 
     @Test
     public void notInstalledToolVersion() throws Exception {
-        expect(Result.FAILURE, "errors", "notInstalledToolVersion")
+        expectError("notInstalledToolVersion")
                 .logContains("Tool type 'maven' does not have an install of 'apache-maven-3.0.2' configured - did you mean 'apache-maven-3.0.1'?")
                 .go();
     }
@@ -333,7 +359,7 @@ public class ValidatorTest extends AbstractModelDefTest {
         initGlobalLibrary();
 
         // Test the case of a function with a body that doesn't consist of steps - this will fail.
-        expect(Result.FAILURE, "errors", "globalLibraryNonStepBody")
+        expectError("globalLibraryNonStepBody")
                 .logContains("MultipleCompilationErrorsException: startup failed:",
                         "Expected a step @ line")
                 .go();
@@ -344,7 +370,7 @@ public class ValidatorTest extends AbstractModelDefTest {
         initGlobalLibrary();
 
         // Test the case of calling a method on an object, i.e., foo.bar(1). This will fail.
-        expect(Result.FAILURE, "errors", "globalLibraryObjectMethodCall")
+        expectError("globalLibraryObjectMethodCall")
                 .logContains("MultipleCompilationErrorsException: startup failed:",
                         "Expected a symbol @ line")
                 .go();
@@ -352,56 +378,56 @@ public class ValidatorTest extends AbstractModelDefTest {
 
     @Test
     public void unknownAgentType() throws Exception {
-        expect(Result.FAILURE, "errors", "unknownAgentType")
+        expectError("unknownAgentType")
                 .logContains("No agent type specified. Must contain one of [otherField, docker, dockerfile, label, any, none]")
                 .go();
     }
 
     @Test
     public void unknownBareAgentType() throws Exception {
-        expect(Result.FAILURE, "errors", "unknownBareAgentType")
+        expectError("unknownBareAgentType")
                 .logContains("Invalid argument for agent - 'foo' - must be map of config options or bare [any, none]")
                 .go();
     }
 
     @Test
     public void agentMissingRequiredParam() throws Exception {
-        expect(Result.FAILURE, "errors", "agentMissingRequiredParam")
+        expectError("agentMissingRequiredParam")
                 .logContains("Missing required parameter for agent type 'otherField': label")
                 .go();
     }
 
     @Test
     public void agentUnknownParamForType() throws Exception {
-        expect(Result.FAILURE, "errors", "agentUnknownParamForType")
+        expectError("agentUnknownParamForType")
                 .logContains("Invalid config option 'fruit' for agent type 'otherField'. Valid config options are [label, otherField]")
                 .go();
     }
 
     @Test
     public void packageShouldNotSkipParsing() throws Exception {
-        expect(Result.FAILURE, "errors", "packageShouldNotSkipParsing")
+        expectError("packageShouldNotSkipParsing")
                 .logContains("Missing required section 'agent'")
                 .go();
     }
 
     @Test
     public void importAndFunctionShouldNotSkipParsing() throws Exception {
-        expect(Result.FAILURE, "errors", "importAndFunctionShouldNotSkipParsing")
+        expectError("importAndFunctionShouldNotSkipParsing")
                 .logContains("Missing required section 'agent'")
                 .go();
     }
 
     @Test
     public void invalidWrapperType() throws Exception {
-        expect(Result.FAILURE, "errors", "invalidWrapperType")
+        expectError("invalidWrapperType")
                 .logContains("Invalid wrapper type 'echo'. Valid wrapper types: " + Wrappers.getEligibleSteps())
                 .go();
     }
 
     @Test
     public void notificationsSectionRemoved() throws Exception {
-        expect(Result.FAILURE, "errors", "notificationsSectionRemoved")
+        expectError("notificationsSectionRemoved")
                 .logContains("The 'notifications' section has been removed as of version 0.6. Use 'post' for all post-build actions.")
                 .go();
     }
@@ -409,7 +435,7 @@ public class ValidatorTest extends AbstractModelDefTest {
     @Issue("JENKINS-39799")
     @Test
     public void badPostContent() throws Exception {
-        expect(Result.FAILURE, "errors", "badPostContent")
+        expectError("badPostContent")
                 .logContains("MultipleCompilationErrorsException: startup failed:",
                         "The 'post' section can only contain build condition names with code blocks. "
                                 + "Valid condition names are " + BuildCondition.getOrderedConditionNames(),

--- a/pipeline-model-definition/src/test/resources/errors/invalidParameterType.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidParameterType.groovy
@@ -22,31 +22,19 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
-
-import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
-
-/**
- * A block scoped step to wrap the entire build within.
- *
- * @author Andrew Bayer
- */
-public class ModelASTWrapper extends ModelASTMethodCall {
-    public ModelASTWrapper(Object sourceLocation) {
-        super(sourceLocation);
+pipeline {
+    agent none
+    parameters {
+        bananaParam(defaultValue: true, description: '', name: 'flag')
     }
-
-    @Override
-    public void validate(final ModelValidator validator) {
-        validator.validateElement(this);
-        super.validate(validator);
-    }
-
-    @Override
-    public String toString() {
-        return "ModelASTWrapper{" +
-                "name='" + getName() + '\'' +
-                ", args=" + getArgs() +
-                "}";
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
     }
 }
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/invalidPropertiesType.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidPropertiesType.groovy
@@ -22,31 +22,19 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
-
-import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
-
-/**
- * A block scoped step to wrap the entire build within.
- *
- * @author Andrew Bayer
- */
-public class ModelASTWrapper extends ModelASTMethodCall {
-    public ModelASTWrapper(Object sourceLocation) {
-        super(sourceLocation);
+pipeline {
+    agent none
+    properties {
+        banana(logRotator(numToKeepStr:'1'))
     }
-
-    @Override
-    public void validate(final ModelValidator validator) {
-        validator.validateElement(this);
-        super.validate(validator);
-    }
-
-    @Override
-    public String toString() {
-        return "ModelASTWrapper{" +
-                "name='" + getName() + '\'' +
-                ", args=" + getArgs() +
-                "}";
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
     }
 }
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/invalidTriggerType.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidTriggerType.groovy
@@ -22,31 +22,19 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
-
-import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
-
-/**
- * A block scoped step to wrap the entire build within.
- *
- * @author Andrew Bayer
- */
-public class ModelASTWrapper extends ModelASTMethodCall {
-    public ModelASTWrapper(Object sourceLocation) {
-        super(sourceLocation);
+pipeline {
+    agent none
+    triggers {
+        banana('@daily')
     }
-
-    @Override
-    public void validate(final ModelValidator validator) {
-        validator.validateElement(this);
-        super.validate(validator);
-    }
-
-    @Override
-    public String toString() {
-        return "ModelASTWrapper{" +
-                "name='" + getName() + '\'' +
-                ", args=" + getArgs() +
-                "}";
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
     }
 }
+
+
+


### PR DESCRIPTION
[JENKINS-40418](https://issues.jenkins-ci.org/browse/JENKINS-40418)

Turns out we do need validate methods on child classes - the parent
validate method will end up calling
validator.validateElement(ParentClass) which is...not what we
want. So, fixing that in a bunch of places and adding tests.

Also, added an expectError convenience method.

cc @reviewbybees esp @rsandell