### PR TITLE
[JENKINS-38110] Add a libraries section

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTLibraries.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTLibraries.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A container for one or more library strings
+ *
+ * @author Andrew Bayer
+ */
+public final class ModelASTLibraries extends ModelASTElement {
+    private List<ModelASTValue> libs = new ArrayList<>();
+
+    public ModelASTLibraries(Object sourceLocation) {
+        super(sourceLocation);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        final JSONArray a = new JSONArray();
+        for (ModelASTValue v : libs) {
+            a.add(v.toJSON());
+        }
+        return new JSONObject().accumulate("libraries", a);
+    }
+
+    @Override
+    public void validate(final ModelValidator validator) {
+        validator.validateElement(this);
+        for (ModelASTValue v : libs) {
+            v.validate(validator);
+        }
+    }
+
+    @Override
+    public String toGroovy() {
+        StringBuilder result = new StringBuilder("libraries {\n");
+        for (ModelASTValue v : libs) {
+            result.append("lib(").append(v.toGroovy()).append(")\n");
+        }
+        result.append("}\n");
+        return result.toString();
+    }
+
+    @Override
+    public void removeSourceLocation() {
+        super.removeSourceLocation();
+        for (ModelASTValue v : libs) {
+            v.removeSourceLocation();
+        }
+    }
+
+    public List<ModelASTValue> getLibs() {
+        return libs;
+    }
+
+    public void setLibs(List<ModelASTValue> libs) {
+        this.libs = libs;
+    }
+
+    @Override
+    public String toString() {
+        return "ModelASTLibraries{" +
+                "libs=" + libs +
+                "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ModelASTLibraries that = (ModelASTLibraries) o;
+
+        return getLibs() != null ? getLibs().equals(that.getLibs()) : that.getLibs() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getLibs() != null ? getLibs().hashCode() : 0);
+        return result;
+    }
+}

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
@@ -19,6 +19,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
     private ModelASTOptions options;
     private ModelASTBuildParameters parameters;
     private ModelASTTriggers triggers;
+    private ModelASTLibraries libraries;
 
     public ModelASTPipelineDef(Object sourceLocation) {
         super(sourceLocation);
@@ -46,6 +47,11 @@ public final class ModelASTPipelineDef extends ModelASTElement {
             a.put("triggers", triggers.toJSON());
         } else {
             a.put("triggers", null);
+        }
+        if (libraries != null && !libraries.getLibs().isEmpty()) {
+            a.put("libraries", libraries.toJSON());
+        } else {
+            a.put("libraries", null);
         }
         return new JSONObject().accumulate("pipeline", a);
     }
@@ -78,6 +84,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         if (triggers != null) {
             triggers.validate(validator);
         }
+        if (libraries != null) {
+            libraries.validate(validator);
+        }
     }
 
     @Override
@@ -86,6 +95,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         result.append("pipeline {\n");
         if (agent != null) {
             result.append(agent.toGroovy());
+        }
+        if (libraries != null) {
+            result.append(libraries.toGroovy());
         }
         if (stages != null) {
             result.append(stages.toGroovy());
@@ -161,6 +173,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         if (stages != null) {
             stages.removeSourceLocation();
         }
+        if (libraries != null) {
+            libraries.removeSourceLocation();
+        }
         if (postBuild != null) {
             postBuild.removeSourceLocation();
         }
@@ -191,6 +206,14 @@ public final class ModelASTPipelineDef extends ModelASTElement {
 
     public void setStages(ModelASTStages stages) {
         this.stages = stages;
+    }
+
+    public ModelASTLibraries getLibraries() {
+        return libraries;
+    }
+
+    public void setLibraries(ModelASTLibraries libraries) {
+        this.libraries = libraries;
     }
 
     public ModelASTPostBuild getPostBuild() {
@@ -261,6 +284,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
                 ", options=" + options +
                 ", parameters=" + parameters +
                 ", triggers=" + triggers +
+                ", libraries=" + libraries +
                 "}";
     }
 
@@ -303,6 +327,9 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         if (getParameters() != null ? !getParameters().equals(that.getParameters()) : that.getParameters() != null) {
             return false;
         }
+        if (getLibraries() != null ? !getLibraries().equals(that.getLibraries()) : that.getLibraries() != null) {
+            return false;
+        }
         return getTriggers() != null ? getTriggers().equals(that.getTriggers()) : that.getTriggers() == null;
 
     }
@@ -318,6 +345,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
         result = 31 * result + (getOptions() != null ? getOptions().hashCode() : 0);
         result = 31 * result + (getParameters() != null ? getParameters().hashCode() : 0);
         result = 31 * result + (getTriggers() != null ? getTriggers().hashCode() : 0);
+        result = 31 * result + (getLibraries() != null ? getLibraries().hashCode() : 0);
         return result;
     }
 }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
@@ -34,6 +34,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildParameter
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildParameters;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTClosureMap;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTEnvironment;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTLibraries;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall;
@@ -89,6 +90,8 @@ public interface ModelValidator {
     boolean validateElement(ModelASTStage stage);
 
     boolean validateElement(ModelASTStages stages);
+
+    boolean validateElement(ModelASTLibraries libraries);
 
     boolean validateWhenCondition(ModelASTStep condition);
 }

--- a/pipeline-model-api/src/main/resources/ast-schema.json
+++ b/pipeline-model-api/src/main/resources/ast-schema.json
@@ -156,6 +156,14 @@
         }
       ]
     },
+    "libraries": {
+      "description": "One or more shared library identifiers to load",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
     "options": {
       "description": "One or more options (including job properties, wrappers, and options specific to Declarative Pipelines)",
       "type": "object",
@@ -440,6 +448,9 @@
         },
         "parameters": {
           "$ref": "#/definitions/parameters"
+        },
+        "libraries": {
+          "$ref": "#/definitions/libraries"
         }
       },
       "required": [

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -110,13 +110,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
     </dependency>
-
-    <!-- TEST deps -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
-      <scope>test</scope>
     </dependency>
+
+    <!-- TEST deps -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Libraries.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Libraries.groovy
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.model
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+
+
+/**
+ * A container for one or more library identifiers, within the build, in the order they're declared.
+ *
+ * @author Andrew Bayer
+ */
+@ToString
+@EqualsAndHashCode
+@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
+public class Libraries implements Serializable {
+    List<String> libs = []
+
+    Libraries libs(List<String> s) {
+        this.libs = s
+        return this
+    }
+
+    List<String> getLibs() {
+        return libs
+    }
+}

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -55,6 +55,8 @@ public class Root implements NestedModel, Serializable {
 
     Parameters parameters
 
+    Libraries libraries
+
     Root stages(Stages s) {
         this.stages = s
         return this
@@ -92,6 +94,11 @@ public class Root implements NestedModel, Serializable {
 
     Root parameters(Parameters p) {
         this.parameters = p
+        return this
+    }
+
+    Root libraries(Libraries l) {
+        this.libraries = l
         return this
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -116,6 +116,9 @@ class JSONParser implements Parser {
                     case 'parameters':
                         pipelineDef.parameters = parseBuildParameters(pipelineJson.append(JsonPointer.of("parameters")))
                         break
+                    case 'libraries':
+                        pipelineDef.libraries = parseLibraries(pipelineJson.append(JsonPointer.of("libraries")))
+                        break
                     default:
                         errorCollector.error(pipelineDef, Messages.Parser_UndefinedSection(sectionName))
                 }
@@ -199,6 +202,18 @@ class JSONParser implements Parser {
             when.conditions.add(parseStep(condTree))
         }
         return when
+    }
+
+    public @CheckForNull ModelASTLibraries parseLibraries(JsonTree j) {
+        ModelASTLibraries l = new ModelASTLibraries(j)
+
+        JsonTree libsTree = j.append(JsonPointer.of("libraries"))
+        libsTree.node.eachWithIndex { JsonNode entry, int i ->
+            JsonTree thisNode = libsTree.append(JsonPointer.of(i))
+            l.libs.add(ModelASTValue.fromConstant(thisNode.node.asText(), thisNode))
+        }
+
+        return l
     }
 
     public @CheckForNull ModelASTOptions parseOptions(JsonTree j) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -178,6 +178,21 @@ class ModelValidatorImpl implements ModelValidator {
         return valid
     }
 
+    public boolean validateElement(ModelASTLibraries libraries) {
+        boolean valid = true
+
+        if (libraries.libs.isEmpty()) {
+            errorCollector.error(libraries, Messages.ModelValidatorImpl_EmptySection("libraries"))
+            valid = false
+        } else {
+            libraries.libs.each { l ->
+                // TODO: Decide what validation, if any, we want to do for library identifiers.
+            }
+        }
+
+        return valid
+    }
+
     public boolean validateWhenCondition(ModelASTStep condition) {
         def allNames = DeclarativeStageConditionalDescriptor.allNames()
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ClosureModelTranslator.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.AbstractBuildConditionResponder
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.ClosureContentsChecker
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Environment
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Libraries
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.MappedClosure
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.MethodMissingWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.MethodsToList
@@ -158,6 +159,11 @@ public class ClosureModelTranslator implements MethodMissingWrapper, Serializabl
                         def mtl = new MethodsToListTranslator(script, actualType)
                         resolveClosure(argValue, mtl)
                         resultValue = mtl.toListModel(actualType)
+                    }
+                    else if (Utils.assignableFromWrapper(Libraries.class, actualType)) {
+                        def lt = new LibrariesTranslator(script)
+                        resolveClosure(argValue, lt)
+                        resultValue = lt.toListModel()
                     }
                     // And lastly, recurse - this must be another container block.
                     else {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTranslator.groovy
@@ -29,7 +29,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.Libraries
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 /**
- * Translates a closure containing a sequence of "library('string')" calls into an instance of {@link Libraries}.
+ * Translates a closure containing a sequence of "lib('string')" calls into an instance of {@link Libraries}.
  *
  * @author Andrew Bayer
  */

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTranslator.groovy
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.jenkinsci.plugins.pipeline.modeldefinition
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Libraries
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+/**
+ * Translates a closure containing a sequence of "library('string')" calls into an instance of {@link Libraries}.
+ *
+ * @author Andrew Bayer
+ */
+public class LibrariesTranslator implements Serializable {
+    List<String> actualList = []
+    CpsScript script
+
+    LibrariesTranslator(CpsScript script) {
+        this.script = script
+    }
+
+    def lib(String l) {
+        actualList.add(l)
+    }
+
+    Libraries toListModel() {
+        Libraries l = new Libraries()
+        l.libs(actualList)
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -27,6 +27,7 @@ PipelineModelDefinition.DisplayName=Pipeline Model Definition
 DeclarativeLinterCommand.ShortDescription=Validate a Jenkinsfile containing a Declarative Pipeline
 
 Parser.BuildParameters=Build parameters
+Parser.Libraries=Libraries
 Parser.Options=Options
 Parser.MultipleOfSection=Multiple occurrences of the {0} section
 Parser.Triggers=Triggers
@@ -40,6 +41,7 @@ ModelParser.ExpectedBlock=Expected a block
 ModelParser.ExpectedBuildParameter=Expected a build parameter definition
 ModelParser.ExpectedClosureOrFailFast=Expected closure or failFast
 ModelParser.ExpectedFailFast=Expected a boolean with failFast
+ModelParser.ExpectedLibrary=Expected a "library(...)" but got "{0}"
 ModelParser.ExpectedMapMethod=Expected to find 'someKey "someValue"'
 ModelParser.ExpectedOption=Expected an option
 ModelParser.ExpectedNVPairs=Expected name=value pairs

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -41,7 +41,7 @@ ModelParser.ExpectedBlock=Expected a block
 ModelParser.ExpectedBuildParameter=Expected a build parameter definition
 ModelParser.ExpectedClosureOrFailFast=Expected closure or failFast
 ModelParser.ExpectedFailFast=Expected a boolean with failFast
-ModelParser.ExpectedLibrary=Expected a "library(...)" but got "{0}"
+ModelParser.ExpectedLibrary=Expected a "lib(...)" but got {0}
 ModelParser.ExpectedMapMethod=Expected to find 'someKey "someValue"'
 ModelParser.ExpectedOption=Expected an option
 ModelParser.ExpectedNVPairs=Expected name=value pairs

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -66,6 +66,8 @@ public class ModelInterpreter implements Serializable {
             boolean postBuildRun = false
 
             try {
+                loadLibraries(root)
+
                 executeProperties(root)
 
                 // Entire build, including notifications, runs in the withEnv.
@@ -472,6 +474,21 @@ public class ModelInterpreter implements Serializable {
         }
 
         return stageError
+    }
+
+    /**
+     * Load specified libraries.
+     *
+     * @param root The root context we're running in
+     */
+    def loadLibraries(Root root) {
+        if (root.libraries != null) {
+            for (int i = 0; i < root.libraries.libs.size(); i++) {
+                String lib = root.libraries.libs.get(i)
+                // TODO: Actually *do* this. Gotta wait for workflow-cps-global-lib-plugin release.
+                // script.library(lib)
+            }
+        }
     }
 
     /**

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -487,6 +487,7 @@ public class ModelInterpreter implements Serializable {
                 String lib = root.libraries.libs.get(i)
                 // TODO: Actually *do* this. Gotta wait for workflow-cps-global-lib-plugin release.
                 // script.library(lib)
+                script.echo("LOADING LIBRARY ${lib}")
             }
         }
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -485,9 +485,7 @@ public class ModelInterpreter implements Serializable {
         if (root.libraries != null) {
             for (int i = 0; i < root.libraries.libs.size(); i++) {
                 String lib = root.libraries.libs.get(i)
-                // TODO: Actually *do* this. Gotta wait for workflow-cps-global-lib-plugin release.
-                // script.library(lib)
-                script.echo("LOADING LIBRARY ${lib}")
+                script.library(lib)
             }
         }
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -93,6 +93,7 @@ public abstract class AbstractModelDefTest {
     public static JenkinsRule j = new JenkinsRule();
     @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
     @Rule public GitSampleRepoRule otherRepo = new GitSampleRepoRule();
+    @Rule public GitSampleRepoRule thirdRepo = new GitSampleRepoRule();
 
     @Inject
     WorkflowLibRepository globalLibRepo;

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -506,6 +506,24 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-38110")
+    @Test
+    public void librariesDirective() throws Exception {
+        otherRepo.init();
+        otherRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
+        otherRepo.write("vars/myecho.txt", "Says something very special!");
+        otherRepo.git("add", "vars");
+        otherRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(
+                new LibraryConfiguration("echo-utils",
+                        new SCMSourceRetriever(new GitSCMSource(null, otherRepo.toString(), "", "*", "", true)))));
+
+        expect("librariesDirective")
+                // TODO: Actually check for the echo once library step is in
+                .logContains("LOADING LIBRARY echo-utils")
+                .go();
+    }
+
     @Issue("JENKINS-40657")
     @Test
     public void libraryObjectInScript() throws Exception {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -528,4 +528,22 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-38110")
+    @Test
+    public void emptyLibrariesDirective() throws Exception {
+        expectError("emptyLibrariesDirective")
+                .logContains(Messages.ModelValidatorImpl_EmptySection("libraries"))
+                .go();
+    }
+
+    @Issue("JENKINS-38110")
+    @Test
+    public void invalidLibrariesDirectiveContent() throws Exception {
+        expectError("invalidLibrariesDirectiveContent")
+                .logContains(Messages.ModelValidatorImpl_EmptySection("libraries"),
+                        Messages.ModelParser_ExpectedLibrary("\"oh hi there\""),
+                        Messages.ModelParser_ExpectedLibrary("foo('bar')"),
+                        Messages.ModelParser_ExpectedLibrary("1 + 2"))
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/errors/emptyLibrariesDirective.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/emptyLibrariesDirective.groovy
@@ -1,0 +1,39 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    libraries {
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "Moving on"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/invalidLibrariesDirectiveContent.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidLibrariesDirectiveContent.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    libraries {
+        "oh hi there"
+        foo('bar')
+        1 + 2
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "Moving on"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/librariesDirective.groovy
+++ b/pipeline-model-definition/src/test/resources/librariesDirective.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    libraries {
+        lib("echo-utils")
+    }
+    stages {
+        stage("foo") {
+            steps {
+                // TODO: Actually use the function instead once library step is in.
+                // myecho()
+                echo "Moving on"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/librariesDirective.groovy
+++ b/pipeline-model-definition/src/test/resources/librariesDirective.groovy
@@ -25,14 +25,14 @@
 pipeline {
     agent none
     libraries {
-        lib("echo-utils")
+        lib("echo-utils@master")
+        lib("whereFrom")
     }
     stages {
         stage("foo") {
             steps {
-                // TODO: Actually use the function instead once library step is in.
-                // myecho()
-                echo "Moving on"
+                myecho()
+                whereFrom()
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps-global-lib</artifactId>
-        <version>2.5</version>
+        <version>2.7-20170301.201004-1</version> <!-- TODO: Update to 2.7 once released -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps-global-lib</artifactId>
-        <version>2.7-20170301.201004-1</version> <!-- TODO: Update to 2.7 once released -->
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-38110](https://issues.jenkins-ci.org/browse/JENKINS-38110)
* Description:
    * Initial work on adding a `libraries` section to Declarative. Current syntax looks like:
```groovy
libraries {
    lib('foo@1.2.3')
    lib('bar')
}
```
Yes, I'd prefer not to have that pointless `lib` there, but the alternative is something like `libraries 'foo@1.2.3', 'bar'` and as we may remember from `agent` back in the day, I do not care for that syntax at _all_. Plus, we may end up wanting to include the ability to specify a `LibraryRetriever` (see [LibraryRetriever.java in workflow-cps-global-lib](https://github.com/jenkinsci/workflow-cps-global-lib-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java) for details), in which case going to `lib(identifier:'foo@1.2.3', retriever:[$class:...])` is a much better option than anything else I could find.
* Documentation changes:
    * Oh my yes will there need to be doc changes. But not 'til this actually is much closer to done.
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
    * @bitwiseman 
    * @HRMPW 
    * @kzantow @michaelneale @i386 (particularly for editor/BO concerns)
