### PR TITLE
Followup to JENKINS-41900 - just record if in stage

### DIFF
--- a/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-declarative-agent/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -35,15 +35,15 @@ import org.kohsuke.stapler.DataBoundSetter;
  * @author Andrew Bayer
  */
 public abstract class DeclarativeAgent<A extends DeclarativeAgent<A>> extends WithScriptDescribable<A> implements ExtensionPoint {
-    protected Object context;
+    protected boolean inStage;
     protected boolean doCheckout;
 
-    public void setContext(Object context) {
-        this.context = context;
+    public void setInStage(boolean inStage) {
+        this.inStage = inStage;
     }
 
-    public Object getContext() {
-        return context;
+    public boolean isInStage() {
+        return inStage;
     }
 
     public void setDoCheckout(boolean doCheckout) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -71,7 +71,11 @@ public class Agent extends MappedClosure<Object,Agent> implements Serializable {
 
             DeclarativeAgent a = DeclarativeAgentDescriptor.instanceForDescriptor(foundDescriptor, argMap)
             boolean doCheckout = false
-            a.setContext(context)
+            if (context instanceof Root) {
+                a.setInStage(false)
+            } else {
+                a.setInStage(true)
+            }
             if (root != null) {
                 SkipDefaultCheckout skip = (SkipDefaultCheckout) root?.options?.options?.get("skipDefaultCheckout")
                 if (!skip?.isSkipDefaultCheckout()) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AbstractDockerPipelineScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AbstractDockerPipelineScript.groovy
@@ -46,7 +46,7 @@ public abstract class AbstractDockerPipelineScript<A extends AbstractDockerAgent
         } else {
             String targetLabel = DeclarativeDockerUtils.getLabel(describable.label)
             Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: targetLabel])
-            l.context = describable.context
+            l.inStage = describable.inStage
             l.doCheckout = describable.doCheckout
             LabelScript labelScript = (LabelScript) l.getScript(script)
             return labelScript.run {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AnyScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AnyScript.groovy
@@ -37,7 +37,7 @@ public class AnyScript extends DeclarativeAgentScript<Any> {
     @Override
     public Closure run(Closure body) {
         Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: null])
-        l.context = describable.context
+        l.inStage = describable.inStage
         l.doCheckout = describable.doCheckout
         LabelScript labelScript = (LabelScript) l.getScript(script)
         return labelScript.run {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -46,7 +46,7 @@ public class LabelScript extends DeclarativeAgentScript<Label> {
             try {
                 script.node(describable?.label) {
                     if (describable.isDoCheckout() && describable.hasScmContext(script)) {
-                        if (describable.context instanceof Root) {
+                        if (!describable.inStage) {
                             script.stage(SyntheticStageNames.checkout()) {
                                 script.checkout script.scm
                             }

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
@@ -39,7 +39,7 @@ public class LabelAndOtherFieldAgentScript extends DeclarativeAgentScript<LabelA
         script.echo "Running in labelAndOtherField with otherField = ${describable.getOtherField()}"
         script.echo "And nested: ${describable.getNested()}"
         Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: describable.label])
-        l.context = describable.context
+        l.inStage = describable.inStage
         l.doCheckout = describable.doCheckout
         LabelScript labelScript = (LabelScript) l.getScript(script)
         return labelScript.run {


### PR DESCRIPTION
* JENKINS issue(s):
    * Follow up to [JENKINS-41900](https://issues.jenkins-ci.org/browse/JENKINS-41900)
* Description:
    * There's no actual good reason for carrying the whole context (i.e., Root or Stage object) around in the DeclarativeAgent when all we need to know is whether we're already in a stage. So...switch that to a boolean and have Agent.groovy check whether the context it's handed is a Root instance. If it is a Root instance, we're not in a stage. If it isn't a Root instance, we are in a stage. Tada.
    * And yes, this is an API change, but https://github.com/jenkinsci/kubernetes-plugin/pull/127 is the only thing yet using that API and I'm changing it specifically *for* that PR. =)
* Documentation changes:
    * n/a, just an API change.
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
