### PR TITLE
[FIXED JENKINS-45546] Add jacoco code coverage to Declarative builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,9 +35,11 @@ pipeline {
         }
         success {
             archive "**/target/*.hpi"
+            archive "**/target/site/jacoco/jacoco.xml"
         }
         unstable {
             archive "**/target/*.hpi"
+            archive "**/target/site/jacoco/jacoco.xml"
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,45 @@
           <tagNameFormat>pipeline-model-definition-@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.9</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>post-unit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <!-- Sets the path to the file which contains the execution data. -->
+
+              <dataFile>target/jacoco.exec</dataFile>
+              <!-- Sets the output directory for the code coverage report. -->
+              <outputDirectory>target/jacoco-ut</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <systemPropertyVariables>
+            <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-45546](https://issues.jenkins-ci.org/browse/JENKINS-45546)
* Description:
    * Note that we're not using the Jacoco plugin - it's not installed on ci.jenkins.io in the first place, and I think the real value is probably going to come from the XML file anyway, which can be slurped in by other tools.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 

