### PR TITLE
[FIXED JENKINS-43071] Use Jenkins.READ perms for linter

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DeclarativeLinterCommand.java
@@ -34,7 +34,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.parser.Converter;
 import java.util.ArrayList;
 import java.util.List;
 
-import static hudson.security.Permission.READ;
+import static jenkins.model.Jenkins.READ;
 
 @Extension
 public class DeclarativeLinterCommand extends CLICommand {


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43071](https://issues.jenkins-ci.org/browse/JENKINS-43071)
* Description:
    * `Permission.READ` meant that you actually needed admin rights to run the command. Which is dumb and wrong. So instead, go with a standard `Jenkins.READ`.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
