### PR TITLE
[FIXED JENKINS-43872, JENKINS-43910] Yet more env tweaks

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -346,6 +346,10 @@ public class Utils {
         return StringEscapeUtils.unescapeJava(s)
     }
 
+    static String unescapeDollars(String s) {
+        return StringUtils.replace(s, Environment.DOLLAR_PLACEHOLDER, '$')
+    }
+
     static List<List<String>> getEnvCredentials(Environment environment, CpsScript script) {
         List<List<String>> credsTuples = new ArrayList<>()
         if (environment != null) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -350,10 +350,10 @@ public class Utils {
         return StringUtils.replace(s, Environment.DOLLAR_PLACEHOLDER, '$')
     }
 
-    static List<List<String>> getEnvCredentials(Environment environment, CpsScript script) {
+    static List<List<String>> getEnvCredentials(Environment environment, CpsScript script, Environment parent = null) {
         List<List<String>> credsTuples = new ArrayList<>()
         if (environment != null) {
-            credsTuples.addAll(environment.getCredsMap(script)?.collect { k, v ->
+            credsTuples.addAll(environment.getCredsMap(script, parent)?.collect { k, v ->
                 [k, v]
             })
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Environment.groovy
@@ -48,9 +48,9 @@ public class Environment implements Serializable {
     Map<String,EnvValue> valueMap = new TreeMap<>()
     Map<String,EnvValue> credsMap = new TreeMap<>()
 
+    // Caching for resolved environment variables and credentials so we don't process them twice if we don't need to.
     private transient Map<String,String> interimResolved = new TreeMap<>()
     private transient Map<String,String> interimResolvedCreds = new TreeMap<>()
-    private transient boolean needsAgent = false
 
     public void setValueMap(Map<String,EnvValue> inMap) {
         this.valueMap.putAll(inMap)
@@ -67,7 +67,7 @@ public class Environment implements Serializable {
     public Map<String,String> getCredsMap(CpsScript script, Environment parent = null) {
         Map<String,String> resolvedMap = new TreeMap<>()
         if (!credsMap.isEmpty()) {
-            if (interimResolvedCreds.isEmpty() || needsAgent) {
+            if (interimResolvedCreds.isEmpty()) {
                 EnvVars contextEnv = new EnvVars()
                 resolveEnvVars(script, true, parent).each { k, v ->
                     if (v instanceof String) {
@@ -91,7 +91,7 @@ public class Environment implements Serializable {
         Map<String, String> alreadySet = new TreeMap<>()
         if (getMap().isEmpty()) {
             return alreadySet
-        } else if (!interimResolved.isEmpty() && !needsAgent) {
+        } else if (!interimResolved.isEmpty()) {
             alreadySet.putAll(interimResolved)
             return alreadySet
         } else {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -213,7 +213,7 @@ public class ModelInterpreter implements Serializable {
             for (int i = 0; i < envVars.size(); i++) {
                 // Evaluate to deal with any as-of-yet unresolved expressions.
                 String toEval = Utils.prepareForEvalToString(envVars.get(i))
-                evaledEnv.add(Utils.unescapeFromEval((String)script.evaluate(toEval)))
+                evaledEnv.add(Utils.unescapeDollars(Utils.unescapeFromEval((String)script.evaluate(toEval))))
             }
             return {
                 script.withEnv(evaledEnv) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -92,10 +92,10 @@ public class ModelInterpreter implements Serializable {
                                                     // environment is populated before we evaluate any when condition,
                                                     // and so that we don't go into a per-stage agent if the when condition
                                                     // isn't satisfied.
-                                                    withEnvBlock(thisStage.getEnvVars(root, script)) {
+                                                    inDeclarativeAgent(thisStage, root, thisStage.agent) {
                                                         if (evaluateWhen(thisStage.when)) {
-                                                            inDeclarativeAgent(thisStage, root, thisStage.agent) {
-                                                                withCredentialsBlock(thisStage.environment, root.environment) {
+                                                            withCredentialsBlock(thisStage.environment, root.environment) {
+                                                                withEnvBlock(thisStage.getEnvVars(root, script)) {
                                                                     toolsBlock(thisStage.agent ?: root.agent, thisStage.tools) {
                                                                         // Execute the actual stage and potential post-stage actions
                                                                         executeSingleStage(root, thisStage)

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -73,8 +73,8 @@ public class ModelInterpreter implements Serializable {
                 // Entire build, including notifications, runs in the agent.
                 inDeclarativeAgent(root, root, root.agent) {
                     withCredentialsBlock(root.environment) {
-                        inWrappers(root.options) {
-                            withEnvBlock(root.getEnvVars(script)) {
+                        withEnvBlock(root.getEnvVars(script)) {
+                            inWrappers(root.options) {
                                 toolsBlock(root.agent, root.tools) {
                                     for (int i = 0; i < root.stages.getStages().size(); i++) {
                                         Stage thisStage = root.stages.getStages().get(i)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -29,6 +29,7 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -48,11 +49,13 @@ public class AgentTest extends AbstractModelDefTest {
     public static void setUpAgent() throws Exception {
         s = j.createOnlineSlave();
         s.setLabelString("some-label docker");
-        s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true")));
+        s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
+                new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "first")));
 
         s2 = j.createOnlineSlave();
         s2.setLabelString("other-docker");
-        s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true")));
+        s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
+                new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "second")));
     }
 
     @Test
@@ -291,6 +294,16 @@ public class AgentTest extends AbstractModelDefTest {
                         "The answer is 42",
                         "-v /tmp:/tmp -p 8000:8000",
                         "HI THERE")
+                .go();
+    }
+
+    @Ignore("Still not sure yet whether we'll ever fix JENKINS-43911, but wanted to have a test here for if we do")
+    @Issue("JENKINS-43911")
+    @Test
+    public void agentFromEnv() throws Exception {
+        expect("agentFromEnv")
+                .logContains("WHICH_AGENT=first",
+                        "WHICH_AGENT=second")
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -105,6 +105,18 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43872")
+    @Test
+    public void envDollarQuotes() throws Exception {
+        expect("envDollarQuotes")
+                .logContains("[Pipeline] { (foo)",
+                        "FOO is ${FOOTHAT}",
+                        "BAR is ${FOOTHAT}BAR",
+                        "BAZ is ${FOOTHAT}BAZ",
+                        "SPLODE is banana")
+                .go();
+    }
+
     @Test
     public void envDotCrossRef() throws Exception {
         expect("envDotCrossRef")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -71,6 +71,9 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
     private static final String fileCredId = "fileCred";
     private static final String fileCredName = "credFile.txt";
     private static final String fileCredContent = "file-cred-content-is-here";
+    private static final String otherFileCredId = "otherFileCred";
+    private static final String otherFileCredName = "otherCredFile.txt";
+    private static final String otherFileCredContent = "other-file-cred-content-is-here";
     private static Folder folder;
     private static final String mixedEnvInFolderCred1Secret = "Some secret text for 1 folder";
     private static final String mixedEnvInFoldercred2U = "bobby-in-folder";
@@ -92,6 +95,8 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
         store.addCredentials(Domain.global(), mixedEnvCred3);
         FileCredentialsImpl fileCred = new FileCredentialsImpl(CredentialsScope.GLOBAL, fileCredId, "test", fileCredName, SecretBytes.fromBytes(fileCredContent.getBytes()));
         store.addCredentials(Domain.global(), fileCred);
+        FileCredentialsImpl otherFileCred = new FileCredentialsImpl(CredentialsScope.GLOBAL, otherFileCredId, "test", otherFileCredName, SecretBytes.fromBytes(otherFileCredContent.getBytes()));
+        store.addCredentials(Domain.global(), otherFileCred);
 
         folder = j.jenkins.createProject(Folder.class, "testFolder");
         folder.addProperty(new FolderCredentialsProvider.FolderCredentialsProperty(new DomainCredentials[0]));
@@ -187,8 +192,11 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
     public void fileCredentialsInEnv() throws Exception {
         expect("fileCredentialsInEnv")
                 .logContains("FILECRED is ****",
-                        "INBETWEEN is Something **** between")
+                        "INBETWEEN is Something **** between",
+                        "OTHERCRED is ****",
+                        "OTHER_INBETWEEN is THIS **** THAT")
                 .archives("cred1.txt", mixedEnvCred1Secret)
+                .archives("cred2.txt", mixedEnvCred2U + ":" + mixedEnvCred2P)
                 .go();
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -61,7 +61,9 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
     public static final String usernamePasswordPassword = "s3cr37";
     private static final String mixedEnvCred1Id = "cred1";
     private static final String mixedEnvCred2Id = "cred2";
+    private static final String mixedEnvCred3Id = "cred3";
     private static final String mixedEnvCred1Secret = "Some secret text for 1";
+    private static final String mixedEnvCred3Secret = "Some $secret text for 3";
     private static final String mixedEnvCred2U = "bobby";
     private static final String mixedEnvCred2P = "supersecretpassword+mydogsname";
     private static Folder folder;
@@ -81,6 +83,8 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
         store.addCredentials(Domain.global(), mixedEnvCred1);
         UsernamePasswordCredentialsImpl mixedEnvCred2 = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, mixedEnvCred2Id, "sample", mixedEnvCred2U, mixedEnvCred2P);
         store.addCredentials(Domain.global(), mixedEnvCred2);
+        StringCredentialsImpl mixedEnvCred3 = new StringCredentialsImpl(CredentialsScope.GLOBAL, mixedEnvCred3Id, "test", Secret.fromString(mixedEnvCred3Secret));
+        store.addCredentials(Domain.global(), mixedEnvCred3);
 
         folder = j.jenkins.createProject(Folder.class, "testFolder");
         folder.addProperty(new FolderCredentialsProvider.FolderCredentialsProperty(new DomainCredentials[0]));
@@ -159,4 +163,15 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
                 .archives("cred2.txt", mixedEnvCred2U + ":" + mixedEnvCred2P).go();
     }
 
+    @Issue("JENKINS-43872")
+    @Test
+    public void credentialsDollarQuotes() throws Exception {
+        expect("credentialsDollarQuotes")
+                .logContains("SOME_VAR is SOME VALUE",
+                        "INBETWEEN is Something **** between",
+                        "OTHER_VAR is OTHER VALUE")
+                .archives("inbetween.txt", "Something " + mixedEnvCred3Secret + " between")
+                .archives("cred3.txt", mixedEnvCred3Secret)
+                .archives("cred2.txt", mixedEnvCred2U + ":" + mixedEnvCred2P).go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/agentFromEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/agentFromEnv.groovy
@@ -23,36 +23,31 @@
  */
 
 pipeline {
-    environment {
-        FILECRED = credentials("fileCred")
-        INBETWEEN = "Something ${FILECRED} between"
-        CRED_NAME = "cred1"
-        CRED1 = credentials("${CRED_NAME}")
+    agent {
+        label "${FIRST_LABEL}"
     }
-
-    agent any
-
+    environment {
+        FIRST_LABEL = "docker"
+    }
     stages {
         stage("foo") {
             steps {
-                sh 'echo "FILECRED is $FILECRED"'
-                sh 'echo "INBETWEEN is $INBETWEEN"'
-                sh 'echo $CRED1 > cred1.txt'
+                sh('echo WHICH_AGENT=$WHICH_AGENT')
             }
         }
         stage("bar") {
+            agent {
+                label "${SECOND_LABEL}"
+            }
             environment {
-                OTHERCRED = credentials("otherFileCred")
-                OTHER_INBETWEEN = "THIS ${OTHERCRED} THAT"
-                SECOND_CRED = "cred2"
-                CRED2 = credentials("${SECOND_CRED}")
+                SECOND_LABEL = "other-docker"
             }
             steps {
-                sh 'echo "OTHERCRED is $OTHERCRED"'
-                sh 'echo "OTHER_INBETWEEN is $OTHER_INBETWEEN"'
-                sh 'echo $CRED2 > cred2.txt'
-                archive "**/*.txt"
+                sh('echo WHICH_AGENT=$WHICH_AGENT')
             }
         }
     }
 }
+
+
+

--- a/pipeline-model-definition/src/test/resources/credentialsDollarQuotes.groovy
+++ b/pipeline-model-definition/src/test/resources/credentialsDollarQuotes.groovy
@@ -24,29 +24,26 @@
 
 pipeline {
     environment {
-        FOO = 'FOO'
-        BAR = "${FOO}BAR"
+        SOME_VAR = "SOME VALUE"
+        CRED3 = credentials("cred3")
+        INBETWEEN = "Something ${CRED3} between"
+        CRED2 = credentials("cred2")
+        OTHER_VAR = "OTHER VALUE"
     }
-    agent {
-        label "some-label"
-    }
+
+    agent any
 
     stages {
         stage("foo") {
-            environment {
-                BAZ = "${FOO}BAZ"
-                SPLODE = "${params.WUT ?: 'banana'}"
-            }
-
             steps {
-                sh 'echo "FOO is $FOO"'
-                sh 'echo "BAR is $BAR"'
-                sh 'echo "BAZ is $BAZ"'
-                sh 'echo "SPLODE is $SPLODE"'
+                sh 'echo "SOME_VAR is $SOME_VAR"'
+                sh 'echo "OTHER_VAR is $OTHER_VAR"'
+                sh 'echo "INBETWEEN is $INBETWEEN"'
+                sh 'echo $INBETWEEN > inbetween.txt'
+                sh 'echo $CRED3 > cred3.txt'
+                sh 'echo $CRED2 > cred2.txt'
+                archive "**/*.txt"
             }
         }
     }
 }
-
-
-

--- a/pipeline-model-definition/src/test/resources/envDollarQuotes.groovy
+++ b/pipeline-model-definition/src/test/resources/envDollarQuotes.groovy
@@ -24,7 +24,7 @@
 
 pipeline {
     environment {
-        FOO = 'FOO'
+        FOO = '${FOOTHAT}'
         BAR = "${FOO}BAR"
     }
     agent {

--- a/pipeline-model-definition/src/test/resources/fileCredentialsInEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/fileCredentialsInEnv.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FILECRED = credentials("fileCred")
+        INBETWEEN = "Something ${FILECRED} between"
+        CRED_NAME = "cred1"
+        CRED1 = credentials("${CRED_NAME}")
+    }
+
+    agent any
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FILECRED is $FILECRED"'
+                sh 'echo "INBETWEEN is $INBETWEEN"'
+                sh 'echo $CRED1 > cred1.txt'
+                archive "**/*.txt"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43872](https://issues.jenkins-ci.org/browse/JENKINS-43872)
    * [JENKINS-43910](https://issues.jenkins-ci.org/browse/JENKINS-43910)
* Description:
    * Hey look, another dumb `environment`/`script.evaluate` bug! I still should probably rewrite all this yet again, but for now...this "escapes" dollar signs in literal values and credentials values before `evaluate`ing non-literal env vars that may contain references to these literal/credential vars, and then "unescapes" the dollar signs back into place after all the pesky `evaluate`ing is done.
    * Yet more circuitous processing to make sure we have credentials (including file credentials) processed before we try to process the environment, and definitely making agent get processed before either credentials or environment, along with an ignored test for [JENKINS-43911](https://issues.jenkins-ci.org/browse/JENKINS-43911), which existed prior to this but is more obvious now.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @rsandell 
    * @reviewbybees 
    * @stephendonner since it's another one of your reports. =)
