### PR TITLE
[FIXED JENKINS-41090, JENKINS-41089] Groovy serialization cleanup

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
@@ -53,10 +53,10 @@ public final class ModelASTAgent extends ModelASTElement {
             argStr.append(agentType.toGroovy());
             argStr.append(" ");
             argStr.append(variables.toGroovy());
-            argStr.append("\n}\n");
+            argStr.append("\n}");
         }
 
-        return "agent " + argStr.toString();
+        return "agent " + argStr.toString() + "\n";
     }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
@@ -53,10 +53,10 @@ public final class ModelASTAgent extends ModelASTElement {
             argStr.append(agentType.toGroovy());
             argStr.append(" ");
             argStr.append(variables.toGroovy());
-            argStr.append("}");
+            argStr.append("\n}\n");
         }
 
-        return "agent " + argStr.toString() + "\n";
+        return "agent " + argStr.toString();
     }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
@@ -85,28 +85,28 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         StringBuilder result = new StringBuilder();
         result.append("pipeline {\n");
         if (agent != null) {
-            result.append(agent.toGroovy()).append('\n');
+            result.append(agent.toGroovy());
         }
         if (stages != null) {
-            result.append(stages.toGroovy()).append('\n');
+            result.append(stages.toGroovy());
         }
         if (tools != null) {
-            result.append(tools.toGroovy()).append('\n');
+            result.append(tools.toGroovy());
         }
         if (environment != null) {
-            result.append(environment.toGroovy()).append('\n');
+            result.append(environment.toGroovy());
         }
         if (postBuild != null) {
-            result.append(postBuild.toGroovy()).append('\n');
+            result.append(postBuild.toGroovy());
         }
         if (options != null && !options.getOptions().isEmpty()) {
-            result.append(options.toGroovy()).append('\n');
+            result.append(options.toGroovy());
         }
         if (parameters != null && !parameters.getParameters().isEmpty()) {
-            result.append(parameters.toGroovy()).append('\n');
+            result.append(parameters.toGroovy());
         }
         if (triggers != null && !triggers.getTriggers().isEmpty()) {
-            result.append(triggers.toGroovy()).append('\n');
+            result.append(triggers.toGroovy());
         }
 
         result.append("}\n");

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStages.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStages.java
@@ -38,7 +38,7 @@ public final class ModelASTStages extends ModelASTElement {
     public String toGroovy() {
         StringBuilder result = new StringBuilder("stages {\n");
         for (ModelASTStage stage: stages) {
-            result.append(stage.toGroovy()).append("\n");
+            result.append(stage.toGroovy());
         }
         result.append("}\n");
         return result.toString();

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
@@ -100,13 +100,16 @@ public class ModelASTStep extends ModelASTElement {
     private String withOrWithoutParens(ModelASTArgumentList argList) {
         if (argList == null) {
             return name + "()";
-        } else if (!(this instanceof ModelASTTreeStep) &&
-                argList instanceof ModelASTSingleArgument &&
-                // Special-casing for list/map args since they still need parentheses.
-                !argList.toGroovy().startsWith("[")) {
-            return name + " " + argList.toGroovy();
         } else {
-            return name + "(" + argList.toGroovy() + ")";
+            String argGroovy = argList.toGroovy();
+            if (!(this instanceof ModelASTTreeStep) &&
+                    argList instanceof ModelASTSingleArgument &&
+                    // Special-casing for list/map args since they still need parentheses.
+                    !argGroovy.startsWith("[")) {
+                return name + " " + argGroovy;
+            } else {
+                return name + "(" + argGroovy + ")";
+            }
         }
     }
 

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
@@ -94,7 +94,17 @@ public class ModelASTStep extends ModelASTElement {
             }
         }
 
-        return name + "(" + (argList != null ? argList.toGroovy() : "") + ")";
+        return withOrWithoutParens(argList);
+    }
+
+    private String withOrWithoutParens(ModelASTArgumentList argList) {
+        if (argList == null) {
+            return name + "()";
+        } else if (!(this instanceof ModelASTTreeStep) && argList instanceof ModelASTSingleArgument) {
+            return name + argList.toGroovy();
+        } else {
+            return name + "(" + argList.toGroovy() + ")";
+        }
     }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
@@ -100,8 +100,11 @@ public class ModelASTStep extends ModelASTElement {
     private String withOrWithoutParens(ModelASTArgumentList argList) {
         if (argList == null) {
             return name + "()";
-        } else if (!(this instanceof ModelASTTreeStep) && argList instanceof ModelASTSingleArgument) {
-            return name + argList.toGroovy();
+        } else if (!(this instanceof ModelASTTreeStep) &&
+                argList instanceof ModelASTSingleArgument &&
+                // Special-casing for list/map args since they still need parentheses.
+                !argList.toGroovy().startsWith("[")) {
+            return name + " " + argList.toGroovy();
         } else {
             return name + "(" + argList.toGroovy() + ")";
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionStepsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionStepsTest.java
@@ -61,7 +61,7 @@ public class ModelConverterActionStepsTest extends AbstractModelDefTest {
         assertThat(result, hasKey("data"));
         JSONObject data = result.getJSONObject("data");
         assertThat(data, hasEntry("result", "success"));
-        assertThat(data, hasEntry("jenkinsfile", "echo('hello')"));
+        assertThat(data, hasEntry("jenkinsfile", "echo 'hello'"));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class ModelConverterActionStepsTest extends AbstractModelDefTest {
         assertThat(result, hasKey("data"));
         JSONObject data = result.getJSONObject("data");
         assertThat(data, hasEntry("result", "success"));
-        assertThat(data, hasEntry("jenkinsfile", "echo('Hello')\necho('World')"));
+        assertThat(data, hasEntry("jenkinsfile", "echo 'Hello'\necho 'World'"));
     }
 
     @Test


### PR DESCRIPTION
[JENKINS-41089](https://issues.jenkins-ci.org/browse/JENKINS-41089)
[JENKINS-41090](https://issues.jenkins-ci.org/browse/JENKINS-41090)

Get rid of superfluous newlines, make sure we have a newline after
'label "foo"', don't serialize unneeded parentheses for single unnamed
arguments for steps/functions.

cc @reviewbybees esp @rsandell @i386