### PR TITLE
[FIXED JENKINS-40721] Don't require parens for no-arg method calls

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -41,6 +41,9 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.MethodsToList
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepsBlock
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Options
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Parameters
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Triggers
 import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter
 import org.jenkinsci.plugins.structs.SymbolLookup
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable
@@ -382,5 +385,21 @@ public class Utils {
         wrapper.setClosure(c)
 
         return wrapper
+    }
+
+    public static boolean isEligibleMethodSymbol(String symbol, Class c) {
+        switch (c) {
+            case Triggers.class:
+                return symbol in Triggers.allowedTriggerTypes.keySet()
+                break
+            case Parameters.class:
+                return symbol in Parameters.allowedParameterTypes.keySet()
+                break
+            case Options.class:
+                return symbol in Options.allowedOptionTypes.keySet()
+                break
+            default:
+                return false
+        }
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -307,6 +307,7 @@ class ModelValidatorImpl implements ModelValidator {
         if (Jenkins.getInstance() != null) {
             Descriptor desc = lookup.lookupFunction(meth.name)
             DescribableModel<? extends Describable> model
+
             if (desc != null) {
                 model = lookup.modelForDescribable(meth.name)
             }
@@ -352,7 +353,6 @@ class ModelValidatorImpl implements ModelValidator {
                                 valid = validateElement((ModelASTMethodCall) argVal)
                             } else {
                                 if (!validateParameterType((ModelASTValue) argVal, entry.erasedType)) {
-                                    errorCollector.error((ModelASTValue)argVal, Messages.ModelValidatorImpl_WrongParameterType(entry.name))
                                     valid = false
                                 }
                             }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/MethodsToListTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/MethodsToListTranslator.groovy
@@ -47,6 +47,14 @@ public class MethodsToListTranslator implements MethodMissingWrapper, Serializab
         this.clazz = c
     }
 
+    def propertyMissing(String p) {
+        if (Utils.isEligibleMethodSymbol(p, clazz)) {
+            return methodMissing(p, null)
+        } else {
+            return getProperty(p)
+        }
+    }
+
     def methodMissing(String s, args) {
         def argVal
         if (args instanceof List || args instanceof Object[]) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTranslator.groovy
@@ -48,6 +48,14 @@ public class OptionsTranslator implements MethodMissingWrapper, Serializable {
         this.script = script
     }
 
+    def propertyMissing(String p) {
+        if (Utils.isEligibleMethodSymbol(p, Options)) {
+            return methodMissing(p, null)
+        } else {
+            return getProperty(p)
+        }
+    }
+
     def methodMissing(String s, args) {
         def argVal
         if (args instanceof List || args instanceof Object[]) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -128,6 +128,15 @@ public class OptionsTest extends AbstractModelDefTest {
     }
 
     @Test
+    public void optionsBareMethodCall() throws Exception {
+        expect("optionsBareMethodCall")
+                .logContains("[Pipeline] { (foo)",
+                        "[Pipeline] catchError",
+                        "hello")
+                .logNotContains("[Pipeline] { (Post Build Actions)")
+                .go();
+    }
+    @Test
     public void multipleWrappers() throws Exception {
         expect("multipleWrappers")
                 .logContains("[Pipeline] { (foo)",

--- a/pipeline-model-definition/src/test/resources/optionsBareMethodCall.groovy
+++ b/pipeline-model-definition/src/test/resources/optionsBareMethodCall.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    options {
+        catchError
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
[JENKINS-40721](https://issues.jenkins-ci.org/browse/JENKINS-40721)

(note that this is on top of #72)

This is...weird. I'm a little shocked that this works, honestly. But!
You can now do something like:

```
options {
  timestamps
}
```

And it'll work. Note that this is only applicable in the `options`,
`triggers`, and `parameters` sections - no-arg steps still need their
parentheses even with this change.

I'm still not 100% sure this is a good idea, but...dang. It works.

cc @reviewbybees esp @rsandell @michaelneale @i386 @HRMPW 