### PR TITLE
[FIXED JENKINS-46277] Do a pull for stage-level docker agent too

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
@@ -50,6 +50,9 @@ public class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPip
                 }
             }
             try {
+                if (Utils.withinAStage()) {
+                    script.getProperty("docker").image(describable.image).pull()
+                }
                 script.getProperty("docker").image(describable.image).inside(describable.args, {
                     body.call()
                 })


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-46277](https://issues.jenkins-ci.org/browse/JENKINS-46277)
* Description:
    * When we're at the top level, we want do do a pull of the docker image, but we want to do it within a synthetic stage. That's all well and good, but until now, the way this was done meant we weren't doing an image pull if we were at the stage level. That was dumb. Fixed!
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
