### PR TITLE
[FIXED JENKINS-40793] Add location information to validation errors

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
@@ -122,8 +122,10 @@ public abstract class ModelASTValue extends ModelASTElement implements ModelASTM
                     } else {
                         return "'''" + (str.replace("'''", "\\'\\'\\'")) + "'''";
                     }
-                } else {
+                } else if (getValue() != null) {
                     return getValue().toString();
+                } else {
+                    return "";
                 }
             }
         };

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -383,7 +383,4 @@ public class Utils {
 
         return wrapper
     }
-
-
-
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
@@ -30,6 +30,9 @@ import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule
 import com.github.fge.jsonschema.exceptions.ProcessingException
 import com.github.fge.jsonschema.main.JsonSchema
 import com.github.fge.jsonschema.report.ProcessingReport
+import com.github.fge.jsonschema.tree.JsonTree
+import com.github.fge.jsonschema.tree.SimpleJsonTree
+import com.github.fge.jsonschema.util.JsonLoader
 import net.sf.json.JSONObject
 import org.apache.commons.lang.reflect.FieldUtils
 import org.codehaus.groovy.control.CompilationFailedException
@@ -67,8 +70,10 @@ public class Converter {
      * @throws ProcessingException If an error of high enough severity is detected in processing.
      */
     public static ProcessingReport validateJSONAgainstSchema(JSONObject origJson) throws ProcessingException {
-        JsonNode jsonNode = jacksonJSONFromJSONObject(origJson);
+        return validateJSONAgainstSchema(jacksonJSONFromJSONObject(origJson))
+    }
 
+    public static ProcessingReport validateJSONAgainstSchema(JsonNode jsonNode) throws ProcessingException {
         JsonSchema schema = ASTSchema.getJSONSchema();
 
         return schema.validate(jsonNode)
@@ -85,6 +90,10 @@ public class Converter {
         mapper.registerModule(new JsonOrgModule());
 
         return mapper.valueToTree(input);
+    }
+
+    public static JsonTree jsonTreeFromJSONObject(JSONObject input) {
+        return new SimpleJsonTree(jacksonJSONFromJSONObject(input))
     }
 
     /**

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorCollector.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorCollector.groovy
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.validator
 
+import net.sf.json.JSONArray
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTElement;
 
 /**
@@ -13,4 +14,6 @@ public abstract class ErrorCollector {
     public abstract int getErrorCount()
 
     public abstract List<String> errorsAsStrings()
+
+    public abstract JSONArray asJson()
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONErrorCollector.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONErrorCollector.groovy
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.validator
 
 import com.github.fge.jsonschema.jsonpointer.JsonPointer
 import com.github.fge.jsonschema.tree.JsonTree
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import net.sf.json.JSONArray
 import net.sf.json.JSONObject
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTElement
@@ -34,6 +35,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTElement
  *
  * @author Andrew Bayer
  */
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class JSONErrorCollector extends ErrorCollector {
     List<JSONErrorPair> errors
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONErrorCollector.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONErrorCollector.groovy
@@ -23,6 +23,10 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.validator
 
+import com.github.fge.jsonschema.jsonpointer.JsonPointer
+import com.github.fge.jsonschema.tree.JsonTree
+import net.sf.json.JSONArray
+import net.sf.json.JSONObject
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTElement
 
 /**
@@ -31,7 +35,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTElement
  * @author Andrew Bayer
  */
 public class JSONErrorCollector extends ErrorCollector {
-    List<String> errors = []
+    List<JSONErrorPair> errors
 
     public JSONErrorCollector() {
         errors = []
@@ -39,7 +43,11 @@ public class JSONErrorCollector extends ErrorCollector {
 
     @Override
     public void error(ModelASTElement src, String message) {
-        errors << message
+        JsonTree json = null
+        if (src.sourceLocation instanceof JsonTree) {
+            json = (JsonTree)src.sourceLocation
+        }
+        this.errors.add(new JSONErrorPair(json?.getPointer(), message))
     }
 
     @Override
@@ -49,6 +57,38 @@ public class JSONErrorCollector extends ErrorCollector {
 
     @Override
     public List<String> errorsAsStrings() {
-        return errors
+        return errors.collect { it.message }
+    }
+
+    @Override
+    public JSONArray asJson() {
+        JSONArray a = new JSONArray()
+        errors.each { a.add(it.jsonError) }
+
+        return a
+    }
+
+    public static final class JSONErrorPair {
+        final String message
+        final JsonPointer location
+
+        JSONErrorPair(JsonPointer location, String message) {
+            this.location = location
+            this.message = message
+        }
+
+        public JSONObject getJsonError() {
+            JSONObject o = new JSONObject()
+            JSONArray a = new JSONArray()
+
+            location.iterator().each { t ->
+                a.add(t.toString())
+            }
+
+            o.accumulate("location", a)
+            o.accumulate("error", message)
+
+            return o
+        }
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -517,6 +517,11 @@ class ModelValidatorImpl implements ModelValidator {
             errorCollector.error(stage, Messages.ModelValidatorImpl_NothingForStage(stage.name))
             valid = false
         }
+        def branchNames = stage.branches.collect { it.name }
+        branchNames.findAll { branchNames.count(it) > 1 }.unique().each { bn ->
+            errorCollector.error(stage, Messages.ModelValidatorImpl_DuplicateParallelName(bn))
+            valid = false
+        }
 
         return valid
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/SourceUnitErrorCollector.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/SourceUnitErrorCollector.groovy
@@ -24,6 +24,8 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.validator
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import net.sf.json.JSONArray
+import net.sf.json.JSONObject
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.control.messages.Message
@@ -42,6 +44,19 @@ public class SourceUnitErrorCollector extends ErrorCollector {
 
     public SourceUnitErrorCollector(SourceUnit u) {
         this.sourceUnit = u
+    }
+
+    @Override
+    public JSONArray asJson() {
+        JSONArray a = new JSONArray()
+
+        errorsAsStrings().each {
+            JSONObject o = new JSONObject()
+            o.accumulate("error", it)
+            a.add(o)
+        }
+
+        return a
     }
 
     @Override

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
@@ -26,24 +26,11 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.Extension;
 import hudson.cli.CLICommand;
-import hudson.cli.util.ScriptLoader;
 import jenkins.model.Jenkins;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.codehaus.groovy.control.Janitor;
-import org.codehaus.groovy.control.MultipleCompilationErrorsException;
-import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
 import org.jenkinsci.plugins.pipeline.modeldefinition.endpoints.ModelConverterAction;
 import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter;
-import org.kohsuke.args4j.Argument;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -107,6 +107,7 @@ ModelValidatorImpl.RequiredSection=Missing required section "{0}"
 ModelValidatorImpl.NoStageName=Stage does not have a name
 ModelValidatorImpl.NothingForStage=Nothing to execute within stage "{0}"
 ModelValidatorImpl.NoStages=No stages specified
+ModelValidatorImpl.DuplicateParallelName=Duplicate parallel branch name: "{0}"
 ModelValidatorImpl.DuplicateStageName=Duplicate stage name: "{0}"
 ModelValidatorImpl.InvalidAgent=Invalid argument for agent - "{0}" - must be map of config options or bare {1}.
 ModelValidatorImpl.NoAgentType=No agent type specified. Must contain one of {0}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -80,10 +80,10 @@ JSONParser.InvalidArgumentSyntax=Invalid argument syntax
 JSONParser.MethArgsMustBeObj=Individual method arguments must be a JSON object
 JSONParser.MethArgsMissing=Method arguments missing or not an array
 JSONParser.MethCallMustBeObj=Method call definition must be a JSON object
-JSONParser.MissingRequiredProperties=At {0}: Missing one or more required properties: {1}
-JSONParser.ObjNotJSON=Object {0} is neither a JSONArray nor a JSONObject
-JSONParser.ProcessingError=At {0}: {1}
-JSONParser.TooFewItems=At {0}: Array has {1} entries, requires minimum of {2}
+JSONParser.MissingRequiredProperties=Missing one or more required properties: {0}
+JSONParser.ObjNotJSON=Object {0} is neither a JSON array nor a JSON object
+JSONParser.TooFewItems=Array has {0} entries, requires minimum of {1}
+JSONParser.MissingPipelineRoot=No pipeline block or invalid pipeline block content
 
 ModelValidatorImpl.EmptySection={0} can not be empty
 ModelValidatorImpl.DuplicateBuildCondition=Duplicate build condition name: "{0}"

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ErrorsEndpointOpsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ErrorsEndpointOpsTest.java
@@ -77,7 +77,7 @@ public class ErrorsEndpointOpsTest extends AbstractModelDefTest {
         assertEquals("Result wasn't a failure - " + result.toString(2), "failure", resultData.getString("result"));
 
         assertTrue("Errors array (" + resultData.getJSONArray("errors").toString(2) + ") didn't contain expected error '" + expectedError + "'",
-                foundExpectedError(resultData.getJSONArray("errors")));
+                foundExpectedErrorInJSON(resultData.getJSONArray("errors"), expectedError));
     }
 
     @Test
@@ -148,17 +148,5 @@ public class ErrorsEndpointOpsTest extends AbstractModelDefTest {
         JSONObject resultData = result.getJSONObject("data");
         assertNotNull(resultData);
         assertEquals("Result wasn't a failure - " + result.toString(2), "failure", resultData.getString("result"));
-    }
-
-    private boolean foundExpectedError(JSONArray errors) {
-        for (Object e : JSONArray.toCollection(errors, String.class)) {
-            if (e instanceof String) {
-                if (e.equals(expectedError)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionTest.java
@@ -79,7 +79,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
 
         String expectedError = "No content found for '" + param + "' parameter";
         assertTrue("Errors array (" + resultData.getJSONArray("errors").toString(2) + ") didn't contain expected error '" + expectedError + "'",
-                foundExpectedError(expectedError, resultData.getJSONArray("errors")));
+                foundExpectedErrorInJSON(resultData.getJSONArray("errors"), expectedError));
 
     }
 
@@ -103,7 +103,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
 
         String expectedError = "Jenkinsfile content '" + groovyAsString + "' did not contain the 'pipeline' step";
         assertTrue("Errors array (" + resultData.getJSONArray("errors").toString(2) + ") didn't contain expected error '" + expectedError + "'",
-                foundExpectedError(expectedError, resultData.getJSONArray("errors")));
+                foundExpectedErrorInJSON(resultData.getJSONArray("errors"), expectedError));
 
     }
 
@@ -130,7 +130,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
 
         String expectedError = Messages.ModelValidatorImpl_InvalidBuildCondition("banana", BuildCondition.getOrderedConditionNames());
         assertTrue("Errors array (" + resultData.getJSONArray("errors").toString(2) + ") didn't contain expected error '" + expectedError + "'",
-                foundExpectedError(expectedError, resultData.getJSONArray("errors")));
+                foundExpectedErrorInJSON(resultData.getJSONArray("errors"), expectedError));
     }
 
     @Test
@@ -183,7 +183,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
         String expectedError = Messages.ModelValidatorImpl_InvalidSectionType("tool", "banana", Tools.getAllowedToolTypes().keySet());
 
         assertTrue("Errors array (" + resultData.getJSONArray("errors").toString(2) + ") didn't contain expected error '" + expectedError + "'",
-                foundExpectedError(expectedError, resultData.getJSONArray("errors")));
+                foundExpectedErrorInJSON(resultData.getJSONArray("errors"), expectedError));
     }
 
     @Test
@@ -210,18 +210,6 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
             assertNotNull(resultData);
             assertEquals("Result wasn't a failure - " + result.toString(2), "failure", resultData.getString("result"));
         }
-    }
-
-    private boolean foundExpectedError(String expectedError, JSONArray errors) {
-        for (Object e : JSONArray.toCollection(errors, String.class)) {
-            if (e instanceof String) {
-                if (e.equals(expectedError)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/SuccessfulEndpointOpsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/SuccessfulEndpointOpsTest.java
@@ -152,7 +152,7 @@ public class SuccessfulEndpointOpsTest extends AbstractModelDefTest {
 
         assertNotNull(resultData.getString("json"));
         JSONObject rawJson = JSONObject.fromObject(resultData.getString("json"));
-        JSONParser p = new JSONParser(rawJson);
+        JSONParser p = new JSONParser(Converter.jsonTreeFromJSONObject(rawJson));
 
         ModelASTPipelineDef pipelineDef = p.parse();
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ConvertRoundTripTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ConvertRoundTripTest.java
@@ -65,7 +65,7 @@ public class ConvertRoundTripTest extends BaseParserLoaderTest {
         JSONObject origJson = origRoot.toJSON();
         assertNotNull(origJson);
 
-        JSONParser jp = new JSONParser(origJson);
+        JSONParser jp = new JSONParser(Converter.jsonTreeFromJSONObject(origJson));
         ModelASTPipelineDef newRoot = jp.parse();
 
         assertEquals(getJSONErrorReport(jp, configName), 0, jp.getErrorCollector().getErrorCount());
@@ -94,7 +94,7 @@ public class ConvertRoundTripTest extends BaseParserLoaderTest {
         JSONObject origJson = JSONObject.fromObject(fileContentsFromResources("json/" + configName + ".json"));
         assertNotNull("Couldn't parse JSON for " + configName, origJson);
 
-        JSONParser jp = new JSONParser(origJson);
+        JSONParser jp = new JSONParser(Converter.jsonTreeFromJSONObject(origJson));
         ModelASTPipelineDef pipelineDef = jp.parse();
 
         assertEquals(getJSONErrorReport(jp, configName), 0, jp.getErrorCollector().getErrorCount());
@@ -108,7 +108,7 @@ public class ConvertRoundTripTest extends BaseParserLoaderTest {
         JSONObject origJson = JSONObject.fromObject(fileContentsFromResources("json/" + configName + ".json"));
         assertNotNull("Couldn't parse JSON for " + configName, origJson);
 
-        JSONParser jp = new JSONParser(origJson);
+        JSONParser jp = new JSONParser(Converter.jsonTreeFromJSONObject(origJson));
         ModelASTPipelineDef origRoot = jp.parse();
 
         assertEquals(getJSONErrorReport(jp, configName), 0, jp.getErrorCollector().getErrorCount());

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ExecuteConvertedTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ExecuteConvertedTest.java
@@ -91,7 +91,7 @@ public class ExecuteConvertedTest extends AbstractModelDefTest {
         JSONObject json = JSONObject.fromObject(fileContentsFromResources("json/" + configName + ".json"));
         assertNotNull("Couldn't parse JSON for " + configName, json);
 
-        JSONParser jp = new JSONParser(json);
+        JSONParser jp = new JSONParser(Converter.jsonTreeFromJSONObject(json));
         ModelASTPipelineDef origRoot = jp.parse();
 
         assertEquals(getJSONErrorReport(jp, configName), 0, jp.getErrorCollector().getErrorCount());

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorsJSONParserTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorsJSONParserTest.java
@@ -23,7 +23,9 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.validator;
 
-import net.sf.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jsonschema.tree.SimpleJsonTree;
+import com.github.fge.jsonschema.util.JsonLoader;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.BaseParserLoaderTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.parser.JSONParser;
@@ -53,19 +55,19 @@ public class ErrorsJSONParserTest extends BaseParserLoaderTest {
     @Test
     public void parseAndValidateJSONWithError() throws Exception {
         try {
-            JSONObject json = JSONObject.fromObject(fileContentsFromResources("json/errors/" + configName + ".json"));
+            JsonNode json = JsonLoader.fromString(fileContentsFromResources("json/errors/" + configName + ".json"));
 
             assertNotNull("Couldn't parse JSON for " + configName, json);
-            assertFalse("Couldn't parse JSON for " + configName, json.isEmpty());
-            assertFalse("Couldn't parse JSON for " + configName, json.isNullObject());
+            assertFalse("Couldn't parse JSON for " + configName, json.size() == 0);
+            assertFalse("Couldn't parse JSON for " + configName, json.isNull());
 
-            JSONParser jp = new JSONParser(json);
+            JSONParser jp = new JSONParser(new SimpleJsonTree(json));
             jp.parse();
 
             assertTrue(jp.getErrorCollector().getErrorCount() > 0);
 
             assertTrue("Didn't find expected error in " + getJSONErrorReport(jp, configName),
-                    jp.getErrorCollector().errorsAsStrings().contains(expectedError));
+                    foundExpectedErrorInJSON(jp.getErrorCollector().asJson(), expectedError));
         } catch (Exception e) {
             // If there's a straight-up parsing error, make sure it's what we expect.
             assertTrue(e.getMessage(), e.getMessage().contains(expectedError));

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/SuccessfulJSONParserTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/SuccessfulJSONParserTest.java
@@ -27,6 +27,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.BaseParserLoaderTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
+import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter;
 import org.jenkinsci.plugins.pipeline.modeldefinition.parser.JSONParser;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,7 +62,7 @@ public class SuccessfulJSONParserTest extends BaseParserLoaderTest {
         JSONObject json = JSONObject.fromObject(fileContentsFromResources("json/" + configName + ".json"));
         assertNotNull("Couldn't parse JSON for " + configName, json);
 
-        JSONParser jp = new JSONParser(json);
+        JSONParser jp = new JSONParser(Converter.jsonTreeFromJSONObject(json));
         ModelASTPipelineDef pipelineDef = jp.parse();
 
         assertEquals(getJSONErrorReport(jp, configName), 0, jp.getErrorCollector().getErrorCount());

--- a/pipeline-model-definition/src/test/resources/json/errors/parallelPipelineDuplicateNames.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/parallelPipelineDuplicateNames.json
@@ -1,0 +1,28 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches":     [
+            {
+        "name": "first",
+        "steps": [        {
+          "name": "echo",
+          "arguments":           {
+            "isLiteral": true,
+            "value": "First branch"
+          }
+        }]
+      },
+            {
+        "name": "first",
+        "steps": [        {
+          "name": "echo",
+          "arguments":           {
+            "isLiteral": true,
+            "value": "Second branch"
+          }
+        }]
+      }
+    ]
+  }],
+  "agent": {"type": "none"}
+}}


### PR DESCRIPTION
[JENKINS-40793](https://issues.jenkins-ci.org/browse/JENKINS-40793)

Specifically to the JSON output. This also moves us to not doing
conversion between JSONObject and JsonNode, which is nice. There's
probably some cleanup/optimization that could still be done in
JSONParser.

cc @reviewbybees esp @kzantow @rsandell 