### PR TITLE
[FIXED JENKINS-41950] Properly report errors outside stages

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -124,10 +124,22 @@ public class ModelInterpreter implements Serializable {
                         }
                     }
                 }
+            } catch (Exception e) {
+                // Catch any errors that may have been thrown outside of the stages proper and make sure we set
+                // firstError accordingly.
+                if (firstError == null) {
+                    firstError = e
+                }
             } finally {
                 // If we hit an exception somewhere *before* we got to stages, we still need to do post-build tasks.
                 if (!postBuildRun) {
-                    executePostBuild(root)
+                    try {
+                        executePostBuild(root)
+                    } catch (Exception e) {
+                        if (firstError == null) {
+                            firstError = e
+                        }
+                    }
                 }
             }
             if (firstError != null) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -141,6 +141,19 @@ public class AgentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-41950")
+    @Test
+    public void nonExistentDockerImage() throws Exception {
+        assumeDocker();
+        // Bind mounting /var on OS X doesn't work at the moment
+        onAllowedOS(PossibleOS.LINUX);
+
+        expect(Result.FAILURE, "nonExistentDockerImage")
+                .logContains("ERROR: script returned exit code 1")
+                .go();
+    }
+
+
     @Test
     public void fromDockerfile() throws Exception {
         assumeDocker();

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -149,7 +149,8 @@ public class AgentTest extends AbstractModelDefTest {
         onAllowedOS(PossibleOS.LINUX);
 
         expect(Result.FAILURE, "nonExistentDockerImage")
-                .logContains("ERROR: script returned exit code 1")
+                .logContains("ERROR: script returned exit code 1",
+                        "There is no image")
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/resources/nonExistentDockerImage.groovy
+++ b/pipeline-model-definition/src/test/resources/nonExistentDockerImage.groovy
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            image "httpdIDontExist:2.4.12"
+            args "-v /tmp:/tmp -p 80:80"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+            }
+        }
+    }
+    post {
+        always {
+            deleteDir()
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/nonExistentDockerImage.groovy
+++ b/pipeline-model-definition/src/test/resources/nonExistentDockerImage.groovy
@@ -39,6 +39,7 @@ pipeline {
     }
     post {
         always {
+            echo "There is no image"
             deleteDir()
         }
     }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-41950](https://issues.jenkins-ci.org/browse/JENKINS-41950)
* Description:
    * We hadn't been reporting errors in the pre-stage blocks as `firstError`, so they were getting swallowed, particularly if the `post` that gets run if there are errors pre-stage itself had errors (i.e., due to running `deleteDir()` outside a node context. So now let's catch said pre-stage errors, report them properly, etc.
* Documentation changes:
    * n/a - internal fix.
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
