### PR TITLE
[FIXED JENKINS-44809] Clean up existing job property handling.

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -826,7 +826,7 @@ public class Utils {
                     // instance of the class that we've seen so far. Ideally we'd be ignoring it completely, but due to
                     // JENKINS-44809, we've created situations where tons of duplicate job property instances exist,
                     // which need to be nuked, so go through normal cleanup.
-                    if (!jobPropertiesToApply.any { p.class.isInstance(it) }) {
+                    if (!jobPropertiesToApply.any { p.descriptor == it.descriptor }) {
                         jobPropertiesToApply.add(p)
                     }
                 } else {


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-44809](https://issues.jenkins-ci.org/browse/JENKINS-44809)
* Description:
    * Two aspects - stop re-adding existing job properties defined outside of the Jenkinsfile, since they can't have changed, and remove all existing instances of a job property class defined inside the Jenkinsfile before we add the new instance, to avoid duplication.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
