### PR TITLE
[FIXED JENKINS-42771] Allow + binary expressions in env values

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -58,7 +58,7 @@ ModelParser.InvalidAgent=Only "agent none", "agent any" or "agent '{'...}" are a
 ModelParser.InvalidBuildCondition=The 'post' section can only contain build condition names with code blocks. Valid condition names are {0}
 ModelParser.InvalidEnvironmentIdentifier="{0}" is not a valid environment expression. Use "key = value" pairs with valid Java/shell keys.
 ModelParser.InvalidEnvironmentOperation=Environment variable values can only be joined together with '+'s.
-ModelParser.InvalidEnvironmentConcatValue=Environment variable values to be concatenated together must be strings.
+ModelParser.InvalidEnvironmentConcatValue=Environment variable values to be concatenated together must be single or double quoted.
 ModelParser.InvalidEnvironmentValue=Environment variable values must either be strings or function calls.
 ModelParser.InvalidInternalFunctionArg=Internal function call parameters must be strings.
 ModelParser.InvalidSectionDefinition=Not a valid section definition: "{0}". Some extra configuration is required.

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -57,6 +57,8 @@ ModelParser.ExpectedWhen=Expected a when condition
 ModelParser.InvalidAgent=Only "agent none", "agent any" or "agent '{'...}" are allowed.
 ModelParser.InvalidBuildCondition=The 'post' section can only contain build condition names with code blocks. Valid condition names are {0}
 ModelParser.InvalidEnvironmentIdentifier="{0}" is not a valid environment expression. Use "key = value" pairs with valid Java/shell keys.
+ModelParser.InvalidEnvironmentOperation=Environment variable values can only be joined together with '+'s.
+ModelParser.InvalidEnvironmentConcatValue=Environment variable values to be concatenated together must be strings.
 ModelParser.InvalidEnvironmentValue=Environment variable values must either be strings or function calls.
 ModelParser.InvalidInternalFunctionArg=Internal function call parameters must be strings.
 ModelParser.InvalidSectionDefinition=Not a valid section definition: "{0}". Some extra configuration is required.

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -56,6 +56,16 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-42771")
+    @Test
+    public void multiExpressionEnvironment() throws Exception {
+        expect("multiExpressionEnvironment")
+                .logContains("[Pipeline] { (foo)",
+                        "FOO is BAR",
+                        "_UNDERSCORE is VALID")
+                .go();
+    }
+
     @Test
     public void environmentInStage() throws Exception {
         expect("environmentInStage")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -566,4 +566,13 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-42771")
+    @Test
+    public void invalidMultiExpressionEnvironment() throws Exception {
+        expectError("invalidMultiExpressionEnvironment")
+                .logContains(Messages.ModelParser_InvalidEnvironmentOperation(),
+                        Messages.ModelParser_InvalidEnvironmentConcatValue())
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/errors/invalidMultiExpressionEnvironment.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidMultiExpressionEnvironment.groovy
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO =
+            "B" -
+                "A" +
+                "R"
+        BAR = 1 + credentials("foo")
+        _UNDERSCORE = "VALID"
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/multiExpressionEnvironment.groovy
+++ b/pipeline-model-definition/src/test/resources/multiExpressionEnvironment.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO =
+            "B" +
+                "${'A'}" +
+                "R"
+        _UNDERSCORE = "VALID"
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42771](https://issues.jenkins-ci.org/browse/JENKINS-42771)
* Description:
    * This worked previously because we didn't actually pay attention to what was really in the value for an environment variable in the AST model, only at runtime. And the runtime parsing worked differently, so it did fine with `FOO = "A" + "B" + "C"`. Well, now so does the AST model. Yay!
* Documentation changes:
    * n/a, I think? @bitwiseman, I don't think we should be explicitly documenting that this works, especially since `FOO = "A" + "B" + "C"` will actually roundtrip through the editor to be `FOO = "ABC"`, since we concatenate the strings at parse time...
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
