### PR TITLE
Verifying that nested describables can be used with agent config

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -179,8 +179,8 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"invalidWrapperType", Messages.ModelValidatorImpl_InvalidSectionType("option", "echo", "[buildDiscarder, catchError, disableConcurrentBuilds, overrideIndexTriggers, retry, script, skipDefaultCheckout, timeout, waitUntil, withContext, withEnv, ws]")});
 
         result.add(new Object[]{"unknownBareAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", "[otherField, docker, dockerfile, label, any, none]")});
-        result.add(new Object[]{"agentMissingRequiredParam", Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField]")});
-        result.add(new Object[]{"agentUnknownParamForType", Messages.ModelValidatorImpl_InvalidAgentParameter("fruit", "otherField", "[label, otherField]")});
+        result.add(new Object[]{"agentMissingRequiredParam", Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField, nested]")});
+        result.add(new Object[]{"agentUnknownParamForType", Messages.ModelValidatorImpl_InvalidAgentParameter("fruit", "otherField", "[label, otherField, nested]")});
         result.add(new Object[]{"notificationsSectionRemoved", "additional properties are not allowed"});
         result.add(new Object[]{"unknownWhenConditional", Messages.ModelValidatorImpl_UnknownWhenConditional("banana",
                 "branch, environment, expression")});

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -179,7 +179,7 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"invalidWrapperType", Messages.ModelValidatorImpl_InvalidSectionType("option", "echo", "[buildDiscarder, catchError, disableConcurrentBuilds, overrideIndexTriggers, retry, script, skipDefaultCheckout, timeout, waitUntil, withContext, withEnv, ws]")});
 
         result.add(new Object[]{"unknownBareAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", "[otherField, docker, dockerfile, label, any, none]")});
-        result.add(new Object[]{"agentMissingRequiredParam", Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField, nested]")});
+        result.add(new Object[]{"agentMissingRequiredParam", Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField]")});
         result.add(new Object[]{"agentUnknownParamForType", Messages.ModelValidatorImpl_InvalidAgentParameter("fruit", "otherField", "[label, otherField, nested]")});
         result.add(new Object[]{"notificationsSectionRemoved", "additional properties are not allowed"});
         result.add(new Object[]{"unknownWhenConditional", Messages.ModelValidatorImpl_UnknownWhenConditional("banana",

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -130,7 +130,10 @@ public class AgentTest extends AbstractModelDefTest {
     @Test
     public void multipleVariablesForAgent() throws Exception {
         expect("multipleVariablesForAgent")
-                .logContains("[Pipeline] { (foo)", "ONAGENT=true", "Running in labelAndOtherField with otherField = banana")
+                .logContains("[Pipeline] { (foo)",
+                        "ONAGENT=true",
+                        "Running in labelAndOtherField with otherField = banana",
+                        "And nested: foo: monkey, bar: false")
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -438,7 +438,7 @@ public class ValidatorTest extends AbstractModelDefTest {
     @Test
     public void agentMissingRequiredParam() throws Exception {
         expectError("agentMissingRequiredParam")
-                .logContains(Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField, nested]"))
+                .logContains(Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField]"))
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -438,7 +438,7 @@ public class ValidatorTest extends AbstractModelDefTest {
     @Test
     public void agentMissingRequiredParam() throws Exception {
         expectError("agentMissingRequiredParam")
-                .logContains(Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField]"))
+                .logContains(Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField, nested]"))
                 .go();
     }
 
@@ -452,7 +452,7 @@ public class ValidatorTest extends AbstractModelDefTest {
     @Test
     public void agentUnknownParamForType() throws Exception {
         expectError("agentUnknownParamForType")
-                .logContains(Messages.ModelValidatorImpl_InvalidAgentParameter("fruit", "otherField", "[label, otherField]"))
+                .logContains(Messages.ModelValidatorImpl_InvalidAgentParameter("fruit", "otherField", "[label, otherField, nested]"))
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NestedConf.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NestedConf.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,44 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl;
 
 import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
 import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-public class LabelAndOtherFieldAgent extends DeclarativeAgent<LabelAndOtherFieldAgent> {
-    private String label;
-    private String otherField;
-    private NestedConf nested;
+import java.io.Serializable;
 
+public class NestedConf extends AbstractDescribableImpl<NestedConf> implements Serializable {
     @DataBoundConstructor
-    public LabelAndOtherFieldAgent(String label, String otherField) {
-        this.label = label;
-        this.otherField = otherField;
-    }
+    public NestedConf() {
 
-    public String getLabel() {
-        return label;
-    }
-
-    public String getOtherField() {
-        return otherField;
     }
 
     @DataBoundSetter
-    public void setNested(NestedConf n) {
-        this.nested = n;
+    public String foo;
+    @DataBoundSetter
+    public boolean bar;
+
+    @Override
+    public String toString() {
+        return "foo: " + foo + ", bar: " + bar;
     }
 
-    public NestedConf getNested() {
-        return nested;
-    }
-
-    @Extension(ordinal = 1100) @Symbol("otherField")
-    public static class DescriptorImpl extends DeclarativeAgentDescriptor<LabelAndOtherFieldAgent> {
+    @Extension
+    @Symbol("nestedConf")
+    public static class NestedDesc extends Descriptor<NestedConf> {
     }
 }
+

--- a/pipeline-model-definition/src/test/resources/multipleVariablesForAgent.groovy
+++ b/pipeline-model-definition/src/test/resources/multipleVariablesForAgent.groovy
@@ -27,6 +27,10 @@ pipeline {
         otherField {
             label "some-label"
             otherField "banana"
+            nested {
+                foo "monkey"
+                bar false
+            }
         }
     }
     stages {

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
@@ -37,6 +37,7 @@ public class LabelAndOtherFieldAgentScript extends DeclarativeAgentScript<LabelA
     @Override
     public Closure run(Closure body) {
         script.echo "Running in labelAndOtherField with otherField = ${describable.getOtherField()}"
+        script.echo "And nested: ${describable.getNested()}"
         LabelScript labelScript = (LabelScript) Label.DescriptorImpl.instanceForName("label", [label: describable.label]).getScript(script)
         return labelScript.run {
             body.call()


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a - this is just adding a test for something that already works.
* Description:
    * Adding a test to verify that you can use nested describables within an agent's configuration, which will be relevant for, say, Kubernetes. This already works, but I wanted to make sure we had a test for it so that we don't inadvertently break this behavior in the future.
* Documentation changes:
    * n/a - purely internal test.
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 

