### PR TITLE
[FIXED JENKINS-42858] Process credentials before rest of environment

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -43,6 +43,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -109,6 +110,18 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
                 .logContains("SOME_VAR is SOME VALUE",
                              "INBETWEEN is Something in between",
                              "OTHER_VAR is OTHER VALUE")
+                .archives("cred1.txt", mixedEnvCred1Secret)
+                .archives("cred2.txt", mixedEnvCred2U + ":" + mixedEnvCred2P).go();
+    }
+
+    @Issue("JENKINS-42858")
+    @Test
+    public void credentialsEnvCrossReference() throws Exception {
+        expect("credentialsEnvCrossReference")
+                .logContains("SOME_VAR is SOME VALUE",
+                        "INBETWEEN is Something **** between",
+                        "OTHER_VAR is OTHER VALUE")
+                .archives("inbetween.txt", "Something " + mixedEnvCred1Secret + " between")
                 .archives("cred1.txt", mixedEnvCred1Secret)
                 .archives("cred2.txt", mixedEnvCred2U + ":" + mixedEnvCred2P).go();
     }

--- a/pipeline-model-definition/src/test/resources/credentialsEnvCrossReference.groovy
+++ b/pipeline-model-definition/src/test/resources/credentialsEnvCrossReference.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        SOME_VAR = "SOME VALUE"
+        CRED1 = credentials("cred1")
+        INBETWEEN = "Something ${CRED1} between"
+        CRED2 = credentials("cred2")
+        OTHER_VAR = "OTHER VALUE"
+    }
+
+    agent any
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "SOME_VAR is $SOME_VAR"'
+                sh 'echo "OTHER_VAR is $OTHER_VAR"'
+                sh 'echo "INBETWEEN is $INBETWEEN"'
+                sh 'echo $INBETWEEN > inbetween.txt'
+                sh 'echo $CRED1 > cred1.txt'
+                sh 'echo $CRED2 > cred2.txt'
+                archive "**/*.txt"
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials-binding</artifactId>
-        <version>1.10</version>
+        <version>1.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42858](https://issues.jenkins-ci.org/browse/JENKINS-42858)
* Description:
    * I don't think there's a reasonable use case for an environment variable being in the credentials ID, so there's really no reason *not* to do credentials first, is there? This allows credentials to be referenced by other environment variables.
    * Needs https://github.com/jenkinsci/credentials-binding-plugin/pull/34 to be merged/released before we can actually move forward with this, due to `withCredentials` currently requiring a workspace.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
