### PR TITLE
[FIXED JENKINS-42226] Treat null/empty branch comparison as false

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/BranchConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/BranchConditional.java
@@ -55,7 +55,7 @@ public class BranchConditional extends DeclarativeStageConditional<BranchConditi
     public boolean branchMatches(String actualBranch) {
         if (isEmpty(actualBranch) && isEmpty(this.compare)) {
             return true;
-        } else if (isEmpty(actualBranch)) {
+        } else if (isEmpty(actualBranch) || isEmpty(this.compare)) {
             return false;
         }
         // Replace the Git directory separator character (always '/')

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -338,6 +338,15 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-42226")
+    @Test
+    public void whenBranchNull() throws Exception {
+        expect("whenBranchNull")
+                .logContains("[Pipeline] { (One)", "[Pipeline] { (Two)")
+                .logNotContains("World")
+                .go();
+    }
+
     @Test
     public void whenEnvTrue() throws Exception {
         expect("whenEnvTrue")

--- a/pipeline-model-definition/src/test/resources/whenBranchNull.groovy
+++ b/pipeline-model-definition/src/test/resources/whenBranchNull.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    environment {
+        BRANCH_NAME = "master"
+    }
+    stages {
+        stage("One") {
+            steps {
+                echo "Hello"
+            }
+        }
+        stage("Two") {
+            when {
+                branch null
+            }
+            steps {
+                script {
+                    echo "World"
+                    echo "Heal it"
+                }
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42226](https://issues.jenkins-ci.org/browse/JENKINS-42226)
* Description:
    * We should be null-checking `compare` in all cases as well as `actualBranch`, and if either is null/empty, we should return false. This change does that.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
    * @imod 
