### PR TITLE
[FIXED JENKINS-44149] Properly clean up old props/triggers/params

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -33,6 +33,7 @@ import groovy.json.StringEscapeUtils
 import hudson.ExtensionList
 import hudson.model.Describable
 import hudson.model.Descriptor
+import hudson.model.ParametersDefinitionProperty
 import hudson.model.Result
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.commons.lang.StringUtils
@@ -71,7 +72,9 @@ import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner
 import org.jenkinsci.plugins.workflow.cps.nodes.StepEndNode
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode
 import org.jenkinsci.plugins.workflow.graph.FlowNode
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
+import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor
 import org.jenkinsci.plugins.workflow.support.steps.StageStep
@@ -209,6 +212,27 @@ public class Utils {
         } catch (_) {
             // If we get an IllegalStateException, "checkout scm" isn't valid, so return false.
             return false
+        }
+    }
+
+    static boolean hasJobProperties(CpsScript script) {
+        WorkflowRun r = script.$build()
+
+        WorkflowJob j = r.getParent()
+
+        return j.getAllProperties().any { p ->
+            // We only consider PipelineTriggersJobProperty and ParametersDefinitionProperty if they're empty.
+            if (p instanceof PipelineTriggersJobProperty) {
+                if (!p.getTriggers().isEmpty()) {
+                    return true
+                }
+            } else if (p instanceof ParametersDefinitionProperty) {
+                if (!p.getParameterDefinitions().isEmpty()) {
+                    return true
+                }
+            } else {
+                return true
+            }
         }
     }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -547,7 +547,7 @@ public class ModelInterpreter implements Serializable {
         if (root.parameters != null) {
             jobProps.add(script.parameters(root.parameters.parameters))
         }
-        if (!jobProps.isEmpty()) {
+        if (!jobProps.isEmpty() || Utils.hasJobProperties(script)) {
             script.properties(jobProps)
         }
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
@@ -26,13 +26,16 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.triggers.TimerTrigger;
 import hudson.triggers.Trigger;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TriggersTest extends AbstractModelDefTest {
@@ -58,4 +61,21 @@ public class TriggersTest extends AbstractModelDefTest {
         assertEquals("@daily", timer.getSpec());
     }
 
+    @Issue("JENKINS-44149")
+    @Test
+    public void triggersRemoved() throws Exception {
+        WorkflowRun b = getAndStartNonRepoBuild("simpleTriggers");
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+
+        WorkflowJob job = b.getParent();
+        PipelineTriggersJobProperty triggersJobProperty = job.getProperty(PipelineTriggersJobProperty.class);
+        assertNotNull(triggersJobProperty);
+        assertEquals(1, triggersJobProperty.getTriggers().size());
+
+        job.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources("propsTriggersParamsRemoved"), true));
+        WorkflowRun b2 = job.scheduleBuild2(0).waitForStart();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b2));
+
+        assertNull(job.getProperty(PipelineTriggersJobProperty.class));
+    }
 }

--- a/pipeline-model-definition/src/test/resources/propsTriggersParamsRemoved.groovy
+++ b/pipeline-model-definition/src/test/resources/propsTriggersParamsRemoved.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-44149](https://issues.jenkins-ci.org/browse/JENKINS-44149)
* Description:
    * Previously we weren't calling the properties step if there were no properties (i.e., no job properties from options, no triggers, no parameters), but that left lurking properties when you removed all properties, triggers and parameters from the Jenkinsfile. So now let's check the job config to see if there were *already* defined properties before deciding not to call the properties step. Also make sure that PipelineTriggersJobProperty and ParametersDefinitionProperty are not empty, rather than just present.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @rsandell 
    * @reviewbybees 
