### PR TITLE
JENKINS-41759 read properties into environment

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -97,38 +97,6 @@ public class Root implements NestedModel, Serializable {
         return this
     }
 
-    /**
-     * Helper method for translating the key/value pairs in the {@link Environment} into a list of "key=value" strings
-     * suitable for use with the withEnv step.
-     *
-     * @return a list of "key=value" strings.
-     */
-    List<String> getEnvVars(CpsScript script) {
-        List<String> e = environment.findAll{k, v -> !(v instanceof DeclarativeEnvironmentContributor)}.collect { k, v ->
-            "${k}=${v}"
-        }
-
-        environment.each {k, v ->
-            if (v instanceof DeclarativeEnvironmentContributor && !(v instanceof DeclarativeEnvironmentContributor.MutedGenerator)) {
-                List<String> ee = v.generate(script, k)
-                if (ee != null) {
-                    e.addAll(ee)
-                }
-            }
-        }
-        return e
-    }
-
-    Map<String, Credentials> getEnvCredentials() {
-        Map<String, Credentials> m = [:]
-        environment.each {k, v ->
-            if (v instanceof Credentials) {
-                m["${k}"] = v;
-            }
-        }
-        return m
-    }
-
     @Override
     public void modelFromMap(Map<String,Object> m) {
         m.each { k, v ->

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -92,39 +92,6 @@ public class Stage implements NestedModel, Serializable {
         return this
     }
 
-    /**
-     * Helper method for translating the key/value pairs in the {@link Environment} into a list of "key=value" strings
-     * suitable for use with the withEnv step.
-     *
-     * @return a list of "key=value" strings.
-     */
-    List<String> getEnvVars(CpsScript script) {
-        List<String> e =  environment.findAll{k, v -> !(v instanceof DeclarativeEnvironmentContributor)}.collect { k, v ->
-            "${k}=${v}"
-        }
-        environment.each {k, v ->
-            if (v instanceof DeclarativeEnvironmentContributor && !(v instanceof DeclarativeEnvironmentContributor.MutedGenerator)) {
-                List<String> ee = v.generate(script, k)
-                if (ee != null) {
-                    e.addAll(ee)
-                }
-            }
-        }
-        return e
-    }
-
-    @Nonnull
-    Map<String, Credentials> getEnvCredentials() {
-        Map<String, Credentials> m = [:]
-        environment.each {k, v ->
-            if (v instanceof  Credentials) {
-                m["${k}"] = v;
-            }
-        }
-        return m
-    }
-
-
     @Override
     public void modelFromMap(Map<String,Object> m) {
         m.each { k, v ->

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -26,7 +26,10 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributor
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl.Credentials
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
+import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 import javax.annotation.Nonnull
 
@@ -95,17 +98,26 @@ public class Stage implements NestedModel, Serializable {
      *
      * @return a list of "key=value" strings.
      */
-    List<String> getEnvVars() {
-        return environment.findAll{k, v -> !(v instanceof CredentialWrapper)}.collect { k, v ->
+    List<String> getEnvVars(CpsScript script) {
+        List<String> e =  environment.findAll{k, v -> !(v instanceof DeclarativeEnvironmentContributor)}.collect { k, v ->
             "${k}=${v}"
         }
+        environment.each {k, v ->
+            if (v instanceof DeclarativeEnvironmentContributor && !(v instanceof DeclarativeEnvironmentContributor.MutedGenerator)) {
+                List<String> ee = v.generate(script, k)
+                if (ee != null) {
+                    e.addAll(ee)
+                }
+            }
+        }
+        return e
     }
 
     @Nonnull
-    Map<String, CredentialWrapper> getEnvCredentials() {
-        Map<String, CredentialWrapper> m = [:]
+    Map<String, Credentials> getEnvCredentials() {
+        Map<String, Credentials> m = [:]
         environment.each {k, v ->
-            if (v instanceof  CredentialWrapper) {
+            if (v instanceof  Credentials) {
                 m["${k}"] = v;
             }
         }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/DeclarativeEnvironmentContributor.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/DeclarativeEnvironmentContributor.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.environment;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptDescribable;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+
+import java.util.List;
+
+/**
+ * Defines special functions within the environment directive.
+ */
+public abstract class DeclarativeEnvironmentContributor<C extends WithScriptDescribable<C>> extends WithScriptDescribable<C> {
+
+    public List<String> generate(CpsScript script, String key) throws Exception {
+        return ((DeclarativeEnvironmentContributorScript)getScript(script)).generate(key);
+    }
+
+    /**
+     * Marker interface for a generator that is not part of the standard "withEnv" flow.
+     * But one that needs special handling.
+     * @see com.cloudbees.plugins.credentials.CredentialsStoreAction.CredentialsWrapper
+     */
+    public interface MutedGenerator {
+
+    }
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/DeclarativeEnvironmentContributorDescriptor.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/DeclarativeEnvironmentContributorDescriptor.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.environment;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptDescriptor;
+
+/**
+ * Created by rsandell on 2017-02-06.
+ */
+public class DeclarativeEnvironmentContributorDescriptor<C extends DeclarativeEnvironmentContributor<C>> extends WithScriptDescriptor<C> {
+
+
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/DeclarativeEnvironmentContributorScript.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/DeclarativeEnvironmentContributorScript.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.environment;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptScript;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+
+import java.util.List;
+
+/**
+ * Script base for {@link DeclarativeEnvironmentContributor}s.
+ */
+public abstract class DeclarativeEnvironmentContributorScript<C extends DeclarativeEnvironmentContributor<C>> extends WithScriptScript<C> {
+
+
+    public DeclarativeEnvironmentContributorScript(CpsScript s, C d) {
+        super(s, d);
+    }
+
+    public abstract List<String> generate(String key);
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/Credentials.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/Credentials.java
@@ -26,6 +26,7 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl;
 
 import hudson.Extension;
+import hudson.model.Run;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException;
 import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributor;
@@ -66,8 +67,13 @@ public class Credentials extends DeclarativeEnvironmentContributor<Credentials> 
     }
 
     private void prepare(RunWrapper currentBuild) throws CredentialNotFoundException {
-        CredentialsBindingHandler handler = CredentialsBindingHandler.forId(credentialsId, currentBuild.getRawBuild());
-        withCredentialsParameters = handler.getWithCredentialsParameters(credentialsId);
+        Run<?, ?> r = currentBuild.getRawBuild();
+        if (r != null) {
+            CredentialsBindingHandler handler = CredentialsBindingHandler.forId(credentialsId, currentBuild.getRawBuild());
+            withCredentialsParameters = handler.getWithCredentialsParameters(credentialsId);
+        } else {
+            throw new CredentialNotFoundException(credentialsId);
+        }
     }
 
     @Whitelisted

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/Credentials.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/Credentials.java
@@ -69,7 +69,7 @@ public class Credentials extends DeclarativeEnvironmentContributor<Credentials> 
     private void prepare(RunWrapper currentBuild) throws CredentialNotFoundException {
         Run<?, ?> r = currentBuild.getRawBuild();
         if (r != null) {
-            CredentialsBindingHandler handler = CredentialsBindingHandler.forId(credentialsId, currentBuild.getRawBuild());
+            CredentialsBindingHandler handler = CredentialsBindingHandler.forId(credentialsId, r);
             withCredentialsParameters = handler.getWithCredentialsParameters(credentialsId);
         } else {
             throw new CredentialNotFoundException(credentialsId);

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/Credentials.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/Credentials.java
@@ -32,6 +32,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnv
 import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributorDescriptor;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -57,7 +58,14 @@ public class Credentials extends DeclarativeEnvironmentContributor<Credentials> 
         return credentialsId;
     }
 
-    public void prepare(RunWrapper currentBuild) throws CredentialNotFoundException {
+    @Whitelisted
+    public void addParameters(CpsScript script, String envVarName, List<Map<String, Object>> list) throws CredentialNotFoundException {
+        RunWrapper currentBuild = (RunWrapper) script.getProperty("currentBuild");
+        prepare(currentBuild);
+        list.addAll(resolveParameters(envVarName));
+    }
+
+    private void prepare(RunWrapper currentBuild) throws CredentialNotFoundException {
         CredentialsBindingHandler handler = CredentialsBindingHandler.forId(credentialsId, currentBuild.getRawBuild());
         withCredentialsParameters = handler.getWithCredentialsParameters(credentialsId);
     }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/TrustedProperties.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/TrustedProperties.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributorDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Read environment from a properties file in the scm.
+ */
+public class TrustedProperties extends DeclarativeEnvironmentContributor<TrustedProperties> {
+
+    private final String path;
+
+    @DataBoundConstructor
+    public TrustedProperties(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Extension @Symbol("fromPropertiesFile")
+    public static class DescriptorImpl extends DeclarativeEnvironmentContributorDescriptor<TrustedProperties> {
+
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -28,6 +28,7 @@ import com.cloudbees.groovy.cps.impl.CpsClosure
 import hudson.FilePath
 import hudson.Launcher
 import hudson.model.Result
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl.Credentials
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional
@@ -68,7 +69,7 @@ public class ModelInterpreter implements Serializable {
                 executeProperties(root)
 
                 // Entire build, including notifications, runs in the withEnv.
-                withEnvBlock(root.getEnvVars()) {
+                withEnvBlock(root.getEnvVars(script)) {
                     inWrappers(root.options) {
                         // Stage execution and post-build actions run in try/catch blocks, so we still run post-build actions
                         // even if the build fails.
@@ -81,7 +82,7 @@ public class ModelInterpreter implements Serializable {
                                         try {
                                             script.stage(thisStage.name) {
                                                 if (firstError == null) {
-                                                    withEnvBlock(thisStage.getEnvVars()) {
+                                                    withEnvBlock(thisStage.getEnvVars(script)) {
                                                         if (evaluateWhen(thisStage.when)) {
                                                             inDeclarativeAgent(thisStage, thisStage.agent) {
                                                                 withCredentialsBlock(thisStage.getEnvCredentials()) {
@@ -203,7 +204,7 @@ public class ModelInterpreter implements Serializable {
      * @param body The closure to execute
      * @return The return of the resulting executed closure
      */
-    def withCredentialsBlock(@Nonnull Map<String, CredentialWrapper> credentials, Closure body) {
+    def withCredentialsBlock(@Nonnull Map<String, Credentials> credentials, Closure body) {
         if (!credentials.isEmpty()) {
             List<Map<String, Object>> parameters = createWithCredentialsParameters(credentials)
             return {
@@ -225,11 +226,11 @@ public class ModelInterpreter implements Serializable {
      */
     @NonCPS
     private List<Map<String, Object>> createWithCredentialsParameters(
-            @Nonnull Map<String, CredentialWrapper> credentials) {
+            @Nonnull Map<String, Credentials> credentials) {
         List<Map<String, Object>> parameters = []
-        Set<Map.Entry<String, CredentialWrapper>> set = credentials.entrySet()
-        for (Map.Entry<String, CredentialWrapper> entry : set) {
-            entry.value.addParameters(entry.key, parameters)
+        Set<Map.Entry<String, Credentials>> set = credentials.entrySet()
+        for (Map.Entry<String, Credentials> entry : set) {
+            entry.value.getScript(script).addParameters(entry.key, parameters)
         }
         parameters
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -230,7 +230,7 @@ public class ModelInterpreter implements Serializable {
         List<Map<String, Object>> parameters = []
         Set<Map.Entry<String, Credentials>> set = credentials.entrySet()
         for (Map.Entry<String, Credentials> entry : set) {
-            entry.value.getScript(script).addParameters(entry.key, parameters)
+            entry.value.addParameters(script, entry.key, parameters)
         }
         parameters
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
@@ -58,15 +58,17 @@ public class PropertiesToMapTranslator implements MethodMissingWrapper, Serializ
         }
 
         if (resolveEnvironmentContributors) {
-            UninstantiatedDescribable retVal
+            def retVal
             if (argValue != null) {
                 retVal = script."${s}"(argValue)
             } else {
                 retVal = script."${s}"()
             }
 
-            if (isOfType(retVal, DeclarativeEnvironmentContributor.class)) {
+            if (retVal instanceof UninstantiatedDescribable && isOfType(retVal, DeclarativeEnvironmentContributor.class)) {
                 return retVal.instantiate()
+            } else {
+                return retVal
             }
         }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/PropertiesToMapTranslator.groovy
@@ -23,12 +23,17 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition
 
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributor
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.MethodMissingWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.NestedModel
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+
+import static org.jenkinsci.plugins.pipeline.modeldefinition.Utils.isOfType
 
 /**
  * Translates a closure containing one or more "foo = 'bar'" statements into a map.
@@ -37,10 +42,10 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 public class PropertiesToMapTranslator implements MethodMissingWrapper, Serializable {
     Map<String,Object> actualMap = [:]
     CpsScript script
-    private final boolean resolveCredentials
+    private final boolean resolveEnvironmentContributors
 
-    PropertiesToMapTranslator(CpsScript script, boolean resolveCredentials = false) {
-        this.resolveCredentials = resolveCredentials
+    PropertiesToMapTranslator(CpsScript script, boolean resolveEnvironmentContributors = false) {
+        this.resolveEnvironmentContributors = resolveEnvironmentContributors
         this.script = script
     }
 
@@ -52,16 +57,16 @@ public class PropertiesToMapTranslator implements MethodMissingWrapper, Serializ
             argValue = args[0]
         }
 
-        if (resolveCredentials && s == "credentials") {
-            if (args.length == 1) {
-                String id = "${args[0]}"
-
-                RunWrapper currentBuild = script.getProperty("currentBuild")
-
-                CredentialsBindingHandler handler = CredentialsBindingHandler.forId(id, currentBuild.rawBuild);
-                return new CredentialWrapper(id, handler.getWithCredentialsParameters(id));
+        if (resolveEnvironmentContributors) {
+            UninstantiatedDescribable retVal
+            if (argValue != null) {
+                retVal = script."${s}"(argValue)
             } else {
-                throw new IllegalArgumentException("credentials is expecting one parameter for the credentials id")
+                retVal = script."${s}"()
+            }
+
+            if (isOfType(retVal, DeclarativeEnvironmentContributor.class)) {
+                return retVal.instantiate()
             }
         }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/CredentialsScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/CredentialsScript.groovy
@@ -25,16 +25,12 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributorScript
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
 import org.jenkinsci.plugins.workflow.cps.CpsScript
-import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 public class CredentialsScript extends DeclarativeEnvironmentContributorScript<Credentials> {
 
     CredentialsScript(CpsScript script, Credentials contributor) {
         super(script, contributor)
-        RunWrapper currentBuild = script.getProperty("currentBuild")
-        contributor.prepare(currentBuild)
     }
 
     @Override
@@ -42,8 +38,5 @@ public class CredentialsScript extends DeclarativeEnvironmentContributorScript<C
         return null //Not used because MutedGenerator
     }
 
-    @Whitelisted
-    public void addParameters(String envVarName, List<Map<String, Object>> list) {
-        list.addAll(describable.resolveParameters(envVarName))
-    }
+
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/CredentialsScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/CredentialsScript.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributorScript
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
+
+public class CredentialsScript extends DeclarativeEnvironmentContributorScript<Credentials> {
+
+    CredentialsScript(CpsScript script, Credentials contributor) {
+        super(script, contributor)
+        RunWrapper currentBuild = script.getProperty("currentBuild")
+        contributor.prepare(currentBuild)
+    }
+
+    @Override
+    List<String> generate(String key) {
+        return null //Not used because MutedGenerator
+    }
+
+    @Whitelisted
+    public void addParameters(String envVarName, List<Map<String, Object>> list) {
+        list.addAll(describable.resolveParameters(envVarName))
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/TrustedPropertiesScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/TrustedPropertiesScript.groovy
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl
+
+import com.cloudbees.groovy.cps.NonCPS
+import hudson.Util
+import org.jenkinsci.plugins.pipeline.modeldefinition.environment.DeclarativeEnvironmentContributorScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+/**
+ * Script side of {@link TrustedProperties}.
+ */
+class TrustedPropertiesScript extends DeclarativeEnvironmentContributorScript<TrustedProperties> {
+
+    TrustedPropertiesScript(CpsScript s, TrustedProperties d) {
+        super(s, d)
+    }
+
+    @Override
+    List<String> generate(String key) {
+        String prefix = Util.fixNull(key)
+        if (!prefix.isEmpty() && !prefix.endsWith("_")) {
+            prefix = prefix.trim() + "_"
+        }
+        String content = script.readTrusted(describable.path)
+        return generateEnvStrings(prefix, content)
+    }
+
+    @NonCPS
+    List<String> generateEnvStrings(String prefix, String content) {
+        Properties p = new Properties()
+        p.load(new StringReader(content))
+        List<String> env = []
+
+        for (String suffix : p.keySet()) {
+            env.add("${prefix}${suffix.trim()}=${p.getProperty(suffix, "").trim()}")
+        }
+        return env
+    }
+}

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/TrustedPropertiesTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/environment/impl/TrustedPropertiesTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.environment.impl;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.junit.Test;
+
+/**
+ * Tests {@link TrustedProperties}
+ */
+public class TrustedPropertiesTest extends AbstractModelDefTest {
+
+    @Test
+    public void globalAndStage() throws Exception {
+        sampleRepo.write("marker.properties", "NAME=Bobby\nNUM=1\n");
+        sampleRepo.write("stage/marker.properties", "NAME=Andrew\nNUM=0\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "marker.properties");
+        sampleRepo.git("add", "stage/marker.properties");
+        sampleRepo.git("commit", "--message=Markers");
+
+        expect("environmentFromProperties")
+                .logContains(
+                        "FOO is BAR",
+                        "PROP_NAME is Bobby",
+                        "PROP_NUM is 1",
+                        "P_NAME is Andrew",
+                        "P_NUM is 0").go();
+    }
+}

--- a/pipeline-model-definition/src/test/resources/environmentFromProperties.groovy
+++ b/pipeline-model-definition/src/test/resources/environmentFromProperties.groovy
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+pipeline {
+    environment {
+        FOO = "BAZ"
+        PROP = fromPropertiesFile("marker.properties")
+    }
+    agent any
+
+    stages {
+        stage("foo") {
+            environment {
+                FOO = "BAR"
+                P_ = fromPropertiesFile("stage/marker.properties")
+            }
+
+            steps {
+                sh '''
+echo "FOO is $FOO"
+echo "PROP_NAME is $PROP_NAME"
+echo "PROP_NUM is $PROP_NUM"
+echo "P_NAME is $P_NAME"
+echo "P_NUM is $P_NUM"
+'''
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-41759](https://issues.jenkins-ci.org/browse/JENKINS-41759)
* Description:
    * Refactored the pluggable functions in environment directive to enable extensions and made credentials into such a _(special)_ extension. Then added the `fromPropertiesFile` function that utilizes readTrusted so it doesn't require a workspace.
* Documentation changes:
    * Yes, needs documentation but I don't know how
* Users/aliases to notify:
    * @reviewbybees 
    * @abayer 
