### PR TITLE
[JENKINS-41118] Allow specifying top level ws(...) block

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -151,6 +151,11 @@
       <artifactId>jackson2-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-matchers</artifactId>
+      <scope>test</scope>
+    </dependency>
     
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -528,6 +528,10 @@ class JSONParser implements Parser {
             j.node.get("arguments").isArray() &&
             j.node.get("arguments").size() > 0) {
             agent.variables = parseClosureMap(j.append(JsonPointer.of("arguments")))
+            // HACK FOR JENKINS-41118 to switch to "node" rather than "label" when multiple variable are set.
+            if (agent.agentType.key == "label") {
+                agent.agentType.key = "node"
+            }
         } else if (j.node.has("argument") && j.node.get("argument").isObject()) {
             agent.variables = parseValue(j.append(JsonPointer.of("argument")))
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -759,6 +759,11 @@ class ModelParser implements Parser {
                     agent.agentType = parseKey(typeMeth.method)
                     ModelASTClosureMap parsed = parseClosureMap(m.body)
                     agent.variables = parsed.variables.get(agent.agentType)
+
+                    // HACK FOR JENKINS-41118 to switch to "node" rather than "label" when multiple variable are set.
+                    if (agent.agentType.key == "label" && agent.variables instanceof ModelASTClosureMap) {
+                        agent.agentType.key = "node"
+                    }
                 }
             }
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -857,10 +857,7 @@ class ModelParser implements Parser {
         if (e instanceof ConstantExpression) {
             return ModelASTValue.fromConstant(e.value, e)
         }
-        if (e instanceof GStringExpression) {
-            return ModelASTValue.fromGString(e.text, e)
-        }
-        if (e instanceof MapExpression) {
+        if (e instanceof GStringExpression || e instanceof MapExpression) {
             return ModelASTValue.fromGString(getSourceText(e), e)
         }
         if (e instanceof VariableExpression) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/AbstractDockerAgent.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/AbstractDockerAgent.java
@@ -34,6 +34,7 @@ public abstract class AbstractDockerAgent<D extends AbstractDockerAgent<D>> exte
     protected String args = "";
     protected String registryUrl;
     protected String registryCredentialsId;
+    protected String customWorkspace;
     protected boolean reuseNode;
 
     public @Nullable
@@ -72,6 +73,15 @@ public abstract class AbstractDockerAgent<D extends AbstractDockerAgent<D>> exte
     @DataBoundSetter
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    public @CheckForNull String getCustomWorkspace() {
+        return customWorkspace;
+    }
+
+    @DataBoundSetter
+    public void setCustomWorkspace(String customWorkspace) {
+        this.customWorkspace = customWorkspace;
     }
 
     public @CheckForNull String getArgs() {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
@@ -29,11 +29,14 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 public class Label extends DeclarativeAgent<Label> {
     private String label;
+    private String customWorkspace;
 
     @DataBoundConstructor
     public Label(String label) {
@@ -43,6 +46,16 @@ public class Label extends DeclarativeAgent<Label> {
 
     public @Nullable String getLabel() {
         return label;
+    }
+
+    public @CheckForNull
+    String getCustomWorkspace() {
+        return customWorkspace;
+    }
+
+    @DataBoundSetter
+    public void setCustomWorkspace(String customWorkspace) {
+        this.customWorkspace = customWorkspace;
     }
 
     @Extension(ordinal = -800) @Symbol("label")

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/Label.java
@@ -58,7 +58,7 @@ public class Label extends DeclarativeAgent<Label> {
         this.customWorkspace = customWorkspace;
     }
 
-    @Extension(ordinal = -800) @Symbol("label")
+    @Extension(ordinal = -800) @Symbol({"label","node"})
     public static class DescriptorImpl extends DeclarativeAgentDescriptor<Label> {
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/WorkspaceDir.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/WorkspaceDir.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.options.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nullable;
+
+public class WorkspaceDir extends DeclarativeOption {
+    private String dir;
+
+    @DataBoundConstructor
+    public WorkspaceDir(String dir) {
+        this.dir = dir;
+    }
+
+    public String getDir() {
+        return dir;
+    }
+
+    @Extension @Symbol("workspaceDir")
+    public static class DescriptorImpl extends DeclarativeOptionDescriptor {
+
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -30,6 +30,7 @@ import hudson.Launcher
 import hudson.model.Result
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.impl.SkipStagesAfterUnstable
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.impl.WorkspaceDir
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional
 import org.jenkinsci.plugins.workflow.cps.CpsScript
@@ -319,9 +320,36 @@ public class ModelInterpreter implements Serializable {
             }.call()
         } else {
             return agent.getDeclarativeAgent(root, context).getScript(script).run {
-                body.call()
+                inWorkspace(context) {
+                    body.call()
+                }
             }.call()
         }
+    }
+
+    /**
+     * Allocates a new workspace if the {@link WorkspaceDir} option is set.
+     *
+     * @param context Either a stage or root object, the context we're running in.
+     * @param body The closure to execute
+     * @return The return of the resulting executed closure
+     */
+    def inWorkspace(Object context, Closure body) {
+        // This may change later to allow per-stage workspace dir configuration.
+        if (context instanceof Root) {
+            WorkspaceDir dirOpt = (WorkspaceDir)((Root)context).options?.options?.get("workspaceDir")
+            if (dirOpt != null) {
+                return {
+                    script.ws(dirOpt.dir) {
+                        body.call()
+                    }
+                }.call()
+            }
+        }
+
+        return {
+            body.call()
+        }.call()
     }
 
     /**

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -29,8 +29,6 @@ import hudson.FilePath
 import hudson.Launcher
 import hudson.model.Result
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.*
-import org.jenkinsci.plugins.pipeline.modeldefinition.options.impl.SkipStagesAfterUnstable
-import org.jenkinsci.plugins.pipeline.modeldefinition.options.impl.WorkspaceDir
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional
 import org.jenkinsci.plugins.workflow.cps.CpsScript
@@ -320,36 +318,9 @@ public class ModelInterpreter implements Serializable {
             }.call()
         } else {
             return agent.getDeclarativeAgent(root, context).getScript(script).run {
-                inWorkspace(context) {
-                    body.call()
-                }
+                body.call()
             }.call()
         }
-    }
-
-    /**
-     * Allocates a new workspace if the {@link WorkspaceDir} option is set.
-     *
-     * @param context Either a stage or root object, the context we're running in.
-     * @param body The closure to execute
-     * @return The return of the resulting executed closure
-     */
-    def inWorkspace(Object context, Closure body) {
-        // This may change later to allow per-stage workspace dir configuration.
-        if (context instanceof Root) {
-            WorkspaceDir dirOpt = (WorkspaceDir)((Root)context).options?.options?.get("workspaceDir")
-            if (dirOpt != null) {
-                return {
-                    script.ws(dirOpt.dir) {
-                        body.call()
-                    }
-                }.call()
-            }
-        }
-
-        return {
-            body.call()
-        }.call()
     }
 
     /**

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AbstractDockerPipelineScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AbstractDockerPipelineScript.groovy
@@ -48,6 +48,7 @@ public abstract class AbstractDockerPipelineScript<A extends AbstractDockerAgent
             Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: targetLabel])
             l.inStage = describable.inStage
             l.doCheckout = describable.doCheckout
+            l.customWorkspace = describable.customWorkspace
             LabelScript labelScript = (LabelScript) l.getScript(script)
             return labelScript.run {
                 configureRegistry(body).call()

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -41,22 +41,34 @@ public class LabelScript extends DeclarativeAgentScript<Label> {
         return {
             try {
                 script.node(describable?.label) {
-                    if (describable.isDoCheckout() && describable.hasScmContext(script)) {
-                        if (!describable.inStage) {
-                            script.stage(SyntheticStageNames.checkout()) {
-                                script.checkout script.scm
-                            }
-                        } else {
-                            // No stage when we're in a nested stage already
-                            script.checkout script.scm
+                    if (describable.customWorkspace != null && describable.customWorkspace != "") {
+                        script.ws(describable.customWorkspace) {
+                            checkoutAndRun(body).call()
                         }
+                    } else {
+                        checkoutAndRun(body).call()
                     }
-                    body.call()
                 }
             } catch (Exception e) {
                 script.getProperty("currentBuild").result = Result.FAILURE
                 throw e
             }
+        }
+    }
+
+    private Closure checkoutAndRun(Closure body) {
+        return {
+            if (describable.isDoCheckout() && describable.hasScmContext(script)) {
+                if (!describable.inStage) {
+                    script.stage(SyntheticStageNames.checkout()) {
+                        script.checkout script.scm
+                    }
+                } else {
+                    // No stage when we're in a nested stage already
+                    script.checkout script.scm
+                }
+            }
+            body.call()
         }
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -75,6 +75,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.jcabi.matchers.RegexMatchers.containsPattern;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assert.assertNotNull;
@@ -442,6 +443,7 @@ public abstract class AbstractModelDefTest {
         private Map<String,String> otherResources;
         private List<String> logContains;
         private List<String> logNotContains;
+        private List<String> logMatches;
         private WorkflowRun run;
         private boolean runFromRepo = true;
         private Folder folder; //We use the real stuff here, no mocking fluff
@@ -486,6 +488,15 @@ public abstract class AbstractModelDefTest {
                 logContains.addAll(Arrays.asList(logEntries));
             } else {
                 this.logContains = new ArrayList<>(Arrays.asList(logEntries));
+            }
+            return this;
+        }
+
+        public ExpectationsBuilder logMatches(String... logPatterns) {
+            if (this.logMatches != null) {
+                logMatches.addAll(Arrays.asList(logPatterns));
+            } else {
+                this.logMatches = new ArrayList<>(Arrays.asList(logPatterns));
             }
             return this;
         }
@@ -555,6 +566,12 @@ public abstract class AbstractModelDefTest {
             if (logNotContains != null) {
                 for (String logNotContain : logNotContains) {
                     j.assertLogNotContains(logNotContain, run);
+                }
+            }
+            if (logMatches != null) {
+                String log = JenkinsRule.getLog(run);
+                for (String pattern : logMatches) {
+                    assertThat(log, containsPattern(pattern));
                 }
             }
             if (hasFailureCause) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -142,7 +142,8 @@ public abstract class AbstractModelDefTest {
             "parallelPipelineWithSpaceInBranch",
             "parallelPipelineQuoteEscaping",
             "nestedTreeSteps",
-            "jsonSchemaNull"
+            "jsonSchemaNull",
+            "inCustomWorkspace"
     );
 
     public static Iterable<Object[]> configsWithErrors() {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -215,22 +215,22 @@ public abstract class AbstractModelDefTest {
     }
 
     protected void onAllowedOS(PossibleOS... osList) throws Exception {
-        boolean passed = true;
+        boolean passed = false;
         for (PossibleOS os : osList) {
             switch (os) {
                 case LINUX:
-                    if (!SystemUtils.IS_OS_LINUX) {
-                        passed = false;
+                    if (SystemUtils.IS_OS_LINUX) {
+                        passed = true;
                     }
                     break;
                 case WINDOWS:
-                    if (!SystemUtils.IS_OS_WINDOWS) {
-                        passed = false;
+                    if (SystemUtils.IS_OS_WINDOWS) {
+                        passed = true;
                     }
                     break;
                 case MAC:
-                    if (!SystemUtils.IS_OS_MAC) {
-                        passed = false;
+                    if (SystemUtils.IS_OS_MAC) {
+                        passed = true;
                     }
                     break;
                 default:

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -592,4 +592,12 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .logContains("[Pipeline] { (promote)", "Scheduling project")
                 .go();
     }
+
+    @Issue("JENKINS-41118")
+    @Test
+    public void inWorkspace() throws Exception {
+        expect("inWorkspace")
+                .logMatches("Workspace dir is .*some-sub-dir")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -605,6 +605,15 @@ public class BasicModelDefTest extends AbstractModelDefTest {
 
     @Issue("JENKINS-41118")
     @Test
+    public void inRelativeCustomWorkspace() throws Exception {
+        onAllowedOS(PossibleOS.LINUX, PossibleOS.MAC);
+        expect("inRelativeCustomWorkspace")
+                .logMatches("Workspace dir is .*relative/custom2/workspace3")
+                .go();
+    }
+
+    @Issue("JENKINS-41118")
+    @Test
     public void inAbsoluteCustomWorkspace() throws Exception {
         // Since we're using a Unix path, only run on a Unix environment
         onAllowedOS(PossibleOS.LINUX, PossibleOS.MAC);

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -595,8 +595,16 @@ public class BasicModelDefTest extends AbstractModelDefTest {
 
     @Issue("JENKINS-41118")
     @Test
-    public void inWorkspace() throws Exception {
-        expect("inWorkspace")
+    public void inCustomWorkspace() throws Exception {
+        expect("inCustomWorkspace")
+                .logMatches("Workspace dir is .*some-sub-dir")
+                .go();
+    }
+
+    @Issue("JENKINS-41118")
+    @Test
+    public void inCustomWorkspaceInStage() throws Exception {
+        expect("inCustomWorkspaceInStage")
                 .logMatches("Workspace dir is .*some-sub-dir")
                 .go();
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -27,6 +27,7 @@ import com.google.common.base.Predicate;
 import hudson.model.Result;
 import hudson.model.Slave;
 import jenkins.plugins.git.GitSCMSource;
+import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTNamedArgumentList;
@@ -53,6 +54,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
 import java.util.Arrays;
+import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -599,6 +601,20 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         expect("inCustomWorkspace")
                 .logMatches("Workspace dir is .*some-sub-dir")
                 .go();
+    }
+
+    @Issue("JENKINS-41118")
+    @Test
+    public void inAbsoluteCustomWorkspace() throws Exception {
+        // Since we're using a Unix path, only run on a Unix environment
+        onAllowedOS(PossibleOS.LINUX, PossibleOS.MAC);
+        try {
+            expect("inAbsoluteCustomWorkspace")
+                    .logContains("Workspace dir is /tmp/some-sub-dir")
+                    .go();
+        } finally {
+            FileUtils.deleteDirectory(new File("/tmp/some-sub-dir"));
+        }
     }
 
     @Issue("JENKINS-41118")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParserTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParserTest.java
@@ -1,10 +1,13 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.parser;
 
+import net.sf.json.JSONObject;
 import org.codehaus.groovy.control.ErrorCollector;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.jenkinsci.plugins.pipeline.modeldefinition.BaseParserLoaderTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.Messages;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import static org.junit.Assert.*;
 
@@ -31,4 +34,33 @@ public class ModelParserTest extends BaseParserLoaderTest {
         assertTrue(msg.contains(Messages.ModelParser_ExpectedStringLiteral()));
         assertFalse(msg.contains("Exception")); // we don't want stack trace please
     }
+
+    @Issue("JENKINS-41118")
+    @Test
+    public void labelWithOptionsBecomesNode() throws Exception {
+        ModelASTPipelineDef origRoot = Converter.urlToPipelineDef(getClass().getResource("/inRelativeCustomWorkspace.groovy"));
+
+        assertNotNull(origRoot);
+
+        JSONObject origJson = origRoot.toJSON();
+        assertNotNull(origJson);
+
+        JSONParser jp = new JSONParser(Converter.jsonTreeFromJSONObject(origJson));
+        ModelASTPipelineDef newRoot = jp.parse();
+
+        assertEquals(getJSONErrorReport(jp, "inRelativeCustomWorkspace"), 0, jp.getErrorCollector().getErrorCount());
+        assertNotNull("Pipeline null for inRelativeCustomWorkspace", newRoot);
+
+        JSONObject nodeJson = JSONObject.fromObject(fileContentsFromResources("json/inRelativeCustomWorkspace.json"));
+
+        JSONParser nodeParser = new JSONParser(Converter.jsonTreeFromJSONObject(nodeJson));
+        ModelASTPipelineDef nodeRoot = nodeParser.parse();
+
+        assertEquals(getJSONErrorReport(nodeParser, "inRelativeCustomWorkspace"),
+                0, nodeParser.getErrorCollector().getErrorCount());
+        assertNotNull("Pipeline null for inRelativeCustomWorkspace", nodeRoot);
+
+        assertEquals(nodeRoot, newRoot);
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/inAbsoluteCustomWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/inAbsoluteCustomWorkspace.groovy
@@ -24,7 +24,7 @@
 
 pipeline {
     agent {
-        label {
+        node {
             label ""
             customWorkspace "/tmp/some-sub-dir"
         }

--- a/pipeline-model-definition/src/test/resources/inAbsoluteCustomWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/inAbsoluteCustomWorkspace.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label {
+            label ""
+            customWorkspace "/tmp/some-sub-dir"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "Workspace dir is ${pwd()}"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/inCustomWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/inCustomWorkspace.groovy
@@ -23,9 +23,11 @@
  */
 
 pipeline {
-    agent any
-    options {
-        workspaceDir("some-sub-dir")
+    agent {
+        label {
+            label ""
+            customWorkspace "some-sub-dir"
+        }
     }
     stages {
         stage("foo") {

--- a/pipeline-model-definition/src/test/resources/inCustomWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/inCustomWorkspace.groovy
@@ -24,7 +24,7 @@
 
 pipeline {
     agent {
-        label {
+        node {
             label ""
             customWorkspace "some-sub-dir"
         }

--- a/pipeline-model-definition/src/test/resources/inCustomWorkspaceInStage.groovy
+++ b/pipeline-model-definition/src/test/resources/inCustomWorkspaceInStage.groovy
@@ -22,30 +22,22 @@
  * THE SOFTWARE.
  */
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.options.impl;
-
-import hudson.Extension;
-import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
-import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
-import org.kohsuke.stapler.DataBoundConstructor;
-
-import javax.annotation.Nullable;
-
-public class WorkspaceDir extends DeclarativeOption {
-    private String dir;
-
-    @DataBoundConstructor
-    public WorkspaceDir(String dir) {
-        this.dir = dir;
-    }
-
-    public String getDir() {
-        return dir;
-    }
-
-    @Extension @Symbol("workspaceDir")
-    public static class DescriptorImpl extends DeclarativeOptionDescriptor {
-
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            agent {
+                label {
+                    label ""
+                    customWorkspace "some-sub-dir"
+                }
+            }
+            steps {
+                echo "Workspace dir is ${pwd()}"
+            }
+        }
     }
 }
+
+
+

--- a/pipeline-model-definition/src/test/resources/inCustomWorkspaceInStage.groovy
+++ b/pipeline-model-definition/src/test/resources/inCustomWorkspaceInStage.groovy
@@ -27,7 +27,7 @@ pipeline {
     stages {
         stage("foo") {
             agent {
-                label {
+                node {
                     label ""
                     customWorkspace "some-sub-dir"
                 }

--- a/pipeline-model-definition/src/test/resources/inRelativeCustomWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/inRelativeCustomWorkspace.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label {
+            label ""
+            customWorkspace "./relative/custom/workspace/../../custom2/workspace2/./../workspace3"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "Workspace dir is ${pwd()}"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/inRelativeCustomWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/inRelativeCustomWorkspace.groovy
@@ -24,6 +24,7 @@
 
 pipeline {
     agent {
+        // This is still deliberately 'label' here for testing label->node conversion in ModelParserTest#labelWithOptionsBecomesNode
         label {
             label ""
             customWorkspace "./relative/custom/workspace/../../custom2/workspace2/./../workspace3"

--- a/pipeline-model-definition/src/test/resources/inWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/inWorkspace.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    options {
+        workspaceDir("some-sub-dir")
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "Workspace dir is ${pwd()}"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/json/inCustomWorkspace.json
+++ b/pipeline-model-definition/src/test/resources/json/inCustomWorkspace.json
@@ -1,0 +1,37 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "echo",
+        "arguments": [        {
+          "key": "message",
+          "value":           {
+            "isLiteral": false,
+            "value": "\"Workspace dir is ${pwd()}\""
+          }
+        }]
+      }]
+    }]
+  }],
+  "agent":   {
+    "type": "node",
+    "arguments":     [
+      {
+        "key": "label",
+        "value":         {
+          "isLiteral": true,
+          "value": ""
+        }
+      },
+      {
+        "key": "customWorkspace",
+        "value":         {
+          "isLiteral": true,
+          "value": "some-sub-dir"
+        }
+      }
+    ]
+  }
+}}

--- a/pipeline-model-definition/src/test/resources/json/inRelativeCustomWorkspace.json
+++ b/pipeline-model-definition/src/test/resources/json/inRelativeCustomWorkspace.json
@@ -1,0 +1,37 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "echo",
+        "arguments": [        {
+          "key": "message",
+          "value":           {
+            "isLiteral": false,
+            "value": "\"Workspace dir is ${pwd()}\""
+          }
+        }]
+      }]
+    }]
+  }],
+  "agent":   {
+    "type": "node",
+    "arguments":     [
+      {
+        "key": "label",
+        "value":         {
+          "isLiteral": true,
+          "value": ""
+        }
+      },
+      {
+        "key": "customWorkspace",
+        "value":         {
+          "isLiteral": true,
+          "value": "./relative/custom/workspace/../../custom2/workspace2/./../workspace3"
+        }
+      }
+    ]
+  }
+}}

--- a/pipeline-model-extensions/pom.xml
+++ b/pipeline-model-extensions/pom.xml
@@ -40,6 +40,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
     </dependency>

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -26,8 +26,9 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
 
 import hudson.ExtensionPoint;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptDescribable;
+import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptScript;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
-import org.kohsuke.stapler.DataBoundSetter;
+import org.jenkinsci.plugins.workflow.cps.CpsThread;
 
 /**
  * Implementations for {@link DeclarativeAgentDescriptor} - pluggable agent backends for Declarative Pipelines.
@@ -37,6 +38,17 @@ import org.kohsuke.stapler.DataBoundSetter;
 public abstract class DeclarativeAgent<A extends DeclarativeAgent<A>> extends WithScriptDescribable<A> implements ExtensionPoint {
     protected boolean inStage;
     protected boolean doCheckout;
+
+    @Override
+    public WithScriptScript getScript(CpsScript cpsScript) throws Exception {
+        CpsThread c = CpsThread.current();
+        if (c == null)
+            throw new IllegalStateException("Expected to be called from CpsThread");
+
+        cpsScript.getClass().getClassLoader().loadClass("org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript");
+
+        return super.getScript(cpsScript);
+    }
 
     public void setInStage(boolean inStage) {
         this.inStage = inStage;

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,11 @@
         <artifactId>mockito-core</artifactId>
         <version>2.2.5</version>
       </dependency>
+      <dependency>
+        <groupId>com.jcabi</groupId>
+        <artifactId>jcabi-matchers</artifactId>
+        <version>1.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/rfc/JENKINS-41118-custom-workspaces.md
+++ b/rfc/JENKINS-41118-custom-workspaces.md
@@ -1,0 +1,72 @@
+## RFC: [JENKINS-41118](https://issues.jenkins-ci.org/browse/JENKINS-41118) - custom workspaces in Declarative
+
+* Author: Andrew Bayer
+* Created Date: February 23, 2017
+* Approved Date: n/a
+* JIRA: [JENKINS-41118](https://issues.jenkins-ci.org/browse/JENKINS-41118)
+* Status: Draft
+
+### Problem Statement
+
+As described in the ticket, there are multiple reasons why one 
+may want to use a hardcoded workspace directory under
+`$JENKINS_HOME/workspace` for a Pipeline, such as reusing the
+same checkout of a very large repository, or guaranteeing a
+certain full directory layout to make Golang happy, etc. This
+may be needed both at the top level and per-stage, so that
+individual stages could have a custom workspace when they had
+their own agent configuration as well.
+
+### Runtime Implementation
+
+The actual runtime implementation is very clear - if a custom
+workspace is specified, then immediately after entering the
+relevant `node` block and before doing a `checkout scm`, we
+would enter a `ws('some-dir')` block. 
+
+### Syntax
+
+#### Option Name
+
+Regardless of where the option ends up living in the syntax, I
+propose that it be named `customWorkspace`. This maps to the
+Freestyle "Custom Workspace" option, which is analogous to the
+behavior of the `ws(...)` step (though not exactly, since
+"Custom Workspace" is an absolute path while `ws(...)` is
+relative to the workspace root on the agent).
+
+#### Where the Option is Specified
+The easiest place to add this option so that it would be
+available for use anywhere an `agent` could be specified would
+be in the `agent` itself, as an additional option on relevant
+`DeclarativeAgent` types. That would currently mean `label`,
+`docker`, and `dockerfile` - `any` is a special alias for
+`label ''` and can't be modified, and this would not be
+relevant for `none`. 
+
+For `docker` and `dockerfile`, adding an additional option is 
+trivial, given that they already have additional options for 
+`args` etc. But for `label`, this would be the first additional 
+option and so would create the first case of specifying `label` 
+with a block. However, the block form of `label` actually works 
+currently - `label 'something'` is in fact just a shortcut for 
+`label { label 'something' }` behind the scenes.
+
+#### Examples
+
+```groovy
+agent {
+    label {
+        label "some-label" // This could be changed to something other than "label"
+        customWorkspace "some/path"
+    }
+}
+
+agent {
+    docker {
+        image "some-image"
+        args "-v /tmp:/tmp -p 80:80"
+        customWorkspace "some/path"
+    }
+}
+```

--- a/rfc/JENKINS-41118-custom-workspaces.md
+++ b/rfc/JENKINS-41118-custom-workspaces.md
@@ -53,6 +53,16 @@ with a block. However, the block form of `label` actually works
 currently - `label 'something'` is in fact just a shortcut for 
 `label { label 'something' }` behind the scenes.
 
+In order to address the ugliness of `label { label 'something'; customWorkspace 'some/path' }`,
+we will add an additional `@Symbol` to the `label` agent type,
+`node`. It'll be fully compatible with `label` - either can be
+used interchangeably. But the JSON and Groovy parsers will 
+automatically switch from `label` to `node` if it's used with
+multiple options, i.e., in the block form. This will result in 
+it not mattering at all what symbol the editor is using, because
+it will serialize out as `node` when it's got a block no matter
+what.
+
 #### Alternatives
 
 Perhaps the best alternative to `agent` configuration would be 
@@ -65,7 +75,7 @@ to be configured per-stage currently.
 
 ```groovy
 agent {
-    label {
+    node {
         label "some-label" // This could be changed to something other than "label"
         customWorkspace "some/path"
     }

--- a/rfc/JENKINS-41118-custom-workspaces.md
+++ b/rfc/JENKINS-41118-custom-workspaces.md
@@ -2,9 +2,10 @@
 
 * Author: Andrew Bayer
 * Created Date: February 23, 2017
-* Approved Date: n/a
+* Approved Date: March 2, 2017
+* Target Release: 1.1
 * JIRA: [JENKINS-41118](https://issues.jenkins-ci.org/browse/JENKINS-41118)
-* Status: Draft
+* Status: Approved
 
 ### Problem Statement
 

--- a/rfc/JENKINS-41118-custom-workspaces.md
+++ b/rfc/JENKINS-41118-custom-workspaces.md
@@ -36,6 +36,7 @@ behavior of the `ws(...)` step (though not exactly, since
 relative to the workspace root on the agent).
 
 #### Where the Option is Specified
+
 The easiest place to add this option so that it would be
 available for use anywhere an `agent` could be specified would
 be in the `agent` itself, as an additional option on relevant
@@ -51,6 +52,14 @@ option and so would create the first case of specifying `label`
 with a block. However, the block form of `label` actually works 
 currently - `label 'something'` is in fact just a shortcut for 
 `label { label 'something' }` behind the scenes.
+
+#### Alternatives
+
+Perhaps the best alternative to `agent` configuration would be 
+to have the custom workspace specified as a top-level and 
+per-stage option. This would require adding an `options` 
+section for `stage`, since we don't have anywhere for options 
+to be configured per-stage currently. 
 
 #### Examples
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-41118](https://issues.jenkins-ci.org/browse/JENKINS-41118)
* Description:
    * Enables custom workspaces in Declarative as an `agent` option.
* RFC document:
    * https://github.com/abayer/pipeline-model-definition-plugin/blob/jenkins-41118/rfc/JENKINS-41118-custom-workspaces.md
* Documentation changes:
    * Doc update will be needed for the new `customWorkspace` option for `label`, `docker` and `dockerfile`.
    * [x] Doc PR up - [jenkins.io PR #715](https://github.com/jenkins-infra/jenkins.io/pull/715)
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
