### PR TITLE
Correct the synthetic "Post" stage label

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageNames.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageNames.groovy
@@ -48,6 +48,6 @@ public class SyntheticStageNames {
     }
 
     public static String postBuild() {
-        return "Declarative: Post Build Actions"
+        return "Declarative: Post Actions"
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -131,7 +131,7 @@ public class OptionsTest extends AbstractModelDefTest {
                 .logContains("[Pipeline] { (foo)",
                         "[Pipeline] timeout",
                         "hello")
-                .logNotContains("[Pipeline] { (Post Build Actions)")
+                .logNotContains("[Pipeline] { (Post Actions)")
                 .go();
     }
 
@@ -142,7 +142,7 @@ public class OptionsTest extends AbstractModelDefTest {
                         "[Pipeline] timeout",
                         "[Pipeline] retry",
                         "hello")
-                .logNotContains("[Pipeline] { (Post Build Actions)")
+                .logNotContains("[Pipeline] { (Post Actions)")
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
@@ -40,7 +40,7 @@ public class TriggersTest extends AbstractModelDefTest {
     public void simpleTriggers() throws Exception {
         WorkflowRun b = expect("simpleTriggers")
                 .logContains("[Pipeline] { (foo)", "hello")
-                .logNotContains("[Pipeline] { (Post Build Actions)")
+                .logNotContains("[Pipeline] { (Post Actions)")
                 .go();
 
         WorkflowJob p = b.getParent();


### PR DESCRIPTION
Once upon a time the syntax was called "postBuild' but was renamed to "post"
and this label never got updated.