### PR TITLE
[FIXED JENKINS-43055] Change SyntheticStageGraphListener to an Extension

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -220,9 +220,6 @@ public class Utils {
             ModelASTStages stages = model.stages
 
             stages.removeSourceLocation()
-            if (r.getAction(SyntheticStageGraphListener.GraphListenerAction.class) == null) {
-                r.addAction(new SyntheticStageGraphListener.GraphListenerAction())
-            }
             if (r.getAction(ExecutionModelAction.class) == null) {
                 r.addAction(new ExecutionModelAction(stages))
             }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
@@ -87,7 +87,7 @@ public final class SyntheticStageGraphListener implements GraphListener {
     @Extension
     public static class FlowExecutionListenerImpl extends FlowExecutionListener {
         @Override
-        public void onRunning(FlowExecution execution) {
+        public void onRunning(FlowExecution execution, boolean resumed) {
             if (execution != null && !execution.isComplete()) {
                 // Only attach the graph listener if we know the run this execution is for is a Declarative run,
                 // i.e., if it has an ExecutionModelAction.

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
@@ -25,6 +25,9 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.Extension;
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+import jenkins.model.RunAction2;
 import org.jenkinsci.plugins.pipeline.SyntheticStage;
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
@@ -39,6 +42,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.StageStep;
 
 import java.io.IOException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.WARNING;
@@ -96,9 +100,22 @@ public final class SyntheticStageGraphListener implements GraphListener {
                         }
                     }
                 } catch (IOException e) {
-                    // Do nothing
+                    LOGGER.log(Level.WARNING, "Failure to get run for FlowExecution: {0}", e);
                 }
             }
+        }
+    }
+
+    @Deprecated
+    public static class GraphListenerAction extends InvisibleAction implements RunAction2 {
+        @Override
+        public void onLoad(Run<?,?> r) {
+            // no-op
+        }
+
+        @Override
+        public void onAttached(Run<?, ?> r) {
+            // no-op
         }
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
@@ -107,15 +107,6 @@ public final class SyntheticStageGraphListener implements GraphListener {
     }
 
     @Deprecated
-    public static class GraphListenerAction extends InvisibleAction implements RunAction2 {
-        @Override
-        public void onLoad(Run<?,?> r) {
-            // no-op
-        }
-
-        @Override
-        public void onAttached(Run<?, ?> r) {
-            // no-op
-        }
+    public static class GraphListenerAction extends InvisibleAction {
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
@@ -87,7 +87,16 @@ public final class SyntheticStageGraphListener implements GraphListener {
     @Extension
     public static class FlowExecutionListenerImpl extends FlowExecutionListener {
         @Override
-        public void onRunning(FlowExecution execution, boolean resumed) {
+        public void onRunning(FlowExecution execution) {
+            attachGraphListener(execution);
+        }
+
+        @Override
+        public void onResumed(FlowExecution execution) {
+            attachGraphListener(execution);
+        }
+
+        private void attachGraphListener(FlowExecution execution) {
             if (execution != null && !execution.isComplete()) {
                 // Only attach the graph listener if we know the run this execution is for is a Declarative run,
                 // i.e., if it has an ExecutionModelAction.

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
@@ -24,17 +24,15 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
-import hudson.model.InvisibleAction;
-import hudson.model.Run;
-import jenkins.model.RunAction2;
+import hudson.Extension;
 import org.jenkinsci.plugins.pipeline.SyntheticStage;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.TagsAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionListener;
 import org.jenkinsci.plugins.workflow.flow.GraphListener;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.StageStep;
 
 import java.io.IOException;
@@ -79,29 +77,12 @@ public final class SyntheticStageGraphListener implements GraphListener {
         }
     }
 
-    public static class GraphListenerAction extends InvisibleAction implements RunAction2 {
+    @Extension
+    public static class FlowExecutionListenerImpl extends FlowExecutionListener {
         @Override
-        public void onLoad(Run<?, ?> r) {
-            if (r != null && r instanceof WorkflowRun) {
-                WorkflowRun run = (WorkflowRun) r;
-                attachListener(run);
-            }
-        }
-
-        @Override
-        public void onAttached(Run<?, ?> r) {
-            if (r != null && r instanceof WorkflowRun) {
-                WorkflowRun run = (WorkflowRun) r;
-                attachListener(run);
-            }
-        }
-
-        private void attachListener(WorkflowRun run) {
-            if (run != null) {
-                FlowExecution exec = run.getExecution();
-                if (exec != null && !exec.isComplete()) {
-                    exec.addListener(new SyntheticStageGraphListener());
-                }
+        public void onRunning(FlowExecution execution) {
+            if (execution != null && !execution.isComplete()) {
+                execution.addListener(new SyntheticStageGraphListener());
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
-        <version>2.12-20170519.152035-2</version> <!-- TODO: update to release once https://github.com/jenkinsci/workflow-job-plugin/pull/51 is merged and released. -->
+        <version>2.12-20170522.174553-3</version> <!-- TODO: update to release once https://github.com/jenkinsci/workflow-job-plugin/pull/51 is merged and released. -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.14-20170519.151127-6</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-api-plugin/pull/36 is merged and released -->
+        <version>2.15</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,17 +75,17 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2.29</version>
+        <version>2.33-20170525.192309-1</version> <!-- TODO: update to release once 2.33 is released -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
-        <version>2.12-20170522.174553-3</version> <!-- TODO: update to release once https://github.com/jenkinsci/workflow-job-plugin/pull/51 is merged and released. -->
+        <version>2.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.15</version>
+        <version>2.16-20170524.173224-1</version> <!-- TODO: update to release once 2.16 is released -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2.33-20170525.192309-1</version> <!-- TODO: update to release once 2.33 is released -->
+        <version>2.33</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.16-20170524.173224-1</version> <!-- TODO: update to release once 2.16 is released -->
+        <version>2.16</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.14-20170516.161836-2</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-api-plugin/pull/36 is merged and released -->
+        <version>2.14-20170519.135335-5</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-api-plugin/pull/36 is merged and released -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2.31-20170516.164140-1</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-cps-plugin/pull/127 is merged and released -->
+        <version>2.29</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
-        <version>2.9</version>
+        <version>2.12-20170519.143656-1</version> <!-- TODO: update to release once https://github.com/jenkinsci/workflow-job-plugin/pull/51 is merged and released. -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
-        <version>2.12-20170519.143656-1</version> <!-- TODO: update to release once https://github.com/jenkinsci/workflow-job-plugin/pull/51 is merged and released. -->
+        <version>2.12-20170519.152035-2</version> <!-- TODO: update to release once https://github.com/jenkinsci/workflow-job-plugin/pull/51 is merged and released. -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.14-20170519.135335-5</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-api-plugin/pull/36 is merged and released -->
+        <version>2.14-20170519.151127-6</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-api-plugin/pull/36 is merged and released -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2.29</version>
+        <version>2.31-20170516.164140-1</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-cps-plugin/pull/127 is merged and released -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.11</version>
+        <version>2.14-20170516.161836-2</version> <!-- TODO: update when https://github.com/jenkinsci/workflow-api-plugin/pull/36 is merged and released -->
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43055](https://issues.jenkins-ci.org/browse/JENKINS-43055)
* Description:
    * Use the new `GraphListener` `ExtensionPoint` to have a single `SyntheticStageGraphListener` for all runs rather than one per run, with some logic for only firing on Declarative runs. Downstream of the now-merged https://github.com/jenkinsci/workflow-api-plugin/pull/38 and https://github.com/jenkinsci/workflow-cps-plugin/pull/137
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
