### PR TITLE
Give a better error message if no content for endpoint param

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
@@ -118,8 +118,12 @@ public class ModelConverterAction implements RootAction {
         if (groovyAsString != null && !groovyAsString.equals("")) {
             try {
                 ModelASTPipelineDef pipelineDef = Converter.scriptToPipelineDef(groovyAsString);
-                result.accumulate("result", "success");
-                result.accumulate("json", pipelineDef.toJSON());
+                if (pipelineDef != null) {
+                    result.accumulate("result", "success");
+                    result.accumulate("json", pipelineDef.toJSON());
+                } else {
+                    reportFailure(result, "Jenkinsfile content '" + groovyAsString + "' did not contain the 'pipeline' step");
+                }
             } catch (Exception e) {
                 reportFailure(result, e);
             }
@@ -227,7 +231,12 @@ public class ModelConverterAction implements RootAction {
         if (groovyAsString != null && !groovyAsString.equals("")) {
             try {
                 ModelASTPipelineDef pipelineDef = Converter.scriptToPipelineDef(groovyAsString);
-                result.accumulate("result", "success");
+                if (pipelineDef != null) {
+                    result.accumulate("result", "success");
+                } else {
+                    reportFailure(result, "Jenkinsfile content '" + groovyAsString + "' did not contain the 'pipeline' step");
+                }
+
             } catch (Exception e) {
                 reportFailure(result, e);
             }
@@ -280,8 +289,11 @@ public class ModelConverterAction implements RootAction {
 
         if (groovyAsString != null) {
             try {
-                Converter.scriptToPipelineDef(groovyAsString);
-                output.add("Jenkinsfile successfully validated.");
+                if (Converter.scriptToPipelineDef(groovyAsString) != null) {
+                    output.add("Jenkinsfile successfully validated.");
+                } else {
+                   output.add("Jenkinsfile content '" + groovyAsString + "' did not contain the 'pipeline' step");
+                }
             } catch (Exception e) {
                 output.add("Errors encountered validating Jenkinsfile:");
                 output.addAll(ModelConverterAction.errorToStrings(e));

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
@@ -84,7 +84,7 @@ public class ModelConverterAction implements RootAction {
 
         String jsonAsString = req.getParameter("json");
 
-        if (jsonAsString != null && !jsonAsString.equals("")) {
+        if (!StringUtils.isEmpty(jsonAsString)) {
             try {
                 JSONObject json = JSONObject.fromObject(jsonAsString);
 
@@ -115,7 +115,7 @@ public class ModelConverterAction implements RootAction {
 
         String groovyAsString = req.getParameter("jenkinsfile");
 
-        if (groovyAsString != null && !groovyAsString.equals("")) {
+        if (!StringUtils.isEmpty(groovyAsString)) {
             try {
                 ModelASTPipelineDef pipelineDef = Converter.scriptToPipelineDef(groovyAsString);
                 if (pipelineDef != null) {
@@ -143,7 +143,7 @@ public class ModelConverterAction implements RootAction {
 
         String groovyAsString = req.getParameter("jenkinsfile");
 
-        if (groovyAsString != null && !groovyAsString.equals("")) {
+        if (!StringUtils.isEmpty(groovyAsString)) {
             try {
                 List<ModelASTStep> steps = Converter.scriptToPlainSteps(groovyAsString);
                 JSONArray array = new JSONArray();
@@ -170,7 +170,7 @@ public class ModelConverterAction implements RootAction {
         JSONObject result = new JSONObject();
 
         String jsonAsString = req.getParameter("json");
-        if (jsonAsString != null && !jsonAsString.equals("")) {
+        if (!StringUtils.isEmpty(jsonAsString)) {
             try {
                 JSON json = JSONSerializer.toJSON(jsonAsString);
 
@@ -228,7 +228,7 @@ public class ModelConverterAction implements RootAction {
 
         String groovyAsString = req.getParameter("jenkinsfile");
 
-        if (groovyAsString != null && !groovyAsString.equals("")) {
+        if (!StringUtils.isEmpty(groovyAsString)) {
             try {
                 ModelASTPipelineDef pipelineDef = Converter.scriptToPipelineDef(groovyAsString);
                 if (pipelineDef != null) {
@@ -255,7 +255,7 @@ public class ModelConverterAction implements RootAction {
         JSONObject result = new JSONObject();
 
         String jsonAsString = req.getParameter("json");
-        if (jsonAsString != null && !jsonAsString.equals("")) {
+        if (!StringUtils.isEmpty(jsonAsString)) {
             try {
 
                 JSONObject json = JSONObject.fromObject(jsonAsString);

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionTest.java
@@ -44,6 +44,45 @@ import static org.junit.Assert.assertTrue;
 public class ModelConverterActionTest extends AbstractModelDefTest {
 
     @Test
+    public void toJsonEmptyParam() throws Exception {
+        getExpectedErrorNoParam("jenkinsfile", "toJson");
+    }
+
+    @Test
+    public void validateJsonEmptyParam() throws Exception {
+        getExpectedErrorNoParam("json", "validateJson");
+    }
+
+    @Test
+    public void toJenkinsfileEmptyParam() throws Exception {
+        getExpectedErrorNoParam("json", "toJenkinsfile");
+    }
+
+    @Test
+    public void validateJenkinsfileEmptyParam() throws Exception {
+        getExpectedErrorNoParam("jenkinsfile", "validateJenkinsfile");
+    }
+
+    private void getExpectedErrorNoParam(String param, String endpoint) throws Exception {
+        JenkinsRule.WebClient wc = j.createWebClient();
+        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/" + endpoint), HttpMethod.POST);
+        String rawResult = wc.getPage(req).getWebResponse().getContentAsString();
+        assertNotNull(rawResult);
+
+        JSONObject result = JSONObject.fromObject(rawResult);
+        // TODO: Change this when we get proper JSON errors causing HTTP error codes
+        assertEquals("Full result doesn't include status - " + result.toString(2), "ok", result.getString("status"));
+        JSONObject resultData = result.getJSONObject("data");
+        assertNotNull(resultData);
+        assertEquals("Result wasn't a failure - " + result.toString(2), "failure", resultData.getString("result"));
+
+        String expectedError = "No content found for '" + param + "' parameter";
+        assertTrue("Errors array (" + resultData.getJSONArray("errors").toString(2) + ") didn't contain expected error '" + expectedError + "'",
+                foundExpectedError(expectedError, resultData.getJSONArray("errors")));
+
+    }
+
+    @Test
     public void testFailedValidateJsonInvalidBuildCondition() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
         WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);


### PR DESCRIPTION
The previous error message was...annoying. So now let's do a null/empty check before we try to do something with the erstwhile content.

cc @reviewbybees esp @rsandell