### PR TITLE
[FIXED JENKINS-42470] Use CrumbExclusion and Jenkins.READ perms

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Collections;
 
 import static org.jenkinsci.plugins.pipeline.modeldefinition.util.IsJsonObjectContaining.hasEntry;
@@ -86,7 +87,7 @@ public class WhenStageTest extends AbstractModelDefTest {
     public void toJson() throws IOException {
         final String rawJenkinsfile = fileContentsFromResources("when/simpleWhen.groovy", true);
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJson"), HttpMethod.POST);
 
         assertNotNull(rawJenkinsfile);
 
@@ -101,7 +102,7 @@ public class WhenStageTest extends AbstractModelDefTest {
         assertThat(result, hasEntry("status", "ok"));
         assertThat(result, hasEntry("data", hasEntry("result", "success")));
 
-        req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJenkinsfile"), HttpMethod.POST);
+        req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJenkinsfile"), HttpMethod.POST);
         pair = new NameValuePair("json", result.getJSONObject("data").getJSONObject("json").toString());
         req.setRequestParameters(Collections.singletonList(pair));
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ErrorsEndpointOpsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ErrorsEndpointOpsTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.net.URL;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -58,7 +59,7 @@ public class ErrorsEndpointOpsTest extends AbstractModelDefTest {
     @Test
     public void testFailedValidateJson() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
         String simpleJson = fileContentsFromResources("json/errors/" + configName + ".json");
 
         assertNotNull(simpleJson);
@@ -87,7 +88,7 @@ public class ErrorsEndpointOpsTest extends AbstractModelDefTest {
         if (rawJenkinsfile != null) {
 
             JenkinsRule.WebClient wc = j.createWebClient();
-            WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
+            WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
 
             assertNotNull(rawJenkinsfile);
 
@@ -109,7 +110,7 @@ public class ErrorsEndpointOpsTest extends AbstractModelDefTest {
     @Test
     public void testFailedToJenkinsfile() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJenkinsfile"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJenkinsfile"), HttpMethod.POST);
         String simpleJson = fileContentsFromResources("json/errors/" + configName + ".json");
 
         assertNotNull(simpleJson);
@@ -131,7 +132,7 @@ public class ErrorsEndpointOpsTest extends AbstractModelDefTest {
     @Test
     public void testFailedToJson() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJson"), HttpMethod.POST);
         String initialGroovy = fileContentsFromResources("errors/" + configName + ".groovy", true);
 
         assertNotNull(initialGroovy);

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionStepsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionStepsTest.java
@@ -34,6 +34,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Collections;
 
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -158,7 +159,7 @@ public class ModelConverterActionStepsTest extends AbstractModelDefTest {
 
     private JSONObject callStepToJenkinsFile(String jsonFileName) throws IOException {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/stepsToJenkinsfile"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/stepsToJenkinsfile"), HttpMethod.POST);
         String simpleJson = fileContentsFromResources(jsonFileName);
 
         assertNotNull(simpleJson);
@@ -174,7 +175,7 @@ public class ModelConverterActionStepsTest extends AbstractModelDefTest {
 
     private JSONObject callStepsToJson(String jenkinsFileContent) throws IOException {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/stepsToJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/stepsToJson"), HttpMethod.POST);
 
         assertNotNull(jenkinsFileContent);
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterActionTest.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.Tools;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.net.URL;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -66,7 +67,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
 
     private void getExpectedErrorNoParam(String param, String endpoint) throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/" + endpoint), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/" + endpoint), HttpMethod.POST);
         String rawResult = wc.getPage(req).getWebResponse().getContentAsString();
         assertNotNull(rawResult);
 
@@ -86,7 +87,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
     @Test
     public void errorOnNoPipeline() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
         String groovyAsString = "echo 'nothing to see here'";
         NameValuePair pair = new NameValuePair("jenkinsfile", groovyAsString);
         req.setRequestParameters(Collections.singletonList(pair));
@@ -110,7 +111,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
     @Test
     public void testFailedValidateJsonInvalidBuildCondition() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
         String simpleJson = fileContentsFromResources("json/errors/invalidBuildCondition.json");
 
         assertNotNull(simpleJson);
@@ -140,7 +141,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
         if (rawJenkinsfile != null) {
 
             JenkinsRule.WebClient wc = j.createWebClient();
-            WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
+            WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
 
             assertNotNull(rawJenkinsfile);
 
@@ -162,7 +163,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
     @Test
     public void testFailedValidateJsonUnlistedToolType() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
         String simpleJson = fileContentsFromResources("json/errors/unlistedToolType.json");
 
         assertNotNull(simpleJson);
@@ -193,7 +194,7 @@ public class ModelConverterActionTest extends AbstractModelDefTest {
         if (rawJenkinsfile != null) {
 
             JenkinsRule.WebClient wc = j.createWebClient();
-            WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
+            WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
 
             assertNotNull(rawJenkinsfile);
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/SuccessfulEndpointOpsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/SuccessfulEndpointOpsTest.java
@@ -37,6 +37,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -65,7 +66,7 @@ public class SuccessfulEndpointOpsTest extends AbstractModelDefTest {
     @Test
     public void testSuccessfulValidateJson() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJson"), HttpMethod.POST);
         String simpleJson = fileContentsFromResources("json/" + configName + ".json");
 
         assertNotNull(simpleJson);
@@ -86,7 +87,7 @@ public class SuccessfulEndpointOpsTest extends AbstractModelDefTest {
     @Test
     public void testSuccessfulValidateJenkinsfile() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/validateJenkinsfile"), HttpMethod.POST);
         String rawJenkinsfile = fileContentsFromResources(configName + ".groovy");
 
         assertNotNull(rawJenkinsfile);
@@ -107,7 +108,7 @@ public class SuccessfulEndpointOpsTest extends AbstractModelDefTest {
     @Test
     public void testSuccessfulToJenkinsfile() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJenkinsfile"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJenkinsfile"), HttpMethod.POST);
         String simpleJson = fileContentsFromResources("json/" + configName + ".json");
 
         assertNotNull(simpleJson);
@@ -133,7 +134,7 @@ public class SuccessfulEndpointOpsTest extends AbstractModelDefTest {
     @Test
     public void testSuccessfulToJson() throws Exception {
         JenkinsRule.WebClient wc = j.createWebClient();
-        WebRequest req = new WebRequest(wc.createCrumbedUrl(ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJson"), HttpMethod.POST);
+        WebRequest req = new WebRequest(new URL(wc.getContextPath() + ModelConverterAction.PIPELINE_CONVERTER_URL + "/toJson"), HttpMethod.POST);
         String initialGroovy = fileContentsFromResources(configName + ".groovy");
 
         assertNotNull(initialGroovy);


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42470](https://issues.jenkins-ci.org/browse/JENKINS-42470)
* Description:
    * Add a `CrumbExclusion` extension to get rid of the need for a crumb on `ModelConverterAction` calls, since there are no side effects to any of its endpoints.  Additionally, the permission should be changed to `Jenkins.READ` rather than `Permission.READ`.
* Documentation changes:
    * None directly, but [WEBSITE-324](https://issues.jenkins-ci.org/browse/WEBSITE-324) is relevant.
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
    * @jglick 
