### PR TITLE
[FIXED JENKINS-45081] Don't error out for foo.pipeline { ... }

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -118,11 +118,12 @@ class ModelParser implements Parser {
         // first, quickly ascertain if this module should be parsed at all
         // TODO: 'use script' escape hatch
         def pst = src.statementBlock.statements.find {
-            matchMethodCall(it)?.methodAsString == ModelStepLoader.STEP_NAME
+            MethodCallExpression m = matchMethodCall(it)
+            return m != null && matchMethodName(m) == ModelStepLoader.STEP_NAME
         }
 
         if (pst==null) {
-            // Check if there's a 'pipeline' step somewhere nexted within the other statements and error out if that's the case.
+            // Check if there's a 'pipeline' step somewhere nested within the other statements and error out if that's the case.
             src.statementBlock.statements.each { checkForNestedPipelineStep(it) }
             return null; // no 'pipeline', so this doesn't apply
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -312,7 +312,8 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
                 "def hello(name) {echo \"Hello ${name}\"}",
                 "def foo(x) { this.x = x+'-set'; }",
                 "def bar() { return x+'-get' }",
-                "def baz() { return 'nothing here' }")
+                "def baz() { return 'nothing here' }",
+                "def pipeline(Closure c) { c.call() }")
                 , "\n"));
         FileUtils.writeStringToFile(new File(vars, "returnAThing.groovy"), StringUtils.join(Arrays.asList(
                 "def call(a) { return \"${a} tada\" }"), "\n"

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -345,6 +345,16 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-45081")
+    @Test
+    public void objectMethodPipelineCall() throws Exception {
+        initGlobalLibrary();
+
+        expect("objectMethodPipelineCall")
+                .logContains("Hi there")
+                .go();
+    }
+
     @Test
     public void basicWhen() throws Exception {
         expect("basicWhen")

--- a/pipeline-model-definition/src/test/resources/objectMethodPipelineCall.groovy
+++ b/pipeline-model-definition/src/test/resources/objectMethodPipelineCall.groovy
@@ -1,0 +1,27 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+acmeVar.pipeline {
+    echo "Hi there"
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-45081](https://issues.jenkins-ci.org/browse/JENKINS-45081)
* Description:
    * We were erroring out if you had a Scripted Pipeline with, say, a global variable `foo` with a method on it named `pipeline` that was being called like, say, `foo.pipeline { echo 'Hi there' }`. That...was not right. This fixes that. =)
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
