### PR TITLE
Validate converted Jenkinsfile before returning it.

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
@@ -98,8 +98,17 @@ public class ModelConverterAction implements RootAction {
                 ModelASTPipelineDef pipelineDef = parser.parse();
 
                 if (!collectErrors(result, parser.getErrorCollector())) {
-                    result.accumulate("result", "success");
-                    result.accumulate("jenkinsfile", pipelineDef.toPrettyGroovy());
+                    try {
+                        Converter.scriptToPipelineDef(pipelineDef.toPrettyGroovy());
+                        result.accumulate("result", "success");
+                        result.accumulate("jenkinsfile", pipelineDef.toPrettyGroovy());
+                    } catch (Exception e) {
+                        JSONObject jfErrors = new JSONObject();
+                        reportFailure(jfErrors, e);
+                        JSONArray errors = new JSONArray();
+                        errors.add(new JSONObject().accumulate("jenkinsfileErrors", jfErrors));
+                        reportFailure(result, errors);
+                    }
                 }
             } catch (Exception je) {
                 reportFailure(result, je);

--- a/pipeline-model-definition/src/test/resources/json/errors/invalidScriptContents.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/invalidScriptContents.json
@@ -1,0 +1,19 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps": [      {
+        "name": "script",
+        "arguments": [        {
+          "key": "scriptBlock",
+          "value":           {
+            "isLiteral": true,
+            "value": "echo \"In a script step\" 4(--1111d"
+          }
+        }]
+      }]
+    }]
+  }],
+  "agent": {"type": "none"}
+}}


### PR DESCRIPTION
* JENKINS issue(s):
    * Related to [JENKINS-44039](https://issues.jenkins-ci.org/browse/JENKINS-44039) but not exactly the same.
* Description:
    * There are possible edge cases where the editor may not have done a validation of the JSON before saving it - so just to be safe, let's do a validation of the converted Jenkinsfile before returning it from `toJenkinsfile`.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    
