### PR TITLE
[FIXED JENKINS-42498] Dehydrate GStrings in the runtime model

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/SerializableGString.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/SerializableGString.groovy
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition
+
+import org.codehaus.groovy.runtime.GStringImpl
+
+
+class SerializableGString implements Serializable {
+    public String[] strings
+    public Object[] values
+
+    public GString rehydrate() {
+        Object[] vals = new Object[values.length]
+
+        values.eachWithIndex { def entry, int i ->
+            if (entry instanceof SerializableGString) {
+                vals[i] = entry.rehydrate()
+            } else {
+                vals[i] = entry
+            }
+        }
+
+        return new GStringImpl(vals, strings)
+    }
+
+    public static dehydrate(GString g) {
+        String[] strs = g.strings
+        Object[] vals = new Object[g.valueCount]
+        g.values.eachWithIndex { def entry, int i ->
+            if (entry instanceof GString) {
+                vals[i] = dehydrate(entry)
+            } else {
+                vals[i] = entry
+            }
+        }
+
+        return new SerializableGString(strings: strs, values: vals)
+    }
+
+    public static int serialVersionUID = 1L
+}

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -26,7 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
-
+import org.jenkinsci.plugins.pipeline.modeldefinition.SerializableGString
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
@@ -109,16 +109,22 @@ public class Root implements NestedModel, Serializable {
      * @return a list of "key=value" strings.
      */
     List<String> getEnvVars() {
-        return environment.findAll{k, v -> !(v instanceof CredentialWrapper)}.collect { k, v ->
-            "${k}=${v}"
+        if (environment == null) {
+            return []
+        } else {
+            return environment.getMap().findAll { k, v -> !(v instanceof CredentialWrapper) }.collect { k, v ->
+                "${k}=${v}"
+            }
         }
     }
 
     Map<String, CredentialWrapper> getEnvCredentials() {
         Map<String, CredentialWrapper> m = [:]
-        environment.each {k, v ->
-            if (v instanceof  CredentialWrapper) {
-                m["${k}"] = v;
+        if (environment != null) {
+            environment.getMap().each { k, v ->
+                if (v instanceof CredentialWrapper) {
+                    m["${k}"] = v;
+                }
             }
         }
         return m

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
+import org.jenkinsci.plugins.pipeline.modeldefinition.SerializableGString
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 
 import javax.annotation.Nonnull
@@ -96,17 +97,23 @@ public class Stage implements NestedModel, Serializable {
      * @return a list of "key=value" strings.
      */
     List<String> getEnvVars() {
-        return environment.findAll{k, v -> !(v instanceof CredentialWrapper)}.collect { k, v ->
-            "${k}=${v}"
+        if (environment == null) {
+            return []
+        } else {
+            return environment.findAll { k, v -> !(v instanceof CredentialWrapper) }.collect { k, v ->
+                "${k}=${v}"
+            }
         }
     }
 
     @Nonnull
     Map<String, CredentialWrapper> getEnvCredentials() {
         Map<String, CredentialWrapper> m = [:]
-        environment.each {k, v ->
-            if (v instanceof  CredentialWrapper) {
-                m["${k}"] = v;
+        if (environment != null) {
+            environment.each { k, v ->
+                if (v instanceof CredentialWrapper) {
+                    m["${k}"] = v;
+                }
             }
         }
         return m

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/MethodsToListTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/MethodsToListTranslator.groovy
@@ -67,7 +67,8 @@ public class MethodsToListTranslator implements MethodMissingWrapper, Serializab
             retVal = script."${s}"()
         }
 
-        if (isOfType((UninstantiatedDescribable)retVal, Utils.getMethodsToListType(clazz))) {
+        if (retVal instanceof UninstantiatedDescribable &&
+            isOfType((UninstantiatedDescribable)retVal, Utils.getMethodsToListType(clazz))) {
             actualList << retVal
         }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTranslator.groovy
@@ -72,8 +72,9 @@ public class OptionsTranslator implements MethodMissingWrapper, Serializable {
             retVal = script."${s}"()
         }
 
-        if (isOfType(retVal, DeclarativeOption.class)
-            || isOfType(retVal, JobProperty.class)) {
+        if (retVal instanceof UninstantiatedDescribable &&
+            (isOfType(retVal, DeclarativeOption.class)
+                || isOfType(retVal, JobProperty.class))) {
             actualList << retVal
         }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/StageConditionalTranslator.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/StageConditionalTranslator.groovy
@@ -86,7 +86,8 @@ public class StageConditionalTranslator implements MethodMissingWrapper, Seriali
             retVal = Utils.getDescribable(s, DeclarativeStageConditional.class, args)
         }
 
-        if (isOfType((UninstantiatedDescribable) retVal, DeclarativeStageConditional.class)) {
+        if (retVal instanceof UninstantiatedDescribable &&
+            isOfType((UninstantiatedDescribable) retVal, DeclarativeStageConditional.class)) {
             actualList << (UninstantiatedDescribable) retVal
         }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/SerializationTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/SerializationTest.java
@@ -1,0 +1,198 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition;
+
+import hudson.model.BooleanParameterDefinition;
+import hudson.model.Describable;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Slave;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.tasks.LogRotator;
+import hudson.triggers.TimerTrigger;
+import hudson.triggers.Trigger;
+import jenkins.model.BuildDiscarder;
+import jenkins.model.BuildDiscarderProperty;
+import jenkins.plugins.git.GitSCMSource;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.jenkinsci.plugins.workflow.pickles.Pickle;
+import org.jenkinsci.plugins.workflow.support.pickles.SingleTypedPickleFactory;
+import org.jenkinsci.plugins.workflow.support.pickles.XStreamPickle;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Note that in practice, only {@link #serializationEnvGString} fails, but it felt best to cover the other possible
+ * cases as well.
+ */
+@Issue("JENKINS-42498")
+public class SerializationTest extends AbstractModelDefTest {
+
+    private static Slave s;
+
+    @BeforeClass
+    public static void setUpAgent() throws Exception {
+        s = j.createOnlineSlave();
+        s.setNumExecutors(4);
+        s.setLabelString("some-label docker test");
+        s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true")));
+    }
+
+    @Test
+    public void serializationEnvGString() throws Exception {
+        expect("serializationEnvGString")
+                .logContains("[Pipeline] { (foo)",
+                        "_UNDERSCORE is VALID")
+                .logMatches("FOO is test\\d+foo")
+                .go();
+    }
+
+    @Test
+    public void serializationParametersGString() throws Exception {
+        WorkflowRun b = expect("serializationParametersGString")
+                .logContains("[Pipeline] { (foo)", "hello")
+                .logNotContains("[Pipeline] { (" + SyntheticStageNames.postBuild() + ")")
+                .go();
+
+        WorkflowJob p = b.getParent();
+
+        ParametersDefinitionProperty pdp = p.getProperty(ParametersDefinitionProperty.class);
+        assertNotNull(pdp);
+
+        assertEquals(1, pdp.getParameterDefinitions().size());
+        assertEquals(BooleanParameterDefinition.class, pdp.getParameterDefinitions().get(0).getClass());
+        BooleanParameterDefinition bpd = (BooleanParameterDefinition) pdp.getParameterDefinitions().get(0);
+        assertEquals(p.getDisplayName(), bpd.getName());
+        assertTrue(bpd.isDefaultValue());
+    }
+
+    @Test
+    public void serializationAgentGString() throws Exception {
+        expect("serializationAgentGString")
+                .logContains("[Pipeline] { (foo)", "ONAGENT=true")
+                .go();
+    }
+
+    @Test
+    public void serializationAgentNestedGString() throws Exception {
+        expect("serializationAgentNestedGString")
+                .logContains("[Pipeline] { (foo)", "ONAGENT=true")
+                .go();
+    }
+
+    @Test
+    public void serializationJobPropsGString() throws Exception {
+        WorkflowRun b = expect("serializationJobPropsGString")
+                .logContains("[Pipeline] { (foo)", "hello")
+                .logNotContains("[Pipeline] { (" + SyntheticStageNames.postBuild() + ")")
+                .go();
+
+        WorkflowJob p = b.getParent();
+
+        BuildDiscarderProperty bdp = p.getProperty(BuildDiscarderProperty.class);
+        assertNotNull(bdp);
+        BuildDiscarder strategy = bdp.getStrategy();
+        assertNotNull(strategy);
+        assertEquals(LogRotator.class, strategy.getClass());
+        LogRotator lr = (LogRotator) strategy;
+        assertEquals(Integer.parseInt(p.getDisplayName().substring(4)), lr.getNumToKeep());
+    }
+
+    @Test
+    public void serializationLibrariesGString() throws Exception {
+        otherRepo.init();
+        otherRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
+        otherRepo.write("vars/myecho.txt", "Says something very special!");
+        otherRepo.git("add", "vars");
+        otherRepo.git("commit", "--message=init");
+        LibraryConfiguration firstLib = new LibraryConfiguration("echo-utils",
+                new SCMSourceRetriever(new GitSCMSource(null, otherRepo.toString(), "", "*", "", true)));
+
+        thirdRepo.init();
+        thirdRepo.write("vars/whereFrom.groovy", "def call() {echo 'from another library'}");
+        thirdRepo.write("vars/whereFrom.txt", "Says where it's from!");
+        thirdRepo.git("add", "vars");
+        thirdRepo.git("commit", "--message=init");
+        LibraryConfiguration secondLib = new LibraryConfiguration("test",
+                new SCMSourceRetriever(new GitSCMSource(null, thirdRepo.toString(), "", "*", "", true)));
+        secondLib.setDefaultVersion("master");
+        GlobalLibraries.get().setLibraries(Arrays.asList(firstLib, secondLib));
+
+        expect("serializationLibrariesGString")
+                .logContains("something special", "from another library")
+                .go();
+    }
+
+    @Test
+    public void serializationTriggersGString() throws Exception {
+        WorkflowRun b = expect("serializationTriggersGString")
+                .logContains("[Pipeline] { (foo)", "hello")
+                .logNotContains("[Pipeline] { (Post Actions)")
+                .go();
+
+        WorkflowJob p = b.getParent();
+
+        PipelineTriggersJobProperty triggersJobProperty = p.getTriggersJobProperty();
+        assertNotNull(triggersJobProperty);
+        assertEquals(1, triggersJobProperty.getTriggers().size());
+        TimerTrigger.DescriptorImpl timerDesc = j.jenkins.getDescriptorByType(TimerTrigger.DescriptorImpl.class);
+
+        Trigger trigger = triggersJobProperty.getTriggerForDescriptor(timerDesc);
+        assertNotNull(trigger);
+
+        assertTrue(trigger instanceof TimerTrigger);
+        TimerTrigger timer = (TimerTrigger) trigger;
+        assertEquals("@daily", timer.getSpec());
+    }
+
+    @Test
+    public void serializationWhenBranchGString() throws Exception {
+        expect("serializationWhenBranchGString")
+                .logContains("[Pipeline] { (One)", "[Pipeline] { (Two)", "World")
+                .go();
+    }
+
+    @TestExtension
+    public static class XStreamPickleFactory extends SingleTypedPickleFactory<Describable<?>> {
+
+        @Override protected Pickle pickle(Describable<?> d) {
+            return new XStreamPickle(d);
+        }
+
+    }
+
+}

--- a/pipeline-model-definition/src/test/resources/serializationAgentGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationAgentGString.groovy
@@ -1,0 +1,39 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label "${env.JOB_NAME.substring(0, 4)}"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo ONAGENT=$ONAGENT')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/serializationAgentNestedGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationAgentNestedGString.groovy
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        node {
+            label "${env.JOB_NAME.substring(0, 4)}"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo ONAGENT=$ONAGENT')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/serializationEnvGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationEnvGString.groovy
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO = "${env.JOB_NAME}foo"
+        _UNDERSCORE = "VALID"
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            when {
+                expression {
+                    return true
+                }
+            }
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/serializationJobPropsGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationJobPropsGString.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    options {
+        buildDiscarder(logRotator(numToKeepStr:"${env.JOB_NAME.substring(4)}"))
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/serializationLibrariesGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationLibrariesGString.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    libraries {
+        lib("echo-utils@master")
+        lib("${'test'}")
+    }
+    stages {
+        stage("foo") {
+            steps {
+                myecho()
+                whereFrom()
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/serializationParametersGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationParametersGString.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    parameters {
+        booleanParam(defaultValue: true, description: '', name: "${env.JOB_NAME}")
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/serializationTriggersGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationTriggersGString.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    triggers {
+        cron("${'@daily'}")
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/serializationWhenBranchGString.groovy
+++ b/pipeline-model-definition/src/test/resources/serializationWhenBranchGString.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    environment {
+        BRANCH_NAME = "master"
+    }
+    stages {
+        stage("One") {
+            steps {
+                echo "Hello"
+            }
+        }
+        stage("Two") {
+            when {
+                branch "${'master'}"
+            }
+            steps {
+                script {
+                    echo "World"
+                    echo "Heal it"
+                }
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42498](https://issues.jenkins-ci.org/browse/JENKINS-42498)
* Description:
    * This prevents non-serializable errors when there are attempts to serialize via `XStream`, which rejects `GStringImpl`. There's still a question as to whether `GStringImpl` should be rejected by `hudson.remoting.ClassFilter.DEFAULT`, but that's a separate issue. We fix the problem by "dehydrating" `GString`s into their `strings` and `values`, which we can then use to "rehydrate" them into `GStringImpl`s at the right time.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
    * @jglick (would like your thoughts)
