### PR TITLE
Switch to actually calling stage('foo') for parallel stages

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -77,6 +77,8 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecution
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode
+import org.jenkinsci.plugins.workflow.graphanalysis.Filterator
+import org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils
 import org.jenkinsci.plugins.workflow.graphanalysis.ForkScanner
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode
@@ -443,6 +445,14 @@ public class Utils {
         }
     }
 
+    static Predicate<FlowNode> nodeIdNotEquals(final FlowNode original) {
+        return new Predicate<FlowNode>() {
+            @Override
+            boolean apply(@Nullable FlowNode input) {
+                return input == null || original == null || original.id != input.id
+            }
+        }
+    }
     static Predicate<FlowNode> endNodeForStage(final BlockStartNode startNode) {
         return new Predicate<FlowNode>() {
             @Override
@@ -510,27 +520,66 @@ public class Utils {
         return stageNode != null
     }
 
-    private static FlowNode findStageFlowNode(String stageName) {
-        CpsThread thread = CpsThread.current()
-        CpsFlowExecution execution = thread.execution
+    static Predicate<FlowNode> isParallelBranchFlowNode(final String stageName, FlowExecution execution = null) {
+        return new Predicate<FlowNode>() {
+            @Override
+            boolean apply(@Nullable FlowNode input) {
+                if (input != null) {
+                    if (input.getAction(LabelAction.class) != null &&
+                        input.getAction(ThreadNameAction.class) != null &&
+                        (stageName == null || input.getAction(ThreadNameAction)?.threadName == stageName)) {
+                        // This is actually a parallel block
+                        return true
+                    }
+                }
+                return false
+            }
+        }
+    }
+
+    static List<FlowNode> findStageFlowNodes(String stageName, FlowExecution execution = null) {
+        if (execution == null) {
+            CpsThread thread = CpsThread.current()
+            execution = thread.execution
+        }
+
+        List<FlowNode> nodes = []
 
         ForkScanner scanner = new ForkScanner()
 
-        return scanner.findFirstMatch(execution.currentHeads, null, isStageWithOptionalName(stageName))
+        FlowNode stage = scanner.findFirstMatch(execution.currentHeads, null, isStageWithOptionalName(stageName))
+
+        if (stage != null) {
+            nodes.add(stage)
+
+            // Additional check needed to get the possible enclosing parallel branch for a nested stage.
+            Filterator<FlowNode> filtered = FlowScanningUtils.fetchEnclosingBlocks(stage)
+                .filter(isParallelBranchFlowNode(stageName))
+
+            filtered.each { f ->
+                if (f != null) {
+                    nodes.add(f)
+                }
+            }
+        }
+
+        return nodes
     }
 
     private static void markStageWithTag(String stageName, String tagName, String tagValue) {
-        FlowNode currentNode = findStageFlowNode(stageName)
+        List<FlowNode> matched = findStageFlowNodes(stageName)
 
-        if (currentNode != null) {
-            TagsAction tagsAction = currentNode.getAction(TagsAction.class)
-            if (tagsAction == null) {
-                tagsAction = new TagsAction()
-                tagsAction.addTag(tagName, tagValue)
-                currentNode.addAction(tagsAction)
-            } else if (tagsAction.getTagValue(tagName) == null) {
-                tagsAction.addTag(tagName, tagValue)
-                currentNode.save()
+        matched.each { currentNode ->
+            if (currentNode != null) {
+                TagsAction tagsAction = currentNode.getAction(TagsAction.class)
+                if (tagsAction == null) {
+                    tagsAction = new TagsAction()
+                    tagsAction.addTag(tagName, tagValue)
+                    currentNode.addAction(tagsAction)
+                } else if (tagsAction.getTagValue(tagName) == null) {
+                    tagsAction.addTag(tagName, tagValue)
+                    currentNode.save()
+                }
             }
         }
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -148,7 +148,6 @@ public class ModelInterpreter implements Serializable {
         return {
             script.stage(thisStage.name) {
                 try {
-                    // NOTE - this will switch to script.stage in the future.
                     if (firstError != null) {
                         Utils.logToTaskListener("Stage '${thisStage.name}' skipped due to earlier failure(s)")
                         Utils.markStageSkippedForFailure(thisStage.name)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -160,7 +160,9 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         WorkflowRun b = expect(Result.FAILURE, "parallelStagesHaveStatusAndPost")
                 .logContains("[Pipeline] { (foo)",
                         "[first] { (Branch: first)",
+                        "[Pipeline] [first] { (first)",
                         "[second] { (Branch: second)",
+                        "[Pipeline] [second] { (second)",
                         "FIRST BRANCH FAILED",
                         "SECOND BRANCH POST",
                         "FOO STAGE FAILED")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -42,8 +42,8 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTreeStep;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue;
-import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.TagsAction;
+import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
@@ -599,6 +599,90 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         assertNotNull(scanner.findFirstMatch(heads, stageStatusPredicate("baz", Utils.getStageStatusMetadata().getSkippedForFailure())));
     }
 
+    @Test
+    public void skippedStagesInParallel() throws Exception {
+        WorkflowRun b = expect(Result.FAILURE, "skippedStagesInParallel")
+                .logContains("[Pipeline] { (foo)", "hello", "I will not be skipped but I will fail")
+                .logNotContains("I will be skipped", "skipped for earlier failure", "I have succeeded")
+                .go();
+
+        assertTrue(b.getExecution().getCauseOfFailure() != null);
+
+        FlowExecution execution = b.getExecution();
+
+        Collection<FlowNode> heads = execution.getCurrentHeads();
+
+        DepthFirstScanner scanner = new DepthFirstScanner();
+
+        // foo didn't fail at all.
+        List<FlowNode> fooStages = Utils.findStageFlowNodes("foo", execution);
+        assertNotNull(fooStages);
+        assertEquals(1, fooStages.size());
+        FlowNode foo = fooStages.get(0);
+        assertFalse(stageStatusPredicate("foo", StageStatus.getSkippedForFailure()).apply(foo));
+        assertFalse(stageStatusPredicate("foo", StageStatus.getFailedAndContinued()).apply(foo));
+
+        // first-parallel did fail.
+        List<FlowNode> firstParallelStages = Utils.findStageFlowNodes("first-parallel", execution);
+        assertNotNull(firstParallelStages);
+        assertEquals(1, firstParallelStages.size());
+        FlowNode firstParallel = firstParallelStages.get(0);
+        assertFalse(stageStatusPredicate("first-parallel", StageStatus.getSkippedForFailure()).apply(firstParallel));
+        assertTrue(stageStatusPredicate("first-parallel", StageStatus.getFailedAndContinued()).apply(firstParallel));
+
+        // bar was a parallel stage that was skipped due to conditional.
+        List<FlowNode> barStages = Utils.findStageFlowNodes("bar", execution);
+        assertNotNull(barStages);
+        assertEquals(2, barStages.size());
+
+        for (FlowNode bar : barStages) {
+            System.err.println("bar actions: " + bar.getAction(TagsAction.class).getTags());
+            assertTrue(stageStatusPredicate("bar", StageStatus.getSkippedForConditional()).apply(bar));
+        }
+
+        for (FlowNode wut : scanner.filteredNodes(heads, stageStatusPredicate("bar", StageStatus.getSkippedForConditional()))) {
+            System.err.println("wut id: " + wut.getId());
+            System.err.println("wut actions: " + wut.getActions());
+            TagsAction t = wut.getAction(TagsAction.class);
+            if (t != null) {
+                System.err.println("wut tags: " + t.getTags());
+            }
+        }
+        // baz was a parallel stage that failed.
+        List<FlowNode> bazStages = Utils.findStageFlowNodes("baz", execution);
+        assertNotNull(bazStages);
+        assertEquals(2, bazStages.size());
+
+        for (FlowNode baz : bazStages) {
+            assertTrue(stageStatusPredicate("baz", StageStatus.getFailedAndContinued()).apply(baz));
+        }
+
+        // second-parallel should be skipped for failure.
+        List<FlowNode> secondParallelStages = Utils.findStageFlowNodes("second-parallel", execution);
+        assertNotNull(secondParallelStages);
+        assertEquals(1, secondParallelStages.size());
+        FlowNode secondParallel = secondParallelStages.get(0);
+        assertTrue(stageStatusPredicate("second-parallel", StageStatus.getSkippedForFailure()).apply(secondParallel));
+
+        // bar2 was a parallel stage skipped for failure
+        List<FlowNode> bar2Stages = Utils.findStageFlowNodes("bar2", execution);
+        assertNotNull(bar2Stages);
+        assertEquals(2, bar2Stages.size());
+
+        for (FlowNode bar2 : bar2Stages) {
+            assertTrue(stageStatusPredicate("bar2", StageStatus.getSkippedForFailure()).apply(bar2));
+        }
+
+        // baz2 was a parallel stage skipped for failure
+        List<FlowNode> baz2Stages = Utils.findStageFlowNodes("baz2", execution);
+        assertNotNull(baz2Stages);
+        assertEquals(2, baz2Stages.size());
+
+        for (FlowNode baz2 : baz2Stages) {
+            assertTrue(stageStatusPredicate("baz2", StageStatus.getSkippedForFailure()).apply(baz2));
+        }
+    }
+
     @Issue("JENKINS-40226")
     @Test
     public void failureBeforeStages() throws Exception {
@@ -625,7 +709,9 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         return new Predicate<FlowNode>() {
             @Override
             public boolean apply(FlowNode input) {
-                return input.getDisplayName().equals(stageName) &&
+                return (input.getDisplayName().equals(stageName) ||
+                        (input.getAction(ThreadNameAction.class) != null &&
+                                input.getAction(ThreadNameAction.class).getThreadName().equals(stageName))) &&
                         input.getAction(TagsAction.class) != null &&
                         input.getAction(TagsAction.class).getTagValue(tagName) != null &&
                         input.getAction(TagsAction.class).getTagValue(tagName).equals(tagValue);

--- a/pipeline-model-definition/src/test/resources/skippedStagesInParallel.groovy
+++ b/pipeline-model-definition/src/test/resources/skippedStagesInParallel.groovy
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+
+        stage('first-parallel') {
+            parallel {
+                stage("bar") {
+                    when {
+                        expression {
+                            return false
+                        }
+                    }
+                    steps {
+                        echo "I will be skipped"
+                    }
+                }
+
+                stage("baz") {
+                    steps {
+                        error "I will not be skipped but I will fail"
+                    }
+                }
+            }
+        }
+
+        stage('second-parallel') {
+            parallel {
+                stage("bar2") {
+                    steps {
+                        echo "bar2 skipped for earlier failure"
+                    }
+                }
+                stage("baz2") {
+                    steps {
+                        echo "bar3 skipped for earlier failure"
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        failure {
+            echo "I have failed"
+        }
+        success {
+            echo "I have succeeded"
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * I discovered that this won't actually mess with Blue Ocean visualization, since Blue Ocean already discards stages inside parallel branches but keeps the steps inside said stages. So...let's simplify things.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
