### PR TITLE
[FIXED JENKINS-42168] Add validateDeclarativePipeline(path) step

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.steps;
+
+import com.google.inject.Inject;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
+import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Step that will validate a string containing a Declarative Pipeline.
+ *
+ * @author Andrew Bayer
+ */
+public final class ValidateDeclarativePipelineStep extends AbstractStepImpl implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String path;
+
+    @DataBoundConstructor
+    public ValidateDeclarativePipelineStep(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(ValidateDeclarativePipelineStepExecution.class);
+        }
+
+        @Override public String getFunctionName() {
+            return "validateDeclarativePipeline";
+        }
+
+        @Override public String getDisplayName() {
+            return "Validate a string containing a Declarative Pipeline";
+        }
+    }
+
+    public static final class ValidateDeclarativePipelineStepExecution extends AbstractSynchronousNonBlockingStepExecution<Boolean> {
+
+        @Inject(optional=true)
+        private transient ValidateDeclarativePipelineStep step;
+
+        @StepContextParameter
+        private transient FilePath cwd;
+
+        @StepContextParameter
+        private transient TaskListener listener;
+
+        @Override
+        public Boolean run() throws Exception {
+            if (StringUtils.isEmpty(step.getPath())) {
+                listener.getLogger().println("No Declarative Pipeline file specified.");
+                return false;
+            } else {
+                FilePath f = cwd.child(step.getPath());
+                if (!f.exists() || f.isDirectory()) {
+                    listener.getLogger().println("Declarative Pipeline file '" + step.getPath() + "' does not exist.");
+                    return false;
+                } else {
+                    String text = f.readToString();
+                    if (StringUtils.isEmpty(text)) {
+                        listener.getLogger().println("Declarative Pipeline file '" + step.getPath() + "' is empty.");
+                        return false;
+                    } else {
+                        try {
+                            ModelASTPipelineDef pipelineDef = Converter.scriptToPipelineDef(text);
+                            if (pipelineDef != null) {
+                                listener.getLogger().println("Declarative Pipeline file '" + step.getPath() + "' is valid.");
+                                return true;
+                            } else {
+                                listener.getLogger().println("Declarative Pipeline file '" + step.getPath() + "' does not contain the 'pipeline' step.");
+                                return false;
+                            }
+                        } catch (Exception e) {
+                            listener.getLogger().println("Error(s) validating Declarative Pipeline file '" + step.getPath() + "' - " + e.toString());
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep.java
@@ -76,7 +76,7 @@ public final class ValidateDeclarativePipelineStep extends AbstractStepImpl impl
 
     public static final class ValidateDeclarativePipelineStepExecution extends AbstractSynchronousNonBlockingStepExecution<Boolean> {
 
-        @Inject(optional=true)
+        @Inject
         private transient ValidateDeclarativePipelineStep step;
 
         @StepContextParameter

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep.java
@@ -70,7 +70,7 @@ public final class ValidateDeclarativePipelineStep extends AbstractStepImpl impl
         }
 
         @Override public String getDisplayName() {
-            return "Validate a string containing a Declarative Pipeline";
+            return "Validate a file containing a Declarative Pipeline";
         }
     }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="path" title="File path in workspace">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep/help-path.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep/help-path.html
@@ -1,0 +1,27 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    Relative (<code>/</code>-separated) path to file within a workspace to validate as a Declarative Pipeline.
+</div>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep/help.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStep/help.html
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>
+    Checks if the given file (as relative path to current directory) contains a valid Declarative Pipeline.
+    Returns <code>true | false</code>.
+</div>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/ValidateDeclarativePipelineStepTest.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.pipeline.modeldefinition.steps;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.junit.Test;
+
+public class ValidateDeclarativePipelineStepTest extends AbstractModelDefTest {
+
+    @Test
+    public void passes() throws Exception {
+        expect("validateDeclarativePipelineStep")
+                .otherResource("simplePipeline.groovy", "testFile.groovy")
+                .logContains("Declarative Pipeline file 'testFile.groovy' is valid.",
+                        "validation result - true")
+                .go();
+    }
+
+    @Test
+    public void noFile() throws Exception {
+        expect("validateDeclarativePipelineStep")
+                .logContains("Declarative Pipeline file 'testFile.groovy' does not exist.",
+                        "validation result - false")
+                .go();
+    }
+
+    @Test
+    public void noPipelineStep() throws Exception {
+        expect("validateDeclarativePipelineStep")
+                .otherResource("validateDeclarativePipelineStep.groovy", "testFile.groovy")
+                .logContains("Declarative Pipeline file 'testFile.groovy' does not contain the 'pipeline' step.",
+                        "validation result - false")
+                .go();
+    }
+
+    @Test
+    public void validationErrors() throws Exception {
+        expect("validateDeclarativePipelineStep")
+                .otherResource("errors/emptyEnvironment.groovy", "testFile.groovy")
+                .logContains("Error(s) validating Declarative Pipeline file 'testFile.groovy' - org.codehaus.groovy.control.MultipleCompilationErrorsException",
+                        "WorkflowScript: 26: No variables specified for environment @ line 26, column 5.",
+                        "validation result - false")
+                .go();
+    }
+
+}

--- a/pipeline-model-definition/src/test/resources/validateDeclarativePipelineStep.groovy
+++ b/pipeline-model-definition/src/test/resources/validateDeclarativePipelineStep.groovy
@@ -1,0 +1,30 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+node {
+    checkout scm
+
+    def valid = validateDeclarativePipeline("testFile.groovy")
+    echo "validation result - ${valid}"
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42168](https://issues.jenkins-ci.org/browse/JENKINS-42168)
* Description:
    * Given a path to a file containing a Declarative Pipeline to validate, this will read that file from the workspace, validate its contents, echo out relevant errors to the build log, and return true if the contents validated, or false other wise.
* Documentation changes:
    * TBD?
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
    * @jtnord 
    * @batmat 
