### PR TITLE
[FIXED JENKINS-41456] Properly validate publishHTML

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTArgumentList.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTArgumentList.java
@@ -1,8 +1,5 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 
-import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
-
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -129,6 +129,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>htmlpublisher</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness-tools</artifactId>
       <scope>test</scope>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -271,6 +271,7 @@ class ModelParser implements Parser {
                             errorCollector.error(badKey, Messages.ModelValidatorImpl_InvalidIdentifierInEnv(keyTxt))
                         } else {
                             errorCollector.error(badKey, Messages.ModelParser_InvalidEnvironmentIdentifier(srcTxt))
+
                         }
                     }
                 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -278,11 +278,13 @@ class ModelValidatorImpl implements ModelValidator {
                     soleDescribableMap = true
                     valid = validateDescribable(element, model.soleRequiredParameter.name, argList,
                         new DescribableModel<>(model.soleRequiredParameter.erasedType))
+                    // Note - this return is to break out of the .each loop only
                     return
                 }
 
                 if (!isValidStepParameter(model, k.key, k)) {
                     valid = false
+                    // Note - this return is to break out of the .each loop only
                     return
                 }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -235,7 +235,7 @@ class ModelValidatorImpl implements ModelValidator {
                     errorCollector.error(condition, Messages.ModelValidatorImpl_NoNestedWhenAllowed(condition.name))
                     valid = false
                 } else {
-                    valid = validateDescribable(condition, condition.name, condition.args, model, desc, false)
+                    valid = validateDescribable(condition, condition.name, condition.args, model, false)
                 }
             }
         }
@@ -243,26 +243,50 @@ class ModelValidatorImpl implements ModelValidator {
         return valid
     }
 
+    private boolean isValidStepParameter(DescribableModel<? extends Describable> model,
+                                         String key,
+                                         ModelASTElement keyElement) {
+        def p = model?.getParameter(key);
+        if (p == null) {
+            String possible = EditDistance.findNearest(key, model.getParameters().collect {
+                it.name
+            })
+            errorCollector.error(keyElement, Messages.ModelValidatorImpl_InvalidStepParameter(key, possible))
+            return false
+        }
+        return true
+    }
+
     private boolean validateDescribable(ModelASTElement element, String name,
                                         ModelASTArgumentList args,
                                         DescribableModel<? extends Describable> model,
-                                        Descriptor desc, boolean takesClosure = false) {
+                                        boolean takesClosure = false) {
         boolean valid = true
 
         if (args instanceof ModelASTNamedArgumentList) {
             ModelASTNamedArgumentList argList = (ModelASTNamedArgumentList) args
 
+            boolean soleDescribableMap = false
+
             argList.arguments.each { k, v ->
+                // Check if there is a sole required parameter and it's describable
+                if (model.getParameter(k.key) == null &&
+                    model?.soleRequiredParameter != null &&
+                    Describable.class.isAssignableFrom(model.soleRequiredParameter.erasedType)) {
+                    // Check if the argument list validates as that describable. If it does, note that so
+                    // we can proceed.
+                    soleDescribableMap = true
+                    valid = validateDescribable(element, model.soleRequiredParameter.name, argList,
+                        new DescribableModel<>(model.soleRequiredParameter.erasedType))
+                    return
+                }
+
+                if (!isValidStepParameter(model, k.key, k)) {
+                    valid = false
+                    return
+                }
 
                 def p = model.getParameter(k.key);
-                if (p == null) {
-                    String possible = EditDistance.findNearest(k.key, model.getParameters().collect {
-                        it.name
-                    })
-                    errorCollector.error(k, Messages.ModelValidatorImpl_InvalidStepParameter(k.key, possible))
-                    valid = false
-                    return;
-                }
 
                 ModelASTKey validateKey = k
 
@@ -281,10 +305,14 @@ class ModelValidatorImpl implements ModelValidator {
                     valid = false
                 }
             }
-            model.parameters.each { p ->
-                if (p.isRequired() && !argList.containsKeyName(p.name)) {
-                    errorCollector.error(element, Messages.ModelValidatorImpl_MissingRequiredStepParameter(p.name))
-                    valid = false
+            // Only check for required parameters if we're valid up to this point and we haven't already processed
+            // a sole describable map
+            if (valid && !soleDescribableMap) {
+                model.parameters.each { p ->
+                    if (p.isRequired() && !argList.containsKeyName(p.name)) {
+                        errorCollector.error(element, Messages.ModelValidatorImpl_MissingRequiredStepParameter(p.name))
+                        valid = false
+                    }
                 }
             }
         } else if (args instanceof ModelASTPositionalArgumentList) {
@@ -331,7 +359,7 @@ class ModelValidatorImpl implements ModelValidator {
             // No validation needed for code blocks like expression and script
             return true
         } else {
-            return validateDescribable(step, step.name, step.args, model, desc, lookup.stepTakesClosure(desc))
+            return validateDescribable(step, step.name, step.args, model, lookup.stepTakesClosure(desc))
         }
     }
 
@@ -380,15 +408,12 @@ class ModelValidatorImpl implements ModelValidator {
                         }
                         ModelASTKeyValueOrMethodCallPair kvm = (ModelASTKeyValueOrMethodCallPair) a
 
-                        def p = model.getParameter(kvm.key.key);
-                        if (p == null) {
-                            String possible = EditDistance.findNearest(kvm.key.key, model.getParameters().collect {
-                                it.name
-                            })
-                            errorCollector.error(kvm.key, Messages.ModelValidatorImpl_InvalidStepParameter(kvm.key.key, possible))
+                        if (!isValidStepParameter(model, kvm.key.key, kvm.key)) {
                             valid = false
-                            return;
+                            return
                         }
+
+                        def p = model.getParameter(kvm.key.key);
 
                         if (kvm.value instanceof ModelASTMethodCall) {
                             valid = validateElement((ModelASTMethodCall) kvm.value)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.google.common.base.Predicate;
+import htmlpublisher.HtmlPublisherTarget;
 import hudson.model.Result;
 import hudson.model.Slave;
 import jenkins.plugins.git.GitSCMSource;
@@ -225,6 +226,18 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         expect("parallelPipelineWithFailFast")
                 .logContains("[Pipeline] { (foo)", "[first] { (Branch: first)", "[second] { (Branch: second)")
                 .go();
+    }
+
+    @Issue("JENKINS-41456")
+    @Test
+    public void htmlPublisher() throws Exception {
+        WorkflowRun b = expect("htmlPublisher")
+                .logContains("[Pipeline] { (foo)")
+                .go();
+
+        HtmlPublisherTarget.HTMLBuildAction buildReport = b.getAction(HtmlPublisherTarget.HTMLBuildAction.class);
+        assertNotNull(buildReport);
+        assertEquals("Test Report", buildReport.getHTMLTarget().getReportName());
     }
 
     @Test

--- a/pipeline-model-definition/src/test/resources/htmlPublisher.groovy
+++ b/pipeline-model-definition/src/test/resources/htmlPublisher.groovy
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    stages {
+        stage("foo") {
+            steps {
+                sh("mkdir -p tmp")
+                sh('echo "<html><body><h1>HELLO</h1></body></html" > tmp/test.html')
+                publishHTML ([
+                    allowMissing: false,
+                    alwaysLinkToLastBuild: false,
+                    keepAll: true,
+                    reportDir: "tmp",
+                    reportFiles: 'test.html',
+                    reportName: "Test Report"
+                ])
+            }
+        }
+    }
+}
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,11 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>htmlpublisher</artifactId>
+        <version>1.12</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git</artifactId>
         <version>2.6.0</version>
         <exclusions>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-41456](https://issues.jenkins-ci.org/browse/JENKINS-41456)
* Description:
    * Specifically, when we see that there's a sole required parameter, the only provided argument by the user is a map, at least one of those map keys doesn't have a corresponding parameter in the describable, and the sole required parameter's type is a describable itself, validate the argument map against that parameter type describable instead of against the parent describable. So for publishHTML, that means realizing `target` is an `HtmlPublisherTarget` and validating the map against that.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
    * @bitwiseman 
