### PR TITLE
[FIXED JENKINS-43816] Make sure we have a non-null execution.

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
@@ -49,6 +49,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 import java.security.CodeSource
 import java.security.cert.Certificate
+import java.util.concurrent.TimeUnit
 
 import static groovy.lang.GroovyShell.DEFAULT_CODE_BASE
 import static org.codehaus.groovy.control.Phases.CANONICALIZATION
@@ -201,12 +202,14 @@ public class Converter {
      * @param run The {@link WorkflowRun} to pull from.
      * @return A parsed and validated {@link ModelASTPipelineDef}
      */
-    public static ModelASTPipelineDef parseFromWorkflowRun(WorkflowRun run) {
-        CpsFlowExecution execution = Utils.getExecutionForRun(run)
-
-        String rawScript = execution.script
-
-        return scriptToPipelineDef(rawScript)
+    public static ModelASTPipelineDef parseFromWorkflowRun(WorkflowRun run) throws Exception {
+        CpsFlowExecution execution = null
+        if (run.execution != null) {
+            execution = (CpsFlowExecution) run.execution
+        } else if (run.getExecutionPromise() != null) {
+            execution = (CpsFlowExecution) run.getExecutionPromise().get(2, TimeUnit.SECONDS)
+        }
+        return scriptToPipelineDef(execution.script)
     }
 
 }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43816](https://issues.jenkins-ci.org/browse/JENKINS-43816)
* Description:
    * There's a small race condition that can occur where the `WorkflowRun` doesn't yet have a `FlowExecution` but we've been called anyway. In that scenario, calling `run.getExecutionPromise(...)` does the trick.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
