### PR TITLE
[FIXED JENKINS-41518] Validate env var names for validity

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -57,6 +57,7 @@ import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 import org.jenkinsci.plugins.workflow.support.steps.StageStep
 
 import javax.annotation.Nullable
+import javax.lang.model.SourceVersion
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.util.concurrent.TimeUnit
@@ -387,5 +388,14 @@ public class Utils {
         wrapper.setClosure(c)
 
         return wrapper
+    }
+
+    public static boolean validEnvIdentifier(String i) {
+        if (!SourceVersion.isIdentifier(i)) {
+            return false
+        } else if (!i.matches("[a-zA-Z_]+[a-zA-Z0-9_]*")) {
+            return false
+        }
+        return true
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -35,6 +35,7 @@ import jenkins.model.Jenkins
 import org.codehaus.groovy.runtime.ScriptBytecodeAdapter
 import org.jenkinsci.plugins.pipeline.modeldefinition.DescriptorLookupCache
 import org.jenkinsci.plugins.pipeline.modeldefinition.Messages
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
@@ -47,10 +48,8 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageCondi
 import org.jenkinsci.plugins.structs.SymbolLookup
 import org.jenkinsci.plugins.structs.describable.DescribableModel
 import org.jenkinsci.plugins.structs.describable.DescribableParameter
-import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 
 import javax.annotation.Nonnull
-import javax.lang.model.SourceVersion
 
 /**
  * Class for validating various AST elements. Contains the error collector as well as caches for steps, models, etc.
@@ -128,7 +127,7 @@ class ModelValidatorImpl implements ModelValidator {
             valid = false
         }
         env.variables.each { k, v ->
-            if (!SourceVersion.isIdentifier(k.key)) {
+            if (!Utils.validEnvIdentifier(k.key)) {
                 errorCollector.error(k, Messages.ModelValidatorImpl_InvalidIdentifierInEnv(k.key))
                 valid = false
             }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -50,6 +50,7 @@ import org.jenkinsci.plugins.structs.describable.DescribableParameter
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 
 import javax.annotation.Nonnull
+import javax.lang.model.SourceVersion
 
 /**
  * Class for validating various AST elements. Contains the error collector as well as caches for steps, models, etc.
@@ -125,6 +126,12 @@ class ModelValidatorImpl implements ModelValidator {
         if (env.variables.isEmpty()) {
             errorCollector.error(env, Messages.ModelValidatorImpl_NoEnvVars())
             valid = false
+        }
+        env.variables.each { k, v ->
+            if (!SourceVersion.isIdentifier(k.key)) {
+                errorCollector.error(k, Messages.ModelValidatorImpl_InvalidIdentifierInEnv(k.key))
+                valid = false
+            }
         }
 
         return valid

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -117,5 +117,5 @@ ModelValidatorImpl.MissingAgentParameter=Missing required parameter for agent ty
 ModelValidatorImpl.InvalidAgentParameter=Invalid config option "{0}" for agent type "{1}". Valid config options are {2}
 ModelValidatorImpl.UnknownWhenConditional=Unknown conditional {0}. Valid conditionals are: {1}
 ModelValidatorImpl.MultipleAgentParameters=Multiple parameters are required for agent type "{0}" - {1}. Please use a block instead.
-ModelValidatorImpl.InvalidIdentifierInEnv="{0}" is not a valid Java identifier and cannot be used for an environment variable.
+ModelValidatorImpl.InvalidIdentifierInEnv="{0}" is not a valid identifier and cannot be used for an environment variable.
 ModelInterpreter.NoNodeContext=Attempted to execute a step that requires a node context while 'agent none' was specified. Be sure to specify your own 'node { ... }' blocks when using 'agent none'.

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -117,5 +117,5 @@ ModelValidatorImpl.MissingAgentParameter=Missing required parameter for agent ty
 ModelValidatorImpl.InvalidAgentParameter=Invalid config option "{0}" for agent type "{1}". Valid config options are {2}
 ModelValidatorImpl.UnknownWhenConditional=Unknown conditional {0}. Valid conditionals are: {1}
 ModelValidatorImpl.MultipleAgentParameters=Multiple parameters are required for agent type "{0}" - {1}. Please use a block instead.
-
+ModelValidatorImpl.InvalidIdentifierInEnv="{0}" is not a valid Java identifier and cannot be used for an environment variable.
 ModelInterpreter.NoNodeContext=Attempted to execute a step that requires a node context while 'agent none' was specified. Be sure to specify your own 'node { ... }' blocks when using 'agent none'.

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorsJSONParserTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorsJSONParserTest.java
@@ -23,19 +23,11 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.validator;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jsonschema.tree.SimpleJsonTree;
-import com.github.fge.jsonschema.util.JsonLoader;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.BaseParserLoaderTest;
-import org.jenkinsci.plugins.pipeline.modeldefinition.parser.JSONParser;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 public class ErrorsJSONParserTest extends BaseParserLoaderTest {
@@ -54,23 +46,6 @@ public class ErrorsJSONParserTest extends BaseParserLoaderTest {
 
     @Test
     public void parseAndValidateJSONWithError() throws Exception {
-        try {
-            JsonNode json = JsonLoader.fromString(fileContentsFromResources("json/errors/" + configName + ".json"));
-
-            assertNotNull("Couldn't parse JSON for " + configName, json);
-            assertFalse("Couldn't parse JSON for " + configName, json.size() == 0);
-            assertFalse("Couldn't parse JSON for " + configName, json.isNull());
-
-            JSONParser jp = new JSONParser(new SimpleJsonTree(json));
-            jp.parse();
-
-            assertTrue(jp.getErrorCollector().getErrorCount() > 0);
-
-            assertTrue("Didn't find expected error in " + getJSONErrorReport(jp, configName),
-                    foundExpectedErrorInJSON(jp.getErrorCollector().asJson(), expectedError));
-        } catch (Exception e) {
-            // If there's a straight-up parsing error, make sure it's what we expect.
-            assertTrue(e.getMessage(), e.getMessage().contains(expectedError));
-        }
+        findErrorInJSON(expectedError, configName);
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
@@ -23,19 +23,14 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.validator;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jsonschema.tree.SimpleJsonTree;
-import com.github.fge.jsonschema.util.JsonLoader;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.BaseParserLoaderTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.Messages;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
-import org.jenkinsci.plugins.pipeline.modeldefinition.parser.JSONParser;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -76,25 +71,12 @@ public class JSONValidationTest extends BaseParserLoaderTest {
 
     @Test
     public void parallelPipelineDuplicateNames() throws Exception {
-        String expectedError = Messages.ModelValidatorImpl_DuplicateParallelName("first");
-        try {
-            JsonNode json = JsonLoader.fromString(fileContentsFromResources("json/errors/parallelPipelineDuplicateNames.json"));
+        findErrorInJSON(Messages.ModelValidatorImpl_DuplicateParallelName("first"), "parallelPipelineDuplicateNames");
+    }
 
-            assertNotNull("Couldn't parse JSON for parallelPipelineDuplicateNames", json);
-            assertFalse("Couldn't parse JSON for parallelPipelineDuplicateNames", json.size() == 0);
-            assertFalse("Couldn't parse JSON for parallelPipelineDuplicateNames", json.isNull());
-
-            JSONParser jp = new JSONParser(new SimpleJsonTree(json));
-            jp.parse();
-
-            assertTrue(jp.getErrorCollector().getErrorCount() > 0);
-
-            assertTrue("Didn't find expected error in " + getJSONErrorReport(jp, "parallelPipelineDuplicateNames"),
-                    foundExpectedErrorInJSON(jp.getErrorCollector().asJson(), expectedError));
-        } catch (Exception e) {
-            // If there's a straight-up parsing error, make sure it's what we expect.
-            assertTrue(e.getMessage(), e.getMessage().contains(expectedError));
-        }
+    @Test
+    public void invalidIdentifierInEnv() throws Exception {
+        findErrorInJSON(Messages.ModelValidatorImpl_InvalidIdentifierInEnv("F OO"), "invalidIdentifierInEnv");
     }
 
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
@@ -77,6 +77,7 @@ public class JSONValidationTest extends BaseParserLoaderTest {
     @Test
     public void invalidIdentifierInEnv() throws Exception {
         findErrorInJSON(Messages.ModelValidatorImpl_InvalidIdentifierInEnv("F OO"), "invalidIdentifierInEnv");
+        findErrorInJSON(Messages.ModelValidatorImpl_InvalidIdentifierInEnv("F$OO"), "invalidIdentifierInEnv");
     }
 
 }

--- a/pipeline-model-definition/src/test/resources/json/errors/invalidIdentifierInEnv.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/invalidIdentifierInEnv.json
@@ -1,0 +1,32 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "sh",
+        "arguments": [        {
+          "key": "script",
+          "value":           {
+            "isLiteral": true,
+            "value": "echo \"FOO is $FOO\""
+          }
+        }]
+      }]
+    }]
+  }],
+  "environment": [  {
+    "key": "F OO",
+    "value":     {
+      "isLiteral": true,
+      "value": "BAR"
+    }
+  }],
+  "agent":   {
+    "type": "label",
+    "argument":     {
+      "isLiteral": true,
+      "value": "some-label"
+    }
+  }
+}}

--- a/pipeline-model-definition/src/test/resources/json/errors/invalidIdentifierInEnv.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/invalidIdentifierInEnv.json
@@ -21,7 +21,14 @@
       "isLiteral": true,
       "value": "BAR"
     }
-  }],
+  },
+    {
+      "key": "F$OO",
+      "value":     {
+        "isLiteral": true,
+        "value": "BAR"
+      }
+    }],
   "agent":   {
     "type": "label",
     "argument":     {


### PR DESCRIPTION
[JENKINS-41518](https://issues.jenkins-ci.org/browse/JENKINS-41518)

Specifically for validity as Java identifiers - otherwise everything
'splodes. This was never a problem from the Jenkinsfile side, since
there'd be compilation errors before getting to validation if you used
an invalid identifier, but it *is* a problem coming from JSON.

cc @reviewbybees esp @rsandell @kzantow