### PR TITLE
Relocate SyntheticStageNames to model-api

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageNames.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageNames.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,32 +22,33 @@
  * THE SOFTWARE.
  */
 
+package org.jenkinsci.plugins.pipeline.modeldefinition;
 
-package org.jenkinsci.plugins.pipeline.modeldefinition
-
+import java.util.Arrays;
+import java.util.List;
 
 public class SyntheticStageNames {
     public static List<String> preStages() {
-        return [checkout(), agentSetup(), toolInstall()]
+        return Arrays.asList(checkout(), agentSetup(), toolInstall());
     }
 
     public static List<String> postStages() {
-        return [postBuild()]
+        return Arrays.asList(postBuild());
     }
 
     public static String checkout() {
-        return "Declarative: Checkout SCM"
+        return "Declarative: Checkout SCM";
     }
 
     public static String agentSetup() {
-        return "Declarative: Agent Setup"
+        return "Declarative: Agent Setup";
     }
 
     public static String toolInstall() {
-        return "Declarative: Tool Install"
+        return "Declarative: Tool Install";
     }
 
     public static String postBuild() {
-        return "Declarative: Post Actions"
+        return "Declarative: Post Actions";
     }
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -27,11 +27,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
 
 import hudson.model.Result
 import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
-import org.jenkinsci.plugins.pipeline.modeldefinition.model.Root
-import org.jenkinsci.plugins.pipeline.modeldefinition.options.impl.SkipDefaultCheckout
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 public class LabelScript extends DeclarativeAgentScript<Label> {


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * Minor tweak - want to have the `SyntheticStageNames` class somewhere it can be picked up without depending on literally everything else.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
