### PR TITLE
feat: allow to user variables (again) in environment declaration

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -258,6 +258,10 @@ class ModelParser implements Parser {
                                     errorCollector.error(new ModelASTKey(exp.rightExpression), Messages.ModelParser_InvalidEnvironmentOperation())
                                     return
                                 }
+                            } else if (exp.rightExpression instanceof VariableExpression) {
+                                String var = matchStringLiteral(exp.rightExpression)
+                                r.variables[key] =  ModelASTValue.fromConstant(var, exp.rightExpression)
+                                return
                             } else {
                                 errorCollector.error(new ModelASTKey(exp.rightExpression), Messages.ModelParser_InvalidEnvironmentValue())
                                 return

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -97,6 +97,15 @@ public class EnvironmentTest extends AbstractModelDefTest {
     }
 
     @Test
+    public void environmentWithVariable() throws Exception {
+        expect("environmentWithVariable")
+                .logContains("[Pipeline] { (foo)",
+                             "FOO is BAR")
+                .go();
+    }
+
+
+    @Test
     public void nonLiteralEnvironment() throws Exception {
         initGlobalLibrary();
 

--- a/pipeline-model-definition/src/test/resources/environmentWithVariable.groovy
+++ b/pipeline-model-definition/src/test/resources/environmentWithVariable.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+def BAR = "bar";
+
+pipeline {
+    environment {
+        FOO = BAR
+    }
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* Description:
    * We can't use variables in environment declarations since 1.1 release
    * This fix resolves the second point in the provided JenkinsFile.
```
def BAR = "bar";
pipeline {
    environment {
        FOO = "${BAR}" // Binding Error
        FOO = BAR          // Environment variable values must either be strings or function calls
    }
    agent {
        label "some-label"
    }

    stages {
        stage("foo") {
            steps {
                sh 'echo "FOO is $FOO"'
            }
        }
    }
}
```