### PR TITLE
Work around PluginFirstClassLoader+GroovyClassLoader problem

### DIFF
--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescribable.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescribable.java
@@ -61,14 +61,10 @@ public abstract class WithScriptDescribable<T extends WithScriptDescribable<T>> 
         } catch (ClassNotFoundException e) {
             // This is special casing to deal with PluginFirstClassLoaders, which don't have a functional findResource method.
             // That results in GroovyClassLoader.loadClass failing to find resources to parse and load.
-            PluginWrapper pw = Jenkins.getInstance().getPluginManager().whichPlugin(getDescriptor().getClass());
-            if (pw != null) {
-                URL res = pw.classLoader.getResource(getDescriptor().getScriptClass().replace('.', '/') + ".groovy");
-                if (res != null) {
-                    clz = ((GroovyClassLoader) cpsScript.getClass().getClassLoader()).parseClass(new GroovyCodeSource(res));
-                }
-            }
-            if (clz == null) {
+            URL res = getDescriptor().getClass().getClassLoader().getResource(getDescriptor().getScriptClass().replace('.', '/') + ".groovy");
+            if (res != null) {
+                clz = ((GroovyClassLoader) cpsScript.getClass().getClassLoader()).parseClass(new GroovyCodeSource(res));
+            } else {
                 throw e;
             }
         }

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescribable.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescribable.java
@@ -24,11 +24,16 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.withscript;
 
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyCodeSource;
+import hudson.PluginWrapper;
 import hudson.model.AbstractDescribableImpl;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.CpsThread;
 
 import java.io.Serializable;
+import java.net.URL;
 
 /**
  * Implementations for {@link WithScriptDescriptor} - pluggable script backends for Declarative Pipelines.
@@ -50,10 +55,24 @@ public abstract class WithScriptDescribable<T extends WithScriptDescribable<T>> 
         if (c == null)
             throw new IllegalStateException("Expected to be called from CpsThread");
 
-        return (WithScriptScript) cpsScript.getClass()
-                .getClassLoader()
-                .loadClass(getDescriptor().getScriptClass())
-                .getConstructor(CpsScript.class, this.getClass())
+        Class clz = null;
+        try {
+            clz = cpsScript.getClass().getClassLoader().loadClass(getDescriptor().getScriptClass());
+        } catch (ClassNotFoundException e) {
+            // This is special casing to deal with PluginFirstClassLoaders, which don't have a functional findResource method.
+            // That results in GroovyClassLoader.loadClass failing to find resources to parse and load.
+            PluginWrapper pw = Jenkins.getInstance().getPluginManager().whichPlugin(getDescriptor().getClass());
+            if (pw != null) {
+                URL res = pw.classLoader.getResource(getDescriptor().getScriptClass().replace('.', '/') + ".groovy");
+                if (res != null) {
+                    clz = ((GroovyClassLoader) cpsScript.getClass().getClassLoader()).parseClass(new GroovyCodeSource(res));
+                }
+            }
+            if (clz == null) {
+                throw e;
+            }
+        }
+        return (WithScriptScript) clz.getConstructor(CpsScript.class, this.getClass())
                 .newInstance(cpsScript, this);
     }
 

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescribable.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescribable.java
@@ -61,6 +61,7 @@ public abstract class WithScriptDescribable<T extends WithScriptDescribable<T>> 
         } catch (ClassNotFoundException e) {
             // This is special casing to deal with PluginFirstClassLoaders, which don't have a functional findResource method.
             // That results in GroovyClassLoader.loadClass failing to find resources to parse and load.
+            // TODO delete JENKINS-44898 workaround as of Jenkins 2.66
             URL res = getDescriptor().getClass().getClassLoader().getResource(getDescriptor().getScriptClass().replace('.', '/') + ".groovy");
             if (res != null) {
                 clz = ((GroovyClassLoader) cpsScript.getClass().getClassLoader()).parseClass(new GroovyCodeSource(res));

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptScript.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptScript.java
@@ -24,12 +24,15 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.withscript;
 
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 
 import java.io.Serializable;
 
 public abstract class WithScriptScript<T extends WithScriptDescribable<T>> implements Serializable {
+    @Whitelisted
     protected CpsScript script;
+    @Whitelisted
     protected T describable;
 
     public WithScriptScript(CpsScript s, T d) {


### PR DESCRIPTION
* JENKINS issue(s):
    * Related to and a workaround for [JENKINS-44898](https://issues.jenkins-ci.org/browse/JENKINS-44898)
* Description:
    * Note that this may be too insane and/or goofy to actually do. =)
    * Relevant problem discussed at https://github.com/jenkinsci/kubernetes-plugin/pull/127.
    * `PluginFirstClassLoader` doesn't have a functional `findResource` method, which for some reason I have yet to determine breaks `GroovyClassLoader.loadClass` when trying to fetch a groovy file from a `PluginFirstClassLoader` via the `UberClassLoader`. This works around that problem by catching the resulting `ClassNotFoundException` and trying to instead use `getResource` to get the URL for the groovy file and then parse it directly.
    * Also whitelists the fields on `WithScriptScript` so they can be accessed by children outside of these plugins properly.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
