### PR TITLE
[FIXED JENKINS-46309] Restore old blocked steps methods

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMethodCall.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMethodCall.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * A representation of a method call, including its name and a list of {@link ModelASTMethodArg}s.
@@ -17,6 +19,21 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
  * @author Andrew Bayer
  */
 public class ModelASTMethodCall extends ModelASTElement implements ModelASTMethodArg {
+
+    /**
+     * Use {@code org.jenkinsci.plugins.pipeline.modeldefinition.validator.BlockedStepsAndMethodCalls.blockedInMethodCalls()} instead.
+     *
+     * @deprecated since 1.2-beta-4
+     */
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    public static Map<String, String> getBlockedSteps() {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+        map.put("node", Messages.ModelASTMethodCall_BlockedSteps_Node());
+        map.putAll(ModelASTStep.getBlockedSteps());
+        return map;
+    }
+
     private String name;
     private List<ModelASTMethodArg> args = new ArrayList<ModelASTMethodArg>();
 

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
@@ -11,6 +11,8 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.DescriptorLookupCache;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.DescribableParameter;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Represents an individual step within any of the various blocks that can contain steps.
@@ -20,6 +22,30 @@ import org.jenkinsci.plugins.structs.describable.DescribableParameter;
  */
 @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID")
 public class ModelASTStep extends ModelASTElement {
+    /**
+     * @deprecated since 1.2-beta-4
+     */
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    public static Map<String, String> blockedStepsBase() {
+        LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+        map.put("stage", Messages.ModelASTStep_BlockedSteps_Stage());
+        map.put("properties", Messages.ModelASTStep_BlockedSteps_Properties());
+        map.put("parallel", Messages.ModelASTStep_BlockedSteps_Parallel());
+        return map;
+    }
+
+    /**
+     * Use {@code org.jenkinsci.plugins.pipeline.modeldefinition.validator.BlockedStepsAndMethodCalls.blockedInSteps()} instead.
+     *
+     * @deprecated since 1.2-beta-4
+     */
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    public static Map<String, String> getBlockedSteps() {
+        return blockedStepsBase();
+    }
+
     private String name;
     private ModelASTArgumentList args;
 

--- a/pipeline-model-api/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ast/Messages.properties
+++ b/pipeline-model-api/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ast/Messages.properties
@@ -1,0 +1,29 @@
+#
+# The MIT License
+#
+# Copyright (c) 2017, CloudBees, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+ModelASTStep.BlockedSteps.Stage=The stage step cannot be used in Declarative Pipelines
+ModelASTStep.BlockedSteps.Properties=The properties step cannot be used in Declarative Pipelines
+ModelASTStep.BlockedSteps.Parallel=The parallel step can only be used as the only top-level step in a stage's step block
+
+ModelASTMethodCall.BlockedSteps.Node=The node step cannot be called as an argument to a method in Declarative Pipelines


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-46309](https://issues.jenkins-ci.org/browse/JENKINS-46309)
* Description:
    * Needed for backwards compatibility due to the editor calling ModelASTStep.getBlockedSteps() and the like, regrettably.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
