### PR TITLE
[JENKINS-40188] Test to verify that boolean params can be passed on.

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -181,6 +181,13 @@
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-build-step</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <version>2.6.0</version>
       <classifier>tests</classifier>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -372,4 +372,14 @@ public class BasicModelDefTest extends AbstractModelDefTest {
             }
         };
     }
+
+    @Issue("JENKINS-40188")
+    @Test
+    public void booleanParamBuildStep() throws Exception {
+        env(s).set();
+        expect("booleanParamBuildStep")
+                .logContains("[Pipeline] { (promote)", "Scheduling project")
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/booleanParamBuildStep.groovy
+++ b/pipeline-model-definition/src/test/resources/booleanParamBuildStep.groovy
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+
+    parameters {
+        booleanParam(defaultValue: false, description: 'Simulate the promotion', name: 'SIMUL')
+    }
+
+    stages {
+        stage('promote') {
+            when {
+                currentBuild.getNumber() % 2 == 1
+            }
+            steps {
+                build job: currentBuild.getProjectName(), parameters: [
+                    booleanParam(name: 'SIMUL', value: env.SIMUL)
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
[JENKINS-40188](https://issues.jenkins-ci.org/browse/JENKINS-40188)

Can't actually reproduce the issue with 'env.PARAM' or 'params.PARAM',
but can with '"${env.PARAM}"'. If there's a deeper problem here, it's
that we're not actually validating the parameters to the parameters of
steps themselves, but that's a different matter.

cc @reviewbybees esp @rsandell 