### PR TITLE
[FIXED JENKINS-40984] Always evaluate/run all post conditions

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -117,16 +117,6 @@ public class Root implements NestedModel, Serializable {
         return m
     }
 
-    /**
-     * Returns a list of post-build closures whose conditions have been satisfied and should be run.
-     *
-     * @param runWrapperObj The {@link RunWrapper} for the build.
-     * @return a list of closures whose conditions have been satisfied.
-     */
-    List<Closure> satisfiedPostBuilds(Object runWrapperObj) {
-        return satisfiedConditionsForField(post, runWrapperObj)
-    }
-
     @Override
     public void modelFromMap(Map<String,Object> m) {
         m.each { k, v ->
@@ -135,17 +125,17 @@ public class Root implements NestedModel, Serializable {
     }
 
     /**
-     * Gets the list of satisfied build condition closures for the given responder.
+     * Returns true if at least one build condition for the given responder is satisfied currently.
      *
      * @param r an {@link AbstractBuildConditionResponder}, such as {@link PostStage} or {@link PostBuild}.
      * @param runWrapperObj The {@link RunWrapper} for the build.
-     * @return A list of closures from the responder which have had their conditions satisfied.
+     * @return True if at least one condition is satisfied, false otherwise.
      */
-    /*package*/ List<Closure> satisfiedConditionsForField(AbstractBuildConditionResponder r, Object runWrapperObj) {
+    /*package*/ boolean hasSatisfiedConditions(AbstractBuildConditionResponder r, Object runWrapperObj) {
         if (r != null) {
             return r.satisfiedConditions(runWrapperObj)
         } else {
-            return []
+            return false
         }
 
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -119,15 +119,4 @@ public class Stage implements NestedModel, Serializable {
             this."${k}"(v)
         }
     }
-
-    /**
-     * Returns a list of notification closures whose conditions have been satisfied and should be run.
-     *
-     * @param runWrapperObj The {@link org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper} for the build.
-     * @return a list of closures whose conditions have been satisfied.
-     */
-    List<Closure> satisfiedPostStageConditions(Root root, Object runWrapperObj) {
-        return root.satisfiedConditionsForField(post, runWrapperObj)
-    }
-
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
@@ -28,6 +28,7 @@ import hudson.ExtensionList;
 import hudson.ExtensionPoint;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -45,6 +46,13 @@ import java.util.Set;
 public abstract class BuildCondition implements Serializable, ExtensionPoint {
 
     public abstract boolean meetsCondition(WorkflowRun r);
+
+    public boolean meetsCondition(Object runWrapperObj) {
+        RunWrapper runWrapper = (RunWrapper)runWrapperObj;
+        WorkflowRun run = (WorkflowRun)runWrapper.getRawBuild();
+
+        return meetsCondition(run);
+    }
 
     public abstract String getDescription();
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -150,7 +150,7 @@ public class ModelInterpreter implements Serializable {
      *
      * @param c The closure to execute
      */
-    def setUpDelegate(Closure c) {
+    def delegateAndExecute(Closure c) {
         c.delegate = script
         c.resolveStrategy = Closure.DELEGATE_FIRST
         c.call()
@@ -369,7 +369,7 @@ public class ModelInterpreter implements Serializable {
         Throwable stageError = null
         try {
             catchRequiredContextForNode(thisStage.agent ?: root.agent) {
-                setUpDelegate(thisStage.steps.closure)
+                delegateAndExecute(thisStage.steps.closure)
             }
         } catch (Exception e) {
             script.getProperty("currentBuild").result = Result.FAILURE
@@ -445,7 +445,7 @@ public class ModelInterpreter implements Serializable {
                 Closure c = responder.closureForSatisfiedCondition(conditionName, script.getProperty("currentBuild"))
                 if (c != null) {
                     catchRequiredContextForNode(agentContext) {
-                        setUpDelegate(c)
+                        delegateAndExecute(c)
                     }
                 }
             } catch (Exception e) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -48,6 +48,18 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
     }
 
     @Test
+    public void postChecksAllConditions() throws Exception {
+        expect(Result.FAILURE, "postChecksAllConditions")
+                .logContains("[Pipeline] { (foo)",
+                        "hello",
+                        "[Pipeline] { (" + SyntheticStageNames.postBuild() + ")",
+                        "I AM FAILING NOW",
+                        "I FAILED")
+                .logNotContains("MOST DEFINITELY FINISHED")
+                .go();
+    }
+
+    @Test
     public void postOnChanged() throws Exception {
         WorkflowRun b = getAndStartNonRepoBuild("postOnChangeFailed");
         j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b));

--- a/pipeline-model-definition/src/test/resources/postChecksAllConditions.groovy
+++ b/pipeline-model-definition/src/test/resources/postChecksAllConditions.groovy
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+    post {
+        always {
+            error "I AM FAILING NOW"
+        }
+        success {
+            echo "MOST DEFINITELY FINISHED"
+        }
+        failure {
+            echo "I FAILED"
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
[JENKINS-40984](https://issues.jenkins-ci.org/browse/JENKINS-40984)

Even if there's an error in an earlier condition execution, continue
to the subsequent ones. Additionally, switch to doing a one-off check
at the beginning of the post section to see if *any* conditions are
satisfied at that time, and then when actually iterating through the
conditions, check for satisfaction at *that* time. That's so that, for
example, if the build is successful when it gets to evaluating post
conditions and then there's a failure in the execution of `always`,
the `success` block won't be executed, and the `failure` block will,
since the build status has changed.

cc @reviewbybees esp @rsandell @batmat 