### PR TITLE
[FIXED JENKINS-43339] Properly set result from FlowInterruptedException

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -158,6 +158,18 @@
       <artifactId>pipeline-build-step</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-milestone-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-input-step</artifactId>
+      <scope>test</scope>
+    </dependency>
     
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -33,6 +33,7 @@ import groovy.json.StringEscapeUtils
 import hudson.ExtensionList
 import hudson.model.Describable
 import hudson.model.Descriptor
+import hudson.model.Result
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.lang.StringUtils
 import org.jenkinsci.plugins.pipeline.StageStatus
@@ -71,6 +72,7 @@ import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode
 import org.jenkinsci.plugins.workflow.graph.FlowNode
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 import org.jenkinsci.plugins.workflow.support.steps.StageStep
 
@@ -689,4 +691,20 @@ public class Utils {
             return Collections.singletonMap(UninstantiatedDescribable.ANONYMOUS_KEY, _args)
         }
     }
+
+    /**
+     * Get the appropriate result given an exception. If it's a {@link FlowInterruptedException}, return the result
+     * on the exception, otherwise return {@link Result#FAILURE}.
+     *
+     * @param e The exception.
+     * @return The result.
+     */
+    static Result getResultFromException(Exception e) {
+        if (e instanceof FlowInterruptedException) {
+            return ((FlowInterruptedException)e).result
+        } else {
+            return Result.FAILURE
+        }
+    }
+
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,33 +21,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 
-
-package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
-
+import hudson.Extension
 import hudson.model.Result
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
-import org.jenkinsci.plugins.workflow.cps.CpsScript
+import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
-public class LabelScript extends DeclarativeAgentScript<Label> {
-
-    public LabelScript(CpsScript s, Label a) {
-        super(s, a)
+/**
+ * A {@link BuildCondition} for matching unbuilt builds, such as those stopped by milestones.
+ *
+ * @author Andrew Bayer
+ */
+@Extension(ordinal=400d) @Symbol("notBuilt")
+public class NotBuilt extends BuildCondition {
+    @Override
+    public boolean meetsCondition(WorkflowRun r) {
+        return r.getResult() != null && r.getResult().equals(Result.NOT_BUILT)
     }
 
     @Override
-    public Closure run(Closure body) {
-        return {
-            try {
-                script.node(describable?.label) {
-                    CheckoutScript.doCheckout(script, describable, describable.customWorkspace, body).call()
-                }
-            } catch (Exception e) {
-                script.getProperty("currentBuild").result = Utils.getResultFromException(e)
-                throw e
-            }
-        }
+    public String getDescription() {
+        return Messages.NotBuilt_Description()
     }
+
+    public static final long serialVersionUID = 1L
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -27,7 +27,6 @@ import com.cloudbees.groovy.cps.NonCPS
 import com.cloudbees.groovy.cps.impl.CpsClosure
 import hudson.FilePath
 import hudson.Launcher
-import hudson.model.Result
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional
@@ -111,7 +110,7 @@ public class ModelInterpreter implements Serializable {
                                                 }
                                             }
                                         } catch (Exception e) {
-                                            script.getProperty("currentBuild").result = Result.FAILURE
+                                            script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                                             Utils.markStageFailedAndContinued(thisStage.name)
                                             if (firstError == null) {
                                                 firstError = e
@@ -427,7 +426,7 @@ public class ModelInterpreter implements Serializable {
                 delegateAndExecute(thisStage.steps.closure)
             }
         } catch (Exception e) {
-            script.getProperty("currentBuild").result = Result.FAILURE
+            script.getProperty("currentBuild").result = Utils.getResultFromException(e)
             Utils.markStageFailedAndContinued(thisStage.name)
             if (stageError == null) {
                 stageError = e
@@ -503,7 +502,7 @@ public class ModelInterpreter implements Serializable {
                     }
                 }
             } catch (Exception e) {
-                script.getProperty("currentBuild").result = Result.FAILURE
+                script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                 if (stageName != null) {
                     Utils.markStageFailedAndContinued(stageName)
                 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -46,7 +46,7 @@ public class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineSc
                     try {
                         img = buildImage().call()
                     } catch (Exception e) {
-                        script.getProperty("currentBuild").result = Result.FAILURE
+                        script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                         Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
                         throw e
                     }
@@ -55,7 +55,7 @@ public class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineSc
                 try {
                     img = buildImage().call()
                 } catch (Exception e) {
-                    script.getProperty("currentBuild").result = Result.FAILURE
+                    script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                     throw e
                 }
             }
@@ -65,7 +65,7 @@ public class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineSc
                         body.call()
                     })
                 } catch (Exception e) {
-                    script.getProperty("currentBuild").result = Result.FAILURE
+                    script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                     throw e
                 }
             }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
@@ -44,7 +44,7 @@ public class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPip
                     try {
                         script.getProperty("docker").image(describable.image).pull()
                     } catch (Exception e) {
-                        script.getProperty("currentBuild").result = Result.FAILURE
+                        script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                         Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
                         throw e
                     }
@@ -55,7 +55,7 @@ public class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPip
                     body.call()
                 })
             } catch (Exception e) {
-                script.getProperty("currentBuild").result = Result.FAILURE
+                script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                 throw e
             }
         }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
@@ -26,5 +26,6 @@ Aborted.Description=Run when the build status is "Aborted"
 Always.Description=Always run, regardless of build status
 Changed.Description=Run if the current build's status is different than the previous build's status
 Failure.Description=Run if the build status is "Failure"
+NotBuilt.Description=Run if the build status is "Not Built"
 Success.Description=Run if the build status is "Success" or hasn't been set yet
 Unstable.Description=Run if the build status is "Unstable"

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -24,10 +24,13 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.google.common.base.Predicate;
 import htmlpublisher.HtmlPublisherTarget;
 import hudson.model.Result;
 import hudson.model.Slave;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitSCMSource;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction;
@@ -41,10 +44,13 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTreeStep;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue;
 import org.jenkinsci.plugins.workflow.actions.TagsAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.DepthFirstScanner;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.libs.FolderLibraries;
 import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
@@ -52,9 +58,14 @@ import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 
 import java.util.Arrays;
 import java.io.File;
@@ -727,5 +738,90 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         expect("inCustomWorkspaceInStage")
                 .logMatches("Workspace dir is .*some-sub-dir")
                 .go();
+    }
+
+    @Issue("JENKINS-43339")
+    @Test
+    public void notBuiltFlowInterruptedException() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "milestone-flow-interrupted");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "pipeline {\n" +
+                "  agent none\n" +
+                "  stages {\n" +
+                "    stage('milestones') {\n" +
+                "      steps {\n" +
+                "        milestone(1)\n" +
+                "        semaphore 'wait'\n" +
+                "        milestone(2)\n" +
+                "      }\n" +
+                "      post {\n" +
+                "        notBuilt {\n" +
+                "          echo 'Job not built due to milestone'\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n", true));
+
+        WorkflowRun run1 = job.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait/1", run1);
+        WorkflowRun run2 = job.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait/2", run2);
+
+        SemaphoreStep.success("wait/2", null);
+
+        j.waitForCompletion(run2);
+
+        j.assertBuildStatus(Result.NOT_BUILT, j.waitForCompletion(run1));
+
+        j.assertLogContains("Job not built due to milestone", run1);
+    }
+
+    @Issue("JENKINS-43339")
+    @Test
+    public void abortedFlowInterruptedException() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to("ops"));
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "input-flow-interrupted");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "pipeline {\n" +
+                "  agent none\n" +
+                "  stages {\n" +
+                "    stage('input') {\n" +
+                "      steps {\n" +
+                "        input(id: 'InputX', message: 'OK?', ok: 'Yes', submitter: 'ops')\n" +
+                "      }\n" +
+                "      post {\n" +
+                "        aborted {\n" +
+                "          echo 'Job aborted due to input'\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n", true));
+
+        QueueTaskFuture<WorkflowRun> queueTaskFuture = job.scheduleBuild2(0);
+        WorkflowRun run = queueTaskFuture.getStartCondition().get();
+        CpsFlowExecution execution = (CpsFlowExecution) run.getExecutionPromise().get();
+
+        while (run.getAction(InputAction.class) == null) {
+            execution.waitForSuspension();
+        }
+
+        JenkinsRule.WebClient webClient = j.createWebClient();
+
+        webClient.login("ops");
+
+        InputAction inputAction = run.getAction(InputAction.class);
+        InputStepExecution is = inputAction.getExecution("InputX");
+        HtmlPage p = webClient.getPage(run, inputAction.getUrlName());
+
+        j.submit(p.getFormByName(is.getId()), "abort");
+        assertEquals(0, inputAction.getExecutions().size());
+        queueTaskFuture.get();
+
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
+
+        j.assertLogContains("Job aborted due to input", run);
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -23,12 +23,23 @@
  */
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Andrew Bayer
@@ -98,5 +109,90 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 .logContains("[Pipeline] { (foo)", "hello")
                 .inLogInOrder("I AM ALWAYS", "I CHANGED", "I SUCCEEDED")
                 .go();
+    }
+
+    @Issue("JENKINS-43339")
+    @Test
+    public void notBuiltFlowInterruptedException() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "milestone-flow-interrupted");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "pipeline {\n" +
+                "  agent none\n" +
+                "  stages {\n" +
+                "    stage('milestones') {\n" +
+                "      steps {\n" +
+                "        milestone(1)\n" +
+                "        semaphore 'wait'\n" +
+                "        milestone(2)\n" +
+                "      }\n" +
+                "      post {\n" +
+                "        notBuilt {\n" +
+                "          echo 'Job not built due to milestone'\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n", true));
+
+        WorkflowRun run1 = job.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait/1", run1);
+        WorkflowRun run2 = job.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait/2", run2);
+
+        SemaphoreStep.success("wait/2", null);
+
+        j.waitForCompletion(run2);
+
+        j.assertBuildStatus(Result.NOT_BUILT, j.waitForCompletion(run1));
+
+        j.assertLogContains("Job not built due to milestone", run1);
+    }
+
+    @Issue("JENKINS-43339")
+    @Test
+    public void abortedFlowInterruptedException() throws Exception {
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy().grant(Jenkins.ADMINISTER).everywhere().to("ops"));
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "input-flow-interrupted");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "pipeline {\n" +
+                "  agent none\n" +
+                "  stages {\n" +
+                "    stage('input') {\n" +
+                "      steps {\n" +
+                "        input(id: 'InputX', message: 'OK?', ok: 'Yes', submitter: 'ops')\n" +
+                "      }\n" +
+                "      post {\n" +
+                "        aborted {\n" +
+                "          echo 'Job aborted due to input'\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}\n", true));
+
+        QueueTaskFuture<WorkflowRun> queueTaskFuture = job.scheduleBuild2(0);
+        WorkflowRun run = queueTaskFuture.getStartCondition().get();
+        CpsFlowExecution execution = (CpsFlowExecution) run.getExecutionPromise().get();
+
+        while (run.getAction(InputAction.class) == null) {
+            execution.waitForSuspension();
+        }
+
+        JenkinsRule.WebClient webClient = j.createWebClient();
+
+        webClient.login("ops");
+
+        InputAction inputAction = run.getAction(InputAction.class);
+        InputStepExecution is = inputAction.getExecution("InputX");
+        HtmlPage p = webClient.getPage(run, inputAction.getUrlName());
+
+        j.submit(p.getFormByName(is.getId()), "abort");
+        assertEquals(0, inputAction.getExecutions().size());
+        queueTaskFuture.get();
+
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run));
+
+        j.assertLogContains("Job aborted due to input", run);
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -146,6 +146,9 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         j.assertBuildStatus(Result.NOT_BUILT, j.waitForCompletion(run1));
 
         j.assertLogContains("Job not built due to milestone", run1);
+
+        j.assertBuildStatusSuccess(j.waitForCompletion(run2));
+        j.assertLogNotContains("Job not built due to milestone", run2);
     }
 
     @Issue("JENKINS-43339")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -141,13 +141,12 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
 
         SemaphoreStep.success("wait/2", null);
 
-        j.waitForCompletion(run2);
+        j.assertBuildStatusSuccess(j.waitForCompletion(run2));
 
         j.assertBuildStatus(Result.NOT_BUILT, j.waitForCompletion(run1));
 
         j.assertLogContains("Job not built due to milestone", run1);
 
-        j.assertBuildStatusSuccess(j.waitForCompletion(run2));
         j.assertLogNotContains("Job not built due to milestone", run2);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,16 @@
         <artifactId>jcabi-matchers</artifactId>
         <version>1.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>pipeline-milestone-step</artifactId>
+        <version>1.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>pipeline-input-step</artifactId>
+        <version>2.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43339](https://issues.jenkins-ci.org/browse/JENKINS-43339)
* Description:
    * We should be setting the build result to `FlowInterruptedException.getResult()` when we catch a `FlowInterruptedException`, since there's actually a relevant result there. Also added a `notBuilt` post status while I was here.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @rsandell 
    * @reviewbybees 
