### PR TITLE
Add CodeNarc!

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -47,6 +47,26 @@
           <compatibleSinceVersion>0.8</compatibleSinceVersion>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>codenarc-maven-plugin</artifactId>
+        <version>0.22-1</version>
+        <configuration>
+          <groovyVersion>2.4.7</groovyVersion>
+          <sourceDirectory>${project.basedir}/src/main/</sourceDirectory>
+          <maxPriority1Violations>0</maxPriority1Violations>
+        </configuration>
+        <executions>
+          <execution>
+            <id>codenarc</id>
+            <goals>
+              <goal>codenarc</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * Note that we *are* scanning both the compiled and CPS code in pipeline-model-definition. We're only failing for priority 1 warnings - priority 2 is a lot of "don't just catch Exception" or "empty if/else block" that I...frankly don't care about. And most of the priority 3 are unused imports, which would be nice to clean up, sure but don't actually *matter* in the grand scheme of things.
    * Also, opened [INFRA-1267](https://issues.jenkins-ci.org/browse/INFRA-1267) to get the Warnings plugin (and Violations plugin) installed on ci.jenkins.io so we can actually report on failures in a useful way.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
