### PR TITLE
[JENKINS-41645] Better validation for non-binary expressions in env

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -240,6 +240,9 @@ class ModelParser implements Parser {
                                 return
                             }
                         }
+                    } else {
+                        ModelASTKey badKey = new ModelASTKey(exp)
+                        errorCollector.error(badKey, Messages.ModelParser_InvalidEnvironmentIdentifier(getSourceText(exp)))
                     }
                 }
                 errorEncountered = true

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -228,21 +228,25 @@ class ModelParser implements Parser {
             eachStatement(m.body.code) { s ->
                 if (s instanceof ExpressionStatement) {
                     def exp = s.expression;
-                    if (exp instanceof BinaryExpression) {
-                        if (exp.operation.type == Types.EQUAL) {
-                            ModelASTKey key = parseKey(exp.leftExpression)
-                            // Necessary check due to keys with identical names being equal.
-                            if (r.variables.containsKey(key)) {
-                                errorCollector.error(key, Messages.ModelParser_DuplicateEnvVar(key.key))
-                                return
-                            } else {
-                                r.variables[parseKey(exp.leftExpression)] = parseArgument(exp.rightExpression)
-                                return
-                            }
+                    if (exp instanceof BinaryExpression && exp.operation.type == Types.EQUAL) {
+                        ModelASTKey key = parseKey(exp.leftExpression)
+                        // Necessary check due to keys with identical names being equal.
+                        if (r.variables.containsKey(key)) {
+                            errorCollector.error(key, Messages.ModelParser_DuplicateEnvVar(key.key))
+                            return
+                        } else {
+                            r.variables[parseKey(exp.leftExpression)] = parseArgument(exp.rightExpression)
+                            return
                         }
                     } else {
                         ModelASTKey badKey = new ModelASTKey(exp)
-                        errorCollector.error(badKey, Messages.ModelParser_InvalidEnvironmentIdentifier(getSourceText(exp)))
+                        String srcTxt = getSourceText((ASTNode)exp)
+                        if (srcTxt.contains("=")) {
+                            String keyTxt = srcTxt.split("=").first().trim()
+                            errorCollector.error(badKey, Messages.ModelValidatorImpl_InvalidIdentifierInEnv(keyTxt))
+                        } else {
+                            errorCollector.error(badKey, Messages.ModelParser_InvalidEnvironmentIdentifier(srcTxt))
+                        }
                     }
                 }
                 errorEncountered = true

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -53,6 +53,7 @@ ModelParser.ExpectedTool=Expected to find 'someTool "someVersion"'
 ModelParser.ExpectedTrigger=Expected a trigger
 ModelParser.InvalidAgent=Only "agent none", "agent any" or "agent '{'...}" are allowed.
 ModelParser.InvalidBuildCondition=The 'post' section can only contain build condition names with code blocks. Valid condition names are {0}
+ModelParser.InvalidEnvironmentIdentifier="{0}" is not a valid environment expression. Use "key = value" pairs with valid Java/shell keys.
 ModelParser.InvalidSectionDefinition=Not a valid section definition: "{0}". Some extra configuration is required.
 ModelParser.InvalidStageSectionDefinition=Not a valid stage section definition: "{0}". Some extra configuration is required.
 ModelParser.MapNotAllowed={0} cannot be defined as maps

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -119,6 +119,6 @@ ModelValidatorImpl.MissingAgentParameter=Missing required parameter for agent ty
 ModelValidatorImpl.InvalidAgentParameter=Invalid config option "{0}" for agent type "{1}". Valid config options are {2}
 ModelValidatorImpl.UnknownWhenConditional=Unknown conditional {0}. Valid conditionals are: {1}
 ModelValidatorImpl.MultipleAgentParameters=Multiple parameters are required for agent type "{0}" - {1}. Please use a block instead.
-ModelValidatorImpl.InvalidIdentifierInEnv="{0}" is not a valid identifier and cannot be used for an environment variable.
+ModelValidatorImpl.InvalidIdentifierInEnv="{0}" is not a valid identifier and cannot be used for an environment variable. Identifiers must start with a letter or underscore and can contain only letters, numbers or underscores.
 ModelValidatorImpl.DirSeparatorInDockerfileName=Dockerfile filename cannot contain directory separators.
 ModelInterpreter.NoNodeContext=Attempted to execute a step that requires a node context while 'agent none' was specified. Be sure to specify your own 'node { ... }' blocks when using 'agent none'.

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -46,7 +46,9 @@ public class EnvironmentTest extends AbstractModelDefTest {
     @Test
     public void simpleEnvironment() throws Exception {
         expect("simpleEnvironment")
-                .logContains("[Pipeline] { (foo)", "FOO is BAR")
+                .logContains("[Pipeline] { (foo)",
+                        "FOO is BAR",
+                        "_UNDERSCORE is VALID")
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -492,6 +492,14 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-41645")
+    @Test
+    public void invalidEnvironmentIdentifiers() throws Exception {
+        expectError("invalidEnvironmentIdentifiers")
+                .logContains(Messages.ModelParser_InvalidEnvironmentIdentifier("1FOO = \"BLARGH\""))
+                .go();
+    }
+
     @Issue("JENKINS-39799")
     @Test
     public void badPostContent() throws Exception {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -495,8 +495,25 @@ public class ValidatorTest extends AbstractModelDefTest {
     @Issue("JENKINS-41645")
     @Test
     public void invalidEnvironmentIdentifiers() throws Exception {
-        expectError("invalidEnvironmentIdentifiers")
-                .logContains(Messages.ModelParser_InvalidEnvironmentIdentifier("1FOO = \"BLARGH\""))
+        expectError("envIdentifiersCaughtInternally")
+                .runFromRepo(false)
+                .logContains(Messages.ModelValidatorImpl_InvalidIdentifierInEnv("1BAR"),
+                        Messages.ModelValidatorImpl_InvalidIdentifierInEnv("$DOLLAR"))
+                .go();
+
+        expectError("envIdentifierString")
+                .runFromRepo(false)
+                .logContains("[heyLook] is a constant expression, but it should be a variable expression")
+                .go();
+
+        expectError("envIdentifierHyphens")
+                .runFromRepo(false)
+                .logContains("(hey - look) is a binary expression, but it should be a variable expression")
+                .go();
+
+        expectError("envIdentifierDigitsUnderscore")
+                .runFromRepo(false)
+                .logContains("expecting token in range: '0'..'9', found 'A'")
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/resources/errors/envIdentifierDigitsUnderscore.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/envIdentifierDigitsUnderscore.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,8 @@
 
 pipeline {
     environment {
+        123_ABC = "BLARGH"
         FOO = "BAR"
-        _UNDERSCORE = "VALID"
     }
 
     agent {
@@ -36,7 +36,6 @@ pipeline {
         stage("foo") {
             steps {
                 sh 'echo "FOO is $FOO"'
-                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
             }
         }
     }

--- a/pipeline-model-definition/src/test/resources/errors/envIdentifierHyphens.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/envIdentifierHyphens.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,8 @@
 
 pipeline {
     environment {
+        hey-look = "BLARGH"
         FOO = "BAR"
-        _UNDERSCORE = "VALID"
     }
 
     agent {
@@ -36,7 +36,6 @@ pipeline {
         stage("foo") {
             steps {
                 sh 'echo "FOO is $FOO"'
-                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
             }
         }
     }

--- a/pipeline-model-definition/src/test/resources/errors/envIdentifierStartingWithDigit.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/envIdentifierStartingWithDigit.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,8 @@
 
 pipeline {
     environment {
+        1BAR = "BLARGH"
         FOO = "BAR"
-        _UNDERSCORE = "VALID"
     }
 
     agent {
@@ -36,7 +36,6 @@ pipeline {
         stage("foo") {
             steps {
                 sh 'echo "FOO is $FOO"'
-                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
             }
         }
     }

--- a/pipeline-model-definition/src/test/resources/errors/envIdentifierString.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/envIdentifierString.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,8 @@
 
 pipeline {
     environment {
+        "heyLook" = "BLARGH"
         FOO = "BAR"
-        _UNDERSCORE = "VALID"
     }
 
     agent {
@@ -36,7 +36,6 @@ pipeline {
         stage("foo") {
             steps {
                 sh 'echo "FOO is $FOO"'
-                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
             }
         }
     }

--- a/pipeline-model-definition/src/test/resources/errors/envIdentifiersCaughtInternally.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/envIdentifiersCaughtInternally.groovy
@@ -24,7 +24,9 @@
 
 pipeline {
     environment {
-        1FOO = "BLARGH"
+        1BAR = "BLARGH"
+        _UNDERSCORE = "WORKS"
+        $DOLLAR = "Nuh-uh"
         FOO = "BAR"
     }
 

--- a/pipeline-model-definition/src/test/resources/errors/invalidEnvironmentIdentifiers.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidEnvironmentIdentifiers.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        1FOO = "BLARGH"
+        FOO = "BAR"
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
[JENKINS-41645](https://issues.jenkins-ci.org/browse/JENKINS-41645)

We can't handle all invalid environment identifiers currently - things
like 123_ABC or something-with-hyphens or 'somethingInQuotes' all end
up failing out at initial Groovy compilation, before we get the AST to
work with. We do catch those when coming from JSON, which is
something. But until this, we didn't give useful errors for any
invalid environment identifier that actually gets through compilation
- i.e., 3D_GLASSES, 123ABC. Those aren't BinaryExpressions, so they
were skipped and we ended up with just the general error case
reporting. This commit changes that. =)

cc @reviewbybees esp @rsandell and @orrc 