### PR TITLE
[FIXED JENKINS-42027] Actually load GlobalConfig from disk

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/config/GlobalConfig.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/config/GlobalConfig.java
@@ -50,6 +50,10 @@ public class GlobalConfig extends GlobalConfiguration {
     private String dockerLabel;
     private DockerRegistryEndpoint registry;
 
+    public GlobalConfig() {
+        load();
+    }
+
     public String getDockerLabel() {
         return Util.fixEmpty(dockerLabel);
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DurabilityTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DurabilityTest.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
+import org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig;
 import org.jenkinsci.plugins.workflow.actions.WorkspaceAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.graph.FlowGraphWalker;
@@ -39,6 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.model.Statement;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.util.ArrayList;
@@ -54,6 +56,25 @@ public class DurabilityTest {
 
     @Rule
     public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Issue("JENKINS-42027")
+    @Test
+    public void globalConfigPersists() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                GlobalConfig.get().setDockerLabel("config_docker");
+                GlobalConfig.get().save();
+            }
+        });
+
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                assertEquals("config_docker", GlobalConfig.get().getDockerLabel());
+            }
+        });
+    }
 
     @Test
     public void survivesRestart() throws Exception {


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42027](https://issues.jenkins-ci.org/browse/JENKINS-42027)
* Description:
    * We weren't doing this before, and so the settings in GlobalConfig weren't being persisted. That was an oopsie, but this is an easy fix.
* Documentation changes:
    * n/a - bug fix, no docs to change
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
