### PR TITLE
[FIXED JENKINS-42286] Allow dir separator in Dockerfile name

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -588,13 +588,6 @@ class ModelValidatorImpl implements ModelValidator {
                         }
                     }
                     map.variables.each { k, v ->
-                        // TODO: JENKINS-41746 - get rid of this hardcoding and use extensible validation instead once we can
-                        if (typeName == "dockerfile") {
-                            if (k.key == "filename" && (v.toGroovy().contains("/") || v.toGroovy().contains("\\"))) {
-                                errorCollector.error(k, Messages.ModelValidatorImpl_DirSeparatorInDockerfileName())
-                                valid = false
-                            }
-                        }
                         // Make sure we don't actually include "context" in the valid param names, since, well, it's
                         // not really one.
                         List<String> validParamNames = model.parameters.collect { it.name }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -218,6 +218,26 @@ public class AgentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-42286")
+    @Test
+    public void dirSepInDockerfileName() throws Exception {
+        assumeDocker();
+        // Bind mounting /var on OS X doesn't work at the moment
+        onAllowedOS(PossibleOS.LINUX);
+
+        sampleRepo.write("subdir/Dockerfile", "FROM ubuntu:14.04\n\nRUN echo 'HI THERE' > /hi-there\n\n");
+        sampleRepo.git("init");
+        sampleRepo.git("add", "subdir/Dockerfile");
+        sampleRepo.git("commit", "--message=Dockerfile");
+
+        expect("fromDockerfileInOtherDir")
+                .logContains("[Pipeline] { (foo)",
+                        "The answer is 42",
+                        "-v /tmp:/tmp -p 8000:8000",
+                        "HI THERE")
+                .go();
+    }
+
     @Test
     public void fromDockerfileNoArgs() throws Exception {
         assumeDocker();

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -484,14 +484,6 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .go();
     }
 
-    @Issue("JENKINS-41668")
-    @Test
-    public void dirSepInDockerfileName() throws Exception {
-        expectError("dirSepInDockerfileName")
-                .logContains(Messages.ModelValidatorImpl_DirSeparatorInDockerfileName())
-                .go();
-    }
-
     @Issue("JENKINS-41645")
     @Test
     public void invalidEnvironmentIdentifiers() throws Exception {

--- a/pipeline-model-definition/src/test/resources/dirSepInDockerfileName.groovy
+++ b/pipeline-model-definition/src/test/resources/dirSepInDockerfileName.groovy
@@ -25,7 +25,7 @@
 pipeline {
     agent {
         dockerfile {
-            filename "Dockerfile/alternate"
+            filename "subdir/Dockerfile"
             args "-v /tmp:/tmp -p 8000:8000"
         }
     }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42286](https://issues.jenkins-ci.org/browse/JENKINS-42286)
* Description:
    * Turns out this was a regression we shouldn't have allowed - directory separators should be allowed in the `Dockerfile` filename.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
