### PR TITLE
[JENKINS-40790] Add metadata for whether agents support tools

### DIFF
--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentDescriptor.java
@@ -42,6 +42,15 @@ import java.util.Map;
 public abstract class DeclarativeAgentDescriptor<A extends DeclarativeAgent<A>> extends WithScriptDescriptor<A> {
 
     /**
+     * Whether this agent type supports tools within it.
+     *
+     * @return True if the agent type does support tools, false otherwise (and by default).
+     */
+    public boolean supportsTools() {
+        return false;
+    }
+
+    /**
      * Get all {@link DeclarativeAgentDescriptor}s.
      *
      * @return a list of all {@link DeclarativeAgentDescriptor}s registered.`

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Any.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Any.java
@@ -39,5 +39,9 @@ public class Any extends DeclarativeAgent<Any> {
 
     @Extension(ordinal = -900) @Symbol("any")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor<Any> {
+        @Override
+        public boolean supportsTools() {
+            return true;
+        }
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
@@ -47,5 +47,9 @@ public class Label extends DeclarativeAgent<Label> {
 
     @Extension(ordinal = -800) @Symbol("label")
     public static class DescriptorImpl extends DeclarativeAgentDescriptor<Label> {
+        @Override
+        public boolean supportsTools() {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
[JENKINS-40790](https://issues.jenkins-ci.org/browse/JENKINS-40790)

https://github.com/jenkinsci/pipeline-model-definition-plugin/commit/762ee84a08b7881906ce5b7a6e04d27229d499d7 is the only relevant commit - the rest is on top of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/78, since that PR/branch messes around a lot with `DeclarativeAgentDescriptor` and I decided to save the mess by just doing this on top.

cc @reviewbybees esp @rsandell and @kzantow