### PR TITLE
[ENVIRONMENT OMNIBUS] Clean up environment issues stemming from 1.1 changes

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -53,6 +53,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.Root
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepsBlock
 import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter
+import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor
 import org.jenkinsci.plugins.structs.SymbolLookup
@@ -335,7 +336,25 @@ public class Utils {
         }
         return credsTuples
     }
-    
+
+    /**
+     * This exists for pre-1.1.2 -> later upgrades of running builds only.
+     *
+     * @param environment The environment to pull credentials from
+     * @return A non-null but possibly empty map of strings to {@link CredentialWrapper}s
+     */
+    @Nonnull
+    static Map<String, CredentialWrapper> getLegacyEnvCredentials(@Nonnull Environment environment) {
+        Map<String, CredentialWrapper> m = [:]
+        environment.each {k, v ->
+            if (v instanceof  CredentialWrapper) {
+                m["${k}"] = v;
+            }
+        }
+        return m
+    }
+
+
     // Note that we're not using StringUtils.strip(s, "'\"") here because we want to make sure we only get rid of
     // matched pairs of quotes/double-quotes.
     static String trimQuotes(String s) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -337,8 +337,9 @@ public class Utils {
         }
         return credsTuples
     }
-
-
+    
+    // Note that we're not using StringUtils.strip(s, "'\"") here because we want to make sure we only get rid of
+    // matched pairs of quotes/double-quotes.
     static String trimQuotes(String s) {
         if ((s.startsWith('"') && s.endsWith('"')) ||
             (s.startsWith("'") && s.endsWith("'"))) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -46,7 +46,6 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenCondition
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenContent
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenExpression
-import org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Environment
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.MethodsToList
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.StageConditionals
@@ -56,7 +55,6 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepsBlock
 import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor
-import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.structs.SymbolLookup
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable
 import org.jenkinsci.plugins.workflow.actions.TagsAction
@@ -331,7 +329,7 @@ public class Utils {
     static List<List<String>> getEnvCredentials(Environment environment, CpsScript script) {
         List<List<String>> credsTuples = new ArrayList<>()
         if (environment != null) {
-            credsTuples.addAll(environment?.getCredsMap(script)?.collect { k, v ->
+            credsTuples.addAll(environment.getCredsMap(script)?.collect { k, v ->
                 [k, v]
             })
         }
@@ -343,7 +341,7 @@ public class Utils {
     static String trimQuotes(String s) {
         if ((s.startsWith('"') && s.endsWith('"')) ||
             (s.startsWith("'") && s.endsWith("'"))) {
-            return trimQuotes(s.substring(1, s.length() - 1))
+            return trimQuotes(s[1..-2])
         } else {
             return s
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -673,8 +673,4 @@ public class Utils {
             return Collections.singletonMap(UninstantiatedDescribable.ANONYMOUS_KEY, _args)
         }
     }
-
-    static String getCurrentJobName() {
-        return CpsThread.current()?.execution?.owner?.getExecutable()?.getParent()?.getDisplayName() ?: "unknown"
-    }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -68,6 +68,7 @@ import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode
 import org.jenkinsci.plugins.workflow.graph.FlowNode
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 import org.jenkinsci.plugins.workflow.support.steps.StageStep
@@ -671,5 +672,9 @@ public class Utils {
         } else {
             return Collections.singletonMap(UninstantiatedDescribable.ANONYMOUS_KEY, _args)
         }
+    }
+
+    static String getCurrentJobName() {
+        return CpsThread.current()?.execution?.owner?.getExecutable()?.getParent()?.getDisplayName() ?: "unknown"
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
@@ -257,7 +257,7 @@ public class Environment implements Serializable {
     private String resolveAsScript(Binding binding, String script) {
         String toRun = Utils.prepareForEvalToString(script)
         SecureGroovyScript toExec = new SecureGroovyScript(toRun, true)
-            .configuring(ApprovalContext.create().withCurrentUser().withKey(Utils.getCurrentJobName()))
+            .configuring(ApprovalContext.create().withCurrentUser()))
         return toExec.evaluate(this.class.getClassLoader(), binding)
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
@@ -257,7 +257,7 @@ public class Environment implements Serializable {
     private String resolveAsScript(Binding binding, String script) {
         String toRun = Utils.prepareForEvalToString(script)
         SecureGroovyScript toExec = new SecureGroovyScript(toRun, true)
-            .configuring(ApprovalContext.create().withCurrentUser()))
+            .configuring(ApprovalContext.create().withCurrentUser())
         return toExec.evaluate(this.class.getClassLoader(), binding)
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
@@ -53,6 +53,8 @@ import javax.annotation.Nonnull
 @EqualsAndHashCode
 @SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public class Options implements Serializable {
+    public final static List<String> BLOCKED_PROPERTIES = ["pipelineTriggers", "parameters"]
+
     // Transient since JobProperty isn't serializable. Doesn't really matter since we're in trouble if we get interrupted
     // anyway.
     transient List<JobProperty> properties = []
@@ -79,7 +81,7 @@ public class Options implements Serializable {
     private static final Object WRAPPER_STEPS_KEY = new Object()
 
     private static final LoadingCache<Object,Map<String,String>> propertyTypeCache =
-        Utils.generateTypeCache(JobPropertyDescriptor.class, false, ["pipelineTriggers", "parameters"])
+        Utils.generateTypeCache(JobPropertyDescriptor.class, false, BLOCKED_PROPERTIES)
 
     private static final LoadingCache<Object,Map<String,String>> optionTypeCache =
         Utils.generateTypeCache(DeclarativeOptionDescriptor.class, false, [])

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -112,7 +112,7 @@ public class Root implements NestedModel, Serializable {
     List<String> getEnvVars(CpsScript script) {
         if (environment != null) {
             return environment.resolveEnvVars(script, true).findAll {
-                it.key in environment.keySet()
+                it.key in environment.getMap().keySet()
             }.collect { k, v ->
                 "${k}=${v}"
             }
@@ -123,7 +123,7 @@ public class Root implements NestedModel, Serializable {
 
     Map<String, CredentialWrapper> getEnvCredentials() {
         Map<String, CredentialWrapper> m = [:]
-        environment.each {k, v ->
+        environment?.credsMap?.each {k, v ->
             if (v instanceof  CredentialWrapper) {
                 m["${k}"] = v;
             }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -121,16 +121,6 @@ public class Root implements NestedModel, Serializable {
         }
     }
 
-    Map<String, CredentialWrapper> getEnvCredentials() {
-        Map<String, CredentialWrapper> m = [:]
-        environment?.credsMap?.each {k, v ->
-            if (v instanceof  CredentialWrapper) {
-                m["${k}"] = v;
-            }
-        }
-        return m
-    }
-
     @Override
     public void modelFromMap(Map<String,Object> m) {
         m.each { k, v ->

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -108,16 +108,6 @@ public class Stage implements NestedModel, Serializable {
         }
     }
 
-    Map<String, CredentialWrapper> getEnvCredentials() {
-        Map<String, CredentialWrapper> m = [:]
-        environment?.credsMap?.each {k, v ->
-            if (v instanceof  CredentialWrapper) {
-                m["${k}"] = v;
-            }
-        }
-        return m
-    }
-
     @Override
     public void modelFromMap(Map<String,Object> m) {
         m.each { k, v ->

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -99,7 +99,7 @@ public class Stage implements NestedModel, Serializable {
     List<String> getEnvVars(Root root, CpsScript script) {
         if (environment != null) {
             return environment.resolveEnvVars(script, true, root.environment).findAll {
-                it.key in environment.keySet()
+                it.key in environment.getMap().keySet()
             }.collect { k, v ->
                 "${k}=${v}"
             }
@@ -108,17 +108,15 @@ public class Stage implements NestedModel, Serializable {
         }
     }
 
-    @Nonnull
     Map<String, CredentialWrapper> getEnvCredentials() {
         Map<String, CredentialWrapper> m = [:]
-        environment.each {k, v ->
+        environment?.credsMap?.each {k, v ->
             if (v instanceof  CredentialWrapper) {
                 m["${k}"] = v;
             }
         }
         return m
     }
-
 
     @Override
     public void modelFromMap(Map<String,Object> m) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -245,6 +245,7 @@ class ModelParser implements Parser {
                                 r.variables[key] = parseArgument(exp.rightExpression)
                                 return
                             } else if (exp.rightExpression instanceof MethodCallExpression) {
+                                // This is special casing exclusively for credentials and will ideally be eliminated.
                                 r.variables[key] = parseInternalFunctionCall((MethodCallExpression) exp.rightExpression)
                                 return
                             } else if (exp.rightExpression instanceof BinaryExpression) {
@@ -311,7 +312,7 @@ class ModelParser implements Parser {
                     return null
                 }
             } else {
-                errorCollector.error(new ModelASTKey(exp), Messages.ModelParser_InvalidEnvironmentOperation())
+                errorCollector.error(new ModelASTKey(exp.leftExpression), Messages.ModelParser_InvalidEnvironmentOperation())
                 return null
             }
         } else {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/CredentialsBindingHandler.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/CredentialsBindingHandler.java
@@ -71,7 +71,9 @@ public abstract class CredentialsBindingHandler<C extends StandardCredentials> i
     }
 
     @Nonnull
-    public abstract List<MultiBinding<C>> toBindings(String varName, String credentialsId);
+    public List<MultiBinding<C>> toBindings(String varName, String credentialsId) {
+        return Collections.emptyList();
+    }
 
     @Nonnull
     public abstract Class<? extends StandardCredentials> type();

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -211,7 +211,14 @@ public class ModelInterpreter implements Serializable {
             List<String> evaledEnv = new ArrayList<>()
             for (int i = 0; i < envVars.size(); i++) {
                 // Evaluate to deal with any as-of-yet unresolved expressions.
-                evaledEnv.add((String)script.evaluate('"' + envVars.get(i) + '"'))
+                String toEval = envVars.get(i)
+                if (toEval.indexOf('\n') == -1) {
+                    toEval = '"' + (toEval.replace('"', '\\"')) + '"';
+                } else {
+                    toEval = '"""' + (toEval.replace('"""', '\\"\\"\\"')) + '"""';
+                }
+
+                evaledEnv.add((String)script.evaluate(toEval))
             }
             return {
                 script.withEnv(evaledEnv) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -213,7 +213,6 @@ public class ModelInterpreter implements Serializable {
             for (int i = 0; i < envVars.size(); i++) {
                 // Evaluate to deal with any as-of-yet unresolved expressions.
                 String toEval = Utils.prepareForEvalToString(envVars.get(i))
-
                 evaledEnv.add((String)script.evaluate(toEval))
             }
             return {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -213,11 +213,14 @@ public class ModelInterpreter implements Serializable {
                 // Evaluate to deal with any as-of-yet unresolved expressions.
                 String toEval = envVars.get(i)
                 if (toEval.indexOf('\n') == -1) {
-                    toEval = '"' + (toEval.replace('"', '\\"')) + '"';
+                    toEval = '"' + toEval + '"';
+//                    toEval = '"' + (toEval.replace('"', '\\"')) + '"';
                 } else {
-                    toEval = '"""' + (toEval.replace('"""', '\\"\\"\\"')) + '"""';
+                    toEval = '"""' + toEval + '"""';
+//                    toEval = '"""' + (toEval.replace('"""', '\\"\\"\\"')) + '"""';
                 }
 
+                System.err.println("toEval: ${toEval}")
                 evaledEnv.add((String)script.evaluate(toEval))
             }
             return {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -75,7 +75,7 @@ public class ModelInterpreter implements Serializable {
                 inDeclarativeAgent(root, root, root.agent) {
                     withEnvBlock(root.getEnvVars(script)) {
                         inWrappers(root.options) {
-                            withCredentialsBlock(Utils.getEnvCredentials(root.environment, script)) {
+                            withCredentialsBlock(root.environment) {
                                 toolsBlock(root.agent, root.tools) {
                                     for (int i = 0; i < root.stages.getStages().size(); i++) {
                                         Stage thisStage = root.stages.getStages().get(i)
@@ -96,7 +96,7 @@ public class ModelInterpreter implements Serializable {
                                                     withEnvBlock(thisStage.getEnvVars(root, script)) {
                                                         if (evaluateWhen(thisStage.when)) {
                                                             inDeclarativeAgent(thisStage, root, thisStage.agent) {
-                                                                withCredentialsBlock(Utils.getEnvCredentials(thisStage.environment, script)) {
+                                                                withCredentialsBlock(thisStage.environment) {
                                                                     toolsBlock(thisStage.agent ?: root.agent, thisStage.tools) {
                                                                         // Execute the actual stage and potential post-stage actions
                                                                         executeSingleStage(root, thisStage)
@@ -237,8 +237,7 @@ public class ModelInterpreter implements Serializable {
      */
     def withCredentialsBlock(@CheckForNull Environment environment, Closure body) {
         Map<String,CredentialWrapper> creds = new TreeMap<>()
-
-
+        
         if (environment != null) {
             try {
                 List<List<String>> credStrings = Utils.getEnvCredentials(environment, script)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -184,7 +184,7 @@ public abstract class AbstractModelDefTest {
         result.add(new Object[]{"perStageConfigUnknownSection", "additional properties are not allowed"});
 
         result.add(new Object[]{"unknownAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", "[otherField, docker, dockerfile, label, any, none]")});
-        result.add(new Object[]{"invalidWrapperType", Messages.ModelValidatorImpl_InvalidSectionType("option", "echo", "[buildDiscarder, catchError, disableConcurrentBuilds, overrideIndexTriggers, retry, script, skipDefaultCheckout, skipStagesAfterUnstable, timeout, waitUntil, withContext, withEnv, ws]")});
+        result.add(new Object[]{"invalidWrapperType", Messages.ModelValidatorImpl_InvalidSectionType("option", "echo", "[buildDiscarder, catchError, disableConcurrentBuilds, overrideIndexTriggers, retry, script, skipDefaultCheckout, skipStagesAfterUnstable, timeout, waitUntil, withEnv, ws]")});
 
         result.add(new Object[]{"unknownBareAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", "[otherField, docker, dockerfile, label, any, none]")});
         result.add(new Object[]{"agentMissingRequiredParam", Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField]")});

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -54,6 +54,7 @@ import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Options;
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
 import org.jenkinsci.plugins.pipeline.modeldefinition.util.HasArchived;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -130,7 +131,7 @@ public abstract class AbstractModelDefTest {
 
         for (JobPropertyDescriptor d : j.jenkins.getExtensionList(JobPropertyDescriptor.class)) {
             String symbol = symbolFromDescriptor(d);
-            if (symbol != null && !symbol.equals("pipelineTriggers") && !symbol.equals("properties")) {
+            if (symbol != null && !Options.BLOCKED_PROPERTIES.contains(symbol)) {
                 optionTypes.add(symbol);
             }
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -52,6 +52,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
 import org.jenkinsci.plugins.docker.workflow.client.DockerClient;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
 import org.jenkinsci.plugins.pipeline.modeldefinition.util.HasArchived;
@@ -143,7 +144,7 @@ public abstract class AbstractModelDefTest {
 
         for (StepDescriptor d : j.jenkins.getExtensionList(StepDescriptor.class)) {
             if (d.takesImplicitBlockArgument() &&
-                    !(ModelASTStep.getBlockedSteps().containsKey(d.getFunctionName())) &&
+                    !(ModelASTMethodCall.getBlockedSteps().containsKey(d.getFunctionName())) &&
                     !(d.getRequiredContext().contains(FilePath.class)) &&
                     !(d.getRequiredContext().contains(Launcher.class))) {
                 optionTypes.add(d.getFunctionName());

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommandTest.java
@@ -52,7 +52,7 @@ public class DeclarativeLinterCommandTest extends AbstractModelDefTest {
     public TemporaryFolder tmp = new TemporaryFolder();
 
     @Before
-    public void setUp() {
+    public void setUpPerTest() {
         command = new CLICommandInvoker(j, "declarative-linter");
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -105,6 +105,17 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Test
+    public void envDotCrossRef() throws Exception {
+        expect("envDotCrossRef")
+                .logContains("[Pipeline] { (foo)",
+                        "MICROSERVICE_NAME is directory",
+                        "IMAGE_NAME is quay.io/svc/directory",
+                        "IMAGE_ID is quay.io/svc/directory:master_1",
+                        "TAG_NAME is master_1")
+                .go();
+    }
+
     @Issue("JENKINS-41890")
     @Test
     public void environmentWithWorkspace() throws Exception {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -56,6 +56,16 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43137")
+    @Test
+    public void multilineEnvironment() throws Exception {
+        expect("multilineEnvironment")
+                .logContains("[Pipeline] { (foo)",
+                        "FOO is BAR",
+                        "MULTILINE is VALID\n\"SO THERE\"")
+                .go();
+    }
+
     @Issue("JENKINS-42771")
     @Test
     public void multiExpressionEnvironment() throws Exception {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -56,6 +56,16 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43143")
+    @Test
+    public void paramsInEnvironment() throws Exception {
+        expect("paramsInEnvironment")
+                .logContains("[Pipeline] { (foo)",
+                        "FOO is BAR",
+                        "_UNDERSCORE is VALIDAValue")
+                .go();
+    }
+
     @Issue("JENKINS-43137")
     @Test
     public void multilineEnvironment() throws Exception {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -575,4 +575,12 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-42858")
+    @Test
+    public void scriptSecurityRejectionInEnvironment() throws Exception {
+        expectError("scriptSecurityRejectionInEnvironment")
+                .logContains("org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use staticField java.lang.System err")
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -426,14 +426,14 @@ public class ValidatorTest extends AbstractModelDefTest {
     @Test
     public void unknownAgentType() throws Exception {
         expectError("unknownAgentType")
-                .logContains(Messages.ModelValidatorImpl_InvalidAgentType("foo", "[otherField, docker, dockerfile, label, any, none]"))
+                .logContains(Messages.ModelValidatorImpl_InvalidAgentType("foo", legalAgentTypes))
                 .go();
     }
 
     @Test
     public void missingAgentType() throws Exception {
         expectError("missingAgentType")
-                .logContains(Messages.ModelValidatorImpl_NoAgentType("[otherField, docker, dockerfile, label, any, none]"))
+                .logContains(Messages.ModelValidatorImpl_NoAgentType(legalAgentTypes))
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
@@ -35,6 +35,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.endpoints.ModelConverterAc
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
@@ -112,4 +113,13 @@ public class WhenStageTest extends AbstractModelDefTest {
         assertThat(result, hasEntry("status", "ok"));
         assertThat(result, hasEntry("data", hasEntry("result", "success")));
     }
+
+    @Issue("JENKINS-43143")
+    @Test
+    public void paramsInWhenExpression() throws Exception {
+        expect("paramsInWhenExpression")
+                .logContains("[Pipeline] { (One)", "[Pipeline] { (Two)", "World")
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -43,6 +43,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -99,6 +100,18 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
         expect("usernamePassword").runFromRepo(false)
                 .logNotContains(usernamePasswordPassword, "FOO_USR is " + usernamePasswordUsername)
                 .logContains("FOO_USR is *")
+                .archives("combined/foo.txt", allOf(containsString(usernamePasswordUsername), containsString(usernamePasswordPassword)))
+                .archives("foo_usr.txt", usernamePasswordUsername).archives("foo_psw.txt", usernamePasswordPassword).go();
+    }
+
+
+    @Issue("JENKINS-43143")
+    @Test
+    public void paramsInCreds() throws Exception {
+        expect("paramsInCreds").runFromRepo(false)
+                .logNotContains(usernamePasswordPassword, "FOO_USR is " + usernamePasswordUsername)
+                .logContains("FOO_USR is *")
+                .logContains("CONTAINS_CREDS is FOOcredentials")
                 .archives("combined/foo.txt", allOf(containsString(usernamePasswordUsername), containsString(usernamePasswordPassword)))
                 .archives("foo_usr.txt", usernamePasswordUsername).archives("foo_psw.txt", usernamePasswordPassword).go();
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -146,4 +146,17 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
                 .logContains("No suitable binding handler could be found for type com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey")
                 .go();
     }
+
+    @Issue("JENKINS-42858")
+    @Test
+    public void credentialsEnvCrossReference() throws Exception {
+        expect("credentialsEnvCrossReference")
+                .logContains("SOME_VAR is SOME VALUE",
+                        "INBETWEEN is Something **** between",
+                        "OTHER_VAR is OTHER VALUE")
+                .archives("inbetween.txt", "Something " + mixedEnvCred1Secret + " between")
+                .archives("cred1.txt", mixedEnvCred1Secret)
+                .archives("cred2.txt", mixedEnvCred2U + ":" + mixedEnvCred2P).go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/credentialsEnvCrossReference.groovy
+++ b/pipeline-model-definition/src/test/resources/credentialsEnvCrossReference.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        SOME_VAR = "SOME VALUE"
+        CRED1 = credentials("cred1")
+        INBETWEEN = "Something ${CRED1} between"
+        CRED2 = credentials("cred2")
+        OTHER_VAR = "OTHER VALUE"
+    }
+
+    agent any
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "SOME_VAR is $SOME_VAR"'
+                sh 'echo "OTHER_VAR is $OTHER_VAR"'
+                sh 'echo "INBETWEEN is $INBETWEEN"'
+                sh 'echo $INBETWEEN > inbetween.txt'
+                sh 'echo $CRED1 > cred1.txt'
+                sh 'echo $CRED2 > cred2.txt'
+                archive "**/*.txt"
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/envDotCrossRef.groovy
+++ b/pipeline-model-definition/src/test/resources/envDotCrossRef.groovy
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+
+    environment {
+        // Regrettably needed since GitSampleRepoRule doesn't set BRANCH_NAME.
+        BRANCH_NAME = "master"
+
+        MICROSERVICE_NAME = "directory"
+        IMAGE_NAME = "quay.io/svc/${env.MICROSERVICE_NAME}"
+
+        IMAGE_ID = "${env.IMAGE_NAME}:${env.TAG_NAME}"
+        SOMETHING_OR_OTHER = "${env.BRANCH_NAME + "_" + env.BUILD_ID}"
+        TAG_NAME = "${env.SOMETHING_OR_OTHER.replaceAll("[.:/\\\\#]", '-')}"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                echo "MICROSERVICE_NAME is ${env.MICROSERVICE_NAME}"
+                echo "IMAGE_NAME is ${env.IMAGE_NAME}"
+                echo "IMAGE_ID is ${env.IMAGE_ID}"
+                echo "TAG_NAME is ${env.TAG_NAME}"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/scriptSecurityRejectionInEnvironment.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/scriptSecurityRejectionInEnvironment.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO = "BAR"
+        BUILD_NUM_ENV = currentBuild.getNumber()
+        ANOTHER_ENV = "${System.err.println('splode'); currentBuild.getNumber()}"
+        INHERITED_ENV = "\${BUILD_NUM_ENV} is inherited"
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh 'echo "BUILD_NUM_ENV is $BUILD_NUM_ENV"'
+                sh 'echo "ANOTHER_ENV is $ANOTHER_ENV"'
+                sh 'echo "INHERITED_ENV is $INHERITED_ENV"'
+            }
+        }
+    }
+}
+
+

--- a/pipeline-model-definition/src/test/resources/multilineEnvironment.groovy
+++ b/pipeline-model-definition/src/test/resources/multilineEnvironment.groovy
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO = "BAR"
+        MULTILINE = '''VALID
+"SO THERE"
+'''
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh 'echo "MULTILINE is $MULTILINE"'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/paramsInCreds.groovy
+++ b/pipeline-model-definition/src/test/resources/paramsInCreds.groovy
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+
+    parameters {
+        string(defaultValue:'FOOcredentials', description: "A parameter", name: 'testCreds')
+    }
+
+    environment {
+        FOO = credentials("$testCreds")
+        CONTAINS_CREDS = "${testCreds}"
+    }
+
+    agent any
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh 'echo "FOO_USR is $FOO_USR"'
+                sh 'echo "FOO_PSW is $FOO_PSW"'
+                sh 'echo "CONTAINS_CREDS is $CONTAINS_CREDS"'
+
+                //Write to file
+                dir("combined") {
+                    sh 'echo $FOO > foo.txt'
+                }
+                sh 'echo $FOO_PSW > foo_psw.txt'
+                sh 'echo $FOO_USR > foo_usr.txt'
+                archive "**/*.txt"
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/paramsInEnvironment.groovy
+++ b/pipeline-model-definition/src/test/resources/paramsInEnvironment.groovy
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    parameters {
+        string(defaultValue:'AValue', description: "A parameter", name: 'someParam')
+    }
+
+    environment {
+        FOO = "BAR"
+        _UNDERSCORE = "VALID${someParam}"
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh 'echo "_UNDERSCORE is $_UNDERSCORE"'
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/paramsInWhenExpression.groovy
+++ b/pipeline-model-definition/src/test/resources/paramsInWhenExpression.groovy
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+
+    parameters {
+        string(defaultValue:'AValue', description: "A parameter", name: 'someParam')
+    }
+
+    stages {
+        stage("One") {
+            steps {
+                echo "Hello"
+            }
+        }
+        stage("Two") {
+            when {
+                expression {
+                    echo "Should I run?"
+                    return params.someParam == "AValue"
+                }
+            }
+            steps {
+                script {
+                    echo "World"
+                    echo "Heal it"
+                }
+
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.5</version>
+        <version>2.9</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials-binding</artifactId>
-        <version>1.10</version>
+        <version>1.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43137](https://issues.jenkins-ci.org/browse/JENKINS-43137)
    * [JENKINS-43143](https://issues.jenkins-ci.org/browse/JENKINS-43143)
    * [JENKINS-43177](https://issues.jenkins-ci.org/browse/JENKINS-43177)
    * [JENKINS-43013](https://issues.jenkins-ci.org/browse/JENKINS-43013)
    * [JENKINS-42858](https://issues.jenkins-ci.org/browse/JENKINS-42858)
* Description:
    * Environment variables with triple-quoted strings and ones with double-quotes inside them did not evaluate correctly. This fixes that.
    * Make sure we process `params` into the environment, for normal environment variables and credentials.
    * Use our own variable resolution logic rather than that from `EnvVars` to handle more complex expressions.
    * The new round-robin variable resolution also deals with ordering issues!
    * Round-robin process credentials when we're resolving environment variables as well - we'll still end up re-processing credentials later in `withCredentials`, but this way, we can address [JENKINS-42858](https://issues.jenkins-ci.org/browse/JENKINS-42858) and let credential IDs refer to environment variables *and* environment variables refer to credentials env vars (within reason).
    * In general, simplify (ha!) a bunch of environment logic, rationalize it, make it consistent.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
