### PR TITLE
[FIXED JENKINS-43035] Automatically include imports in when expr

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
@@ -4,6 +4,10 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Represents the parsed pipeline definition for visual pipeline editor. Corresponds to {@code Root}.
  *
@@ -21,8 +25,18 @@ public final class ModelASTPipelineDef extends ModelASTElement {
     private ModelASTTriggers triggers;
     private ModelASTLibraries libraries;
 
+    private transient List<String> additionalImports = new ArrayList<>();
+
     public ModelASTPipelineDef(Object sourceLocation) {
         super(sourceLocation);
+    }
+
+    public void setAdditionalImports(@Nonnull List<String> s) {
+        this.additionalImports.addAll(s);
+    }
+
+    public List<String> getAdditionalImports() {
+        return additionalImports;
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -225,6 +225,7 @@ public class Utils {
             }
 
             if (root != null) {
+                root.additionalImports.addAll(model.additionalImports)
                 root = populateWhen(root, model)
                 root = populateEnv(r, root, model)
             }
@@ -264,7 +265,7 @@ public class Utils {
             if (astStage.when != null) {
                 List<DeclarativeStageConditional<? extends DeclarativeStageConditional>> processedConditions =
                     astStage.when.conditions.collect { c ->
-                        stageConditionalFromAST(c)
+                        stageConditionalFromAST(root, c)
                     }
 
                 s.when(new StageConditionals(processedConditions))
@@ -283,7 +284,7 @@ public class Utils {
      * @param w
      * @return A populated {@link DeclarativeStageConditional}
      */
-    private static DeclarativeStageConditional stageConditionalFromAST(ModelASTWhenContent w) {
+    private static DeclarativeStageConditional stageConditionalFromAST(Root r, ModelASTWhenContent w) {
         DeclarativeStageConditional c = null
         DeclarativeStageConditionalDescriptor desc = DeclarativeStageConditionalDescriptor.byName(w.name)
 
@@ -293,16 +294,16 @@ public class Utils {
                 arg[0] = w.args?.argListToMap()
                 c = (DeclarativeStageConditional)getDescribable(w.name, desc.clazz, arg).instantiate()
             } else if (desc.allowedChildrenCount == 1) {
-                DeclarativeStageConditional single = stageConditionalFromAST(w.children.first())
+                DeclarativeStageConditional single = stageConditionalFromAST(r, w.children.first())
                 c = (DeclarativeStageConditional)getDescribable(w.name, desc.clazz, single).instantiate()
             } else {
-                List<DeclarativeStageConditional> nested = w.children.collect { stageConditionalFromAST(it) }
+                List<DeclarativeStageConditional> nested = w.children.collect { stageConditionalFromAST(r, it) }
                 c = (DeclarativeStageConditional)getDescribable(w.name, desc.clazz, nested).instantiate()
             }
         } else if (w instanceof ModelASTWhenExpression) {
             ModelASTWhenExpression expr = (ModelASTWhenExpression)w
-
-            c = (DeclarativeStageConditional)getDescribable(w.name, desc.clazz, expr.codeBlockAsString()).instantiate()
+            String codeBlock = r?.appendImports(expr.codeBlockAsString()) ?: expr.codeBlockAsString()
+            c = (DeclarativeStageConditional)getDescribable(w.name, desc.clazz, codeBlock).instantiate()
         }
 
         return c

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -31,6 +31,8 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
+import javax.annotation.Nonnull
+
 /**
  * Root-level configuration object for the entire model.
  *
@@ -57,6 +59,16 @@ public class Root implements NestedModel, Serializable {
     Parameters parameters
 
     Libraries libraries
+
+    List<String> additionalImports = new ArrayList<>()
+
+    public String appendImports(@Nonnull String input) {
+        if (!additionalImports.isEmpty()) {
+            return additionalImports.join("\n") + "\n" + input
+        } else {
+            return input
+        }
+    }
 
     Root stages(Stages s) {
         this.stages = s

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -30,6 +30,7 @@ import hudson.model.Describable
 import hudson.model.Descriptor
 import jenkins.model.Jenkins
 import org.codehaus.groovy.ast.ASTNode
+import org.codehaus.groovy.ast.ImportNode
 import org.codehaus.groovy.ast.ModuleNode
 import org.codehaus.groovy.ast.expr.*
 import org.codehaus.groovy.ast.stmt.BlockStatement
@@ -127,6 +128,17 @@ class ModelParser implements Parser {
         }
 
         ModelASTPipelineDef r = new ModelASTPipelineDef(pst);
+
+        List<ImportNode> additionalImports = []
+        [src.imports, src.staticImports, src.starImports, src.staticStarImports].each { imports ->
+            imports.each { ImportNode i ->
+                additionalImports.add(i)
+            }
+        }
+
+        if (!additionalImports.isEmpty()) {
+            r.setAdditionalImports(additionalImports.collect { it.text })
+        }
 
         def pipelineBlock = matchBlockStatement(pst);
         if (pipelineBlock==null) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -643,6 +643,30 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43035")
+    @Test
+    public void libraryObjectInWhenExpression() throws Exception {
+        otherRepo.init();
+        otherRepo.write("src/org/foo/Zot.groovy", "package org.foo;\n" +
+                "\n" +
+                "class Zot implements Serializable {\n" +
+                "  Zot(){\n" +
+                "  }\n" +
+                "  def returnTrue() {\n" +
+                "    return true\n" +
+                "  }\n" +
+                "}\n");
+        otherRepo.git("add", "src");
+        otherRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(
+                new LibraryConfiguration("zot-stuff",
+                        new SCMSourceRetriever(new GitSCMSource(null, otherRepo.toString(), "", "*", "", true)))));
+
+        expect("libraryObjectInWhenExpression")
+                .logContains("Hello")
+                .go();
+    }
+
     @Issue("JENKINS-40657")
     @Test
     public void libraryObjectDefinedOutsidePipeline() throws Exception {

--- a/pipeline-model-definition/src/test/resources/libraryObjectInWhenExpression.groovy
+++ b/pipeline-model-definition/src/test/resources/libraryObjectInWhenExpression.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+@Library('zot-stuff@master')
+import org.foo.Zot
+
+pipeline {
+    agent any
+    stages {
+        stage ('prepare') {
+            when {
+                expression {
+                    def z = new Zot()
+                    return z.returnTrue()
+                }
+            }
+            steps {
+                echo "Hello"
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43035](https://issues.jenkins-ci.org/browse/JENKINS-43035)
* Description:
    * Take imports in the Jenkinsfile and automatically include them in the code blocks for when expressions, so that they are actually available when we evaluate the when expression.
    * That said, I'm not sure I want to do it this way - this isn't round-trippable, etc. So thoughts/comments are welcome.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
