### PR TITLE
[FIXED JENKINS-41911] Shade away Jackson

### DIFF
--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-json-shaded</artifactId>
-      <version>1.1-SNAPSHOT</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-declarative-agent/pom.xml
+++ b/pipeline-model-declarative-agent/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -127,18 +127,6 @@
       <version>1.3</version>
     </dependency>
 
-    <!-- JSON schema stuff -->
-    <dependency>
-      <groupId>com.github.fge</groupId>
-      <artifactId>json-schema-validator</artifactId>
-      <version>2.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-json-org</artifactId>
-      <version>2.2.3</version>
-    </dependency>
-
     <!-- TEST deps -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -180,6 +168,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.7.3</version>
+      <scope>test</scope>
+    </dependency>
+    
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
@@ -24,9 +24,9 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.parser
 
 import com.cloudbees.groovy.cps.NonCPS
-import shaded.com.fasterxml.jackson.databind.JsonNode
-import shaded.com.fasterxml.jackson.databind.ObjectMapper
-import shaded.com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule
+import org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml.jackson.databind.JsonNode
+import org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml.jackson.databind.ObjectMapper
+import org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule
 import com.github.fge.jsonschema.exceptions.ProcessingException
 import com.github.fge.jsonschema.main.JsonSchema
 import com.github.fge.jsonschema.report.ProcessingReport

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
@@ -24,9 +24,9 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.parser
 
 import com.cloudbees.groovy.cps.NonCPS
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule
+import shaded.com.fasterxml.jackson.databind.JsonNode
+import shaded.com.fasterxml.jackson.databind.ObjectMapper
+import shaded.com.fasterxml.jackson.datatype.jsonorg.JsonOrgModule
 import com.github.fge.jsonschema.exceptions.ProcessingException
 import com.github.fge.jsonschema.main.JsonSchema
 import com.github.fge.jsonschema.report.ProcessingReport

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.parser
 
-import com.fasterxml.jackson.databind.JsonNode
+import shaded.com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.exceptions.JsonReferenceException
 import com.github.fge.jsonschema.exceptions.ProcessingException
 import com.github.fge.jsonschema.jsonpointer.JsonPointer

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.parser
 
-import shaded.com.fasterxml.jackson.databind.JsonNode
+import org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.exceptions.JsonReferenceException
 import com.github.fge.jsonschema.exceptions.ProcessingException
 import com.github.fge.jsonschema.jsonpointer.JsonPointer

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.endpoints;
 
-import shaded.com.fasterxml.jackson.databind.JsonNode;
+import org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.tree.SimpleJsonTree;
 import com.github.fge.jsonschema.util.JsonLoader;
 import com.google.common.collect.ImmutableList;

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition.endpoints;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import shaded.com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.tree.SimpleJsonTree;
 import com.github.fge.jsonschema.util.JsonLoader;
 import com.google.common.collect.ImmutableList;

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BaseParserLoaderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BaseParserLoaderTest.java
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import shaded.com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.tree.SimpleJsonTree;
 import com.github.fge.jsonschema.util.JsonLoader;
 import org.codehaus.groovy.control.ErrorCollector;

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BaseParserLoaderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BaseParserLoaderTest.java
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
-import shaded.com.fasterxml.jackson.databind.JsonNode;
+import org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.tree.SimpleJsonTree;
 import com.github.fge.jsonschema.util.JsonLoader;
 import org.codehaus.groovy.control.ErrorCollector;

--- a/pipeline-model-json-shaded/pom.xml
+++ b/pipeline-model-json-shaded/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ The MIT License
   ~
-  ~ Copyright (c) 2016, CloudBees, Inc.
+  ~ Copyright (c) 2017, CloudBees, Inc.
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -30,47 +30,53 @@
     <version>1.1-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.jenkinsci.plugins</groupId>
-  <artifactId>pipeline-model-api</artifactId>
-  <packaging>hpi</packaging>
-  <name>Pipeline: Model API</name>
-  <description>Model API for Declarative Pipeline</description>
+  <artifactId>pipeline-model-json-shaded</artifactId>
+  <packaging>jar</packaging>
+  <name>Pipeline: Model Shaded JSON Libraries</name>
+  <description>Library plugin for Pipeline stage tag metadata</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
-
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+            <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <include>com.github.fge:*</include>
+              <include>com.fasterxml*:*</include>
+            </includes>
+          </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>com.fasterxml</pattern>
+              <shadedPattern>shaded.com.fasterxml</shadedPattern>
+            </relocation>
+          </relocations>
+          <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
-    <!-- JSON schema stuff -->
     <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-json-shaded</artifactId>
-      <version>1.1-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.github.fge</groupId>
-          <artifactId>json-schema-validator</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>com.github.fge</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>2.0.4</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-      <version>2.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-      <version>1.5</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.2.5</version>
-      <scope>test</scope>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-json-org</artifactId>
+      <version>2.2.3</version>
     </dependency>
   </dependencies>
-  
 </project>

--- a/pipeline-model-json-shaded/pom.xml
+++ b/pipeline-model-json-shaded/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>pipeline-model-json-shaded</artifactId>
@@ -54,12 +54,34 @@
             <includes>
               <include>com.github.fge:*</include>
               <include>com.fasterxml*:*</include>
+              <include>joda-time:joda-time:*</include>
+              <include>com.google.guava:guava:*</include>
+              <include>com.googlecode.libphonenumber:*</include>
+              <include>org.mozilla:rhino:*</include>
+              <include>javax.mail:mailapi:*</include>
+              <include>org.json:json:*</include>
             </includes>
           </artifactSet>
           <relocations>
             <relocation>
               <pattern>com.fasterxml</pattern>
               <shadedPattern>org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.joda</pattern>
+              <shadedPattern>org.jenkinsci.plugins.pipeline.modeldefinition.shaded.org.joda</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.common</pattern>
+              <shadedPattern>org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.google.common</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.google.i18n.phonenumbers</pattern>
+              <shadedPattern>org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.google.i18n.phonenumbers</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.json</pattern>
+              <shadedPattern>org.jenkinsci.plugins.pipeline.modeldefinition.shaded.org.json</shadedPattern>
             </relocation>
           </relocations>
           <promoteTransitiveDependencies>true</promoteTransitiveDependencies>

--- a/pipeline-model-json-shaded/pom.xml
+++ b/pipeline-model-json-shaded/pom.xml
@@ -59,7 +59,7 @@
           <relocations>
             <relocation>
               <pattern>com.fasterxml</pattern>
-              <shadedPattern>shaded.com.fasterxml</shadedPattern>
+              <shadedPattern>org.jenkinsci.plugins.pipeline.modeldefinition.shaded.com.fasterxml</shadedPattern>
             </relocation>
           </relocations>
           <promoteTransitiveDependencies>true</promoteTransitiveDependencies>

--- a/pipeline-stage-tags-metadata/pom.xml
+++ b/pipeline-stage-tags-metadata/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkinsci.plugins</groupId>
     <artifactId>pipeline-model-parent</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>pipeline-stage-tags-metadata</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <module>pipeline-model-api</module>
     <module>pipeline-model-declarative-agent</module>
     <module>pipeline-model-definition</module>
+    <module>pipeline-model-json-shaded</module>
   </modules>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.jenkinsci.plugins</groupId>
   <artifactId>pipeline-model-parent</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Pipeline: Model Parent POM</name>
   <description>An opinionated, declarative Pipeline</description>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-41911](https://issues.jenkins-ci.org/browse/JENKINS-41911)
* Description:
    * This took some hoop-jumping, but now we should be guaranteed to use our own copy of Jackson at all times. Phew. Note that I added a test dependency on the `jackson2-api` plugin, basically to prove that this works, since the tests fail hard without the shade change but with that plugin.
* Documentation changes:
    * n/a - purely internal change, not at all user facing.
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
    * @kzantow
