### PR TITLE
[FIXED JENKINS-45198] When possible, add scm vars to environment

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -134,6 +134,14 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git-client</artifactId>
+    </dependency>
     <!-- Dependency on tombstoned declarative agent plugin to make sure we don't end up with a
     bad old version installed -->
     <dependency>
@@ -201,7 +209,13 @@
       <artifactId>jcabi-matchers</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ant</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/SyntheticStageGraphListener.java
@@ -58,7 +58,7 @@ public final class SyntheticStageGraphListener implements GraphListener {
         if (node != null && node instanceof StepStartNode &&
                 ((StepStartNode) node).getDescriptor() instanceof StageStep.DescriptorImpl) {
             if (isDeclarativeRun(node.getExecution())) {
-                LabelAction label = node.getPersistentAction(LabelAction.class);
+                LabelAction label = node.getAction(LabelAction.class);
                 if (label != null &&
                         (SyntheticStageNames.preStages().contains(label.getDisplayName()) ||
                                 SyntheticStageNames.postStages().contains(label.getDisplayName()))) {
@@ -74,7 +74,7 @@ public final class SyntheticStageGraphListener implements GraphListener {
     }
 
     private void attachTag(FlowNode currentNode, String syntheticContext) {
-        TagsAction tagsAction = currentNode.getPersistentAction(TagsAction.class);
+        TagsAction tagsAction = currentNode.getAction(TagsAction.class);
         if (tagsAction == null) {
             tagsAction = new TagsAction();
             tagsAction.addTag(SyntheticStage.TAG_NAME, syntheticContext);

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -57,7 +57,6 @@ import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -57,6 +57,7 @@ import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.GenericStatus;
 import org.jenkinsci.plugins.workflow.pipelinegraphanalysis.StatusAndTiming;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -853,5 +854,18 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
 
 
+    }
+
+    @Issue("JENKINS-45198")
+    @Test
+    public void scmEnvVars() throws Exception {
+        // The change to support checkout scm returning a map and that map being added to the environment works fine with
+        // older core etc, but just doesn't do anything, since checkout scm isn't returning anything yet. But with newer
+        // core, etc, it'll Just Work.
+        expect("scmEnvVars")
+                // TODO: switch to .logNotContains("GIT_COMMIT is null") once we've moved to core 2.60+,
+                // workflow-scm-step 2.6+, git 3.3.1+
+                .logContains("GIT_COMMIT is null")
+                .go();
     }
 }

--- a/pipeline-model-definition/src/test/resources/scmEnvVars.groovy
+++ b/pipeline-model-definition/src/test/resources/scmEnvVars.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    stages {
+        stage("foo") {
+            steps {
+                echo "GIT_COMMIT is ${env.GIT_COMMIT}"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
+++ b/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
@@ -55,7 +55,7 @@ public class CheckoutScript implements Serializable {
                     checkoutMap = script.checkout script.scm
                 }
             }
-            if (checkoutMap != null && checkoutMap instanceof Map) {
+            if (checkoutMap) {
                 script.withEnv(checkoutMap.collect { k, v -> "${k}=${v}" }) {
                     body.call()
                 }

--- a/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
+++ b/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
@@ -44,17 +44,24 @@ public class CheckoutScript implements Serializable {
     
     private static Closure checkoutAndRun(CpsScript script, DeclarativeAgent agent, Closure body) {
         return {
+            def checkoutMap
             if (agent.isDoCheckout() && agent.hasScmContext(script)) {
                 if (!agent.inStage) {
                     script.stage(SyntheticStageNames.checkout()) {
-                        script.checkout script.scm
+                        checkoutMap = script.checkout script.scm
                     }
                 } else {
                     // No stage when we're in a nested stage already
-                    script.checkout script.scm
+                    checkoutMap = script.checkout script.scm
                 }
             }
-            body.call()
+            if (checkoutMap != null && checkoutMap instanceof Map) {
+                script.withEnv(checkoutMap.collect { k, v -> "${k}=${v}" }) {
+                    body.call()
+                }
+            } else {
+                body.call()
+            }
         }
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.17</version>
+    <version>2.29</version>
     <relativePath />
   </parent>
 
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2.33</version>
+        <version>2.36.1</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.16</version>
+        <version>2.18</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -95,12 +95,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>2.3</version>
+        <version>2.4</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>2.3</version>
+        <version>2.4</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
@@ -142,7 +142,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>scm-api</artifactId>
-        <version>1.3</version>
+        <version>2.0.8</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -200,12 +200,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.9</version>
+        <version>2.10</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>structs</artifactId>
-        <version>1.5</version>
+        <version>1.7</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -226,6 +226,21 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pipeline-input-step</artifactId>
         <version>2.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>mailer</artifactId>
+        <version>1.17</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>git-client</artifactId>
+        <version>1.21.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>ant</artifactId>
+        <version>1.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-45198](https://issues.jenkins-ci.org/browse/JENKINS-45198)
* Description:
    * This will not result in any change when run on core versions <2.60 (or with workflow-scm-step <2.6, git <3.3.1, etc), but will Just Work if you've got the right core/etc versions installed.
    * BasicModelDefTest#scmEnvVars will start failing when we bump core etc dependencies for this plugin directly.
* Documentation changes:
    * Honestly not sure if there should be doc changes - @bitwiseman, thoughts?
* Users/aliases to notify:
    * @reviewbybees 
