### PR TITLE
[FIXED JENKINS-43486] Handle non-String parameters in env resolution

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
@@ -60,7 +60,11 @@ public class Environment implements Serializable {
 
     public Map<String,String> getCredsMap(CpsScript script) {
         Map<String,String> resolvedMap = new TreeMap<>()
-        EnvVars contextEnv = new EnvVars((Map<String,String>)script.getProperty("params"))
+        EnvVars contextEnv = new EnvVars()
+        ((Map<String,Object>)script.getProperty("params")).each { k, v ->
+            contextEnv.put(k, v.toString())
+        }
+
         contextEnv.overrideExpandingAll(((EnvActionImpl)script.getProperty("env")).getEnvironment())
 
         credsMap.each { k, v ->
@@ -112,7 +116,7 @@ public class Environment implements Serializable {
         Binding binding = new Binding(alreadySet)
 
         // Also add the params global variable to deal with any references to params.FOO.
-        binding.setProperty("params", (Map<String, String>) script.getProperty("params"))
+        binding.setProperty("params", (Map<String, Object>) script.getProperty("params"))
 
         // Do a first round of resolution before we proceed onward to credentials - if no credentials are defined, we
         // don't need to do anything more.

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
@@ -61,12 +61,8 @@ public class Environment implements Serializable {
     public Map<String,String> getCredsMap(CpsScript script) {
         Map<String,String> resolvedMap = new TreeMap<>()
         EnvVars contextEnv = new EnvVars()
-        try {
-            ((Map<String,Object>)script.getProperty("params")).each { k, v ->
-                contextEnv.put(k, v?.toString() ?: "")
-            }
-        } catch (NullPointerException e) {
-            // Continue - once JENKINS-43511 is dealt with we can be more specific here.
+        ((Map<String,Object>)script.getProperty("params")).each { k, v ->
+            contextEnv.put(k, v?.toString() ?: "")
         }
 
         contextEnv.overrideExpandingAll(((EnvActionImpl)script.getProperty("env")).getEnvironment())
@@ -105,12 +101,8 @@ public class Environment implements Serializable {
             alreadySet.putAll(((EnvActionImpl) script.getProperty("env")).getEnvironment())
         }
         // Add parameters.
-        try {
-            ((Map<String, Object>) script.getProperty("params")).each { k, v ->
-                alreadySet.put(k, v?.toString() ?: "")
-            }
-        } catch (NullPointerException e) {
-            // Continue - once JENKINS-43511 is dealt with we can be more specific here.
+        ((Map<String, Object>) script.getProperty("params")).each { k, v ->
+            alreadySet.put(k, v?.toString() ?: "")
         }
 
         // If we're being called for a stage, add any root level environment variables after resolving them.
@@ -126,11 +118,7 @@ public class Environment implements Serializable {
         Binding binding = new Binding(alreadySet)
 
         // Also add the params global variable to deal with any references to params.FOO.
-        try {
-            binding.setProperty("params", (Map<String, Object>) script.getProperty("params"))
-        } catch (NullPointerException e) {
-            // Continue - once JENKINS-43511 is dealt with we can be more specific here.
-        }
+        binding.setProperty("params", (Map<String, Object>) script.getProperty("params"))
 
         // Do a first round of resolution before we proceed onward to credentials - if no credentials are defined, we
         // don't need to do anything more.

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -149,4 +149,11 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43486")
+    @Test
+    public void nullParamAndEnv() throws Exception {
+        expect("nullParamAndEnv")
+                .logContains("hello")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -141,4 +141,12 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43486")
+    @Test
+    public void booleanParamAndEnv() throws Exception {
+        expect("booleanParamAndEnv")
+                .logContains("hello")
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/booleanParamAndEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/booleanParamAndEnv.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    parameters {
+        booleanParam(defaultValue: true, description: '', name: 'flag')
+    }
+    environment {
+        FOO = "bar"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/nullParamAndEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/nullParamAndEnv.groovy
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    parameters {
+        string(description: '', name: 'SOME_STRING')
+        booleanParam(defaultValue: true, description: '', name: 'flag')
+    }
+    environment {
+        FOO = "bar"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2.23</version>
+        <version>2.29</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.8</version>
+        <version>2.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -131,12 +131,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>2.11</version>
+        <version>2.14</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>2.11</version>
+        <version>2.14</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43486](https://issues.jenkins-ci.org/browse/JENKINS-43486)
* Description:
    * non-`String` parameters (most notably `booleanParam`) were causing `ClassCastException`s when we tried to add them to the map for `environment` resolution, so do an explicit `toString()` on them.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @rsandell 
