### PR TITLE
[JENKINS-44039] Fix multiline script blocks containing single quotes

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
@@ -121,7 +121,7 @@ public abstract class ModelASTValue extends ModelASTElement implements ModelASTM
                     if (str.indexOf('\n') == -1) {
                         return "'" + (str.replace("'", "\\'")) + "'";
                     } else {
-                        return "'''" + (str.replace("'''", "\\'\\'\\'")) + "'''";
+                        return "'''" + (str.replace("'", "\\'")) + "'''";
                     }
                 } else if (getValue() != null) {
                     return getValue().toString();

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BaseParserLoaderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BaseParserLoaderTest.java
@@ -143,4 +143,16 @@ public abstract class BaseParserLoaderTest extends AbstractModelDefTest {
 
     }
 
+    protected void successfulJson(String jsonName) throws Exception {
+        JsonNode json = JsonLoader.fromString(fileContentsFromResources("json/" + jsonName + ".json"));
+
+        assertNotNull("Couldn't parse JSON for " + jsonName, json);
+        assertFalse("Couldn't parse JSON for " + jsonName, json.size() == 0);
+        assertFalse("Couldn't parse JSON for " + jsonName, json.isNull());
+
+        JSONParser jp = new JSONParser(new SimpleJsonTree(json));
+        jp.parse();
+
+        assertTrue(jp.getErrorCollector().getErrorCount() == 0);
+    }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
@@ -94,4 +94,10 @@ public class JSONValidationTest extends BaseParserLoaderTest {
     public void jsonMismatchedQuotes() throws Exception {
         findErrorInJSON(Messages.JSONParser_InvalidGroovyString("hello\\'"), "jsonMismatchedQuotes");
     }
+
+    @Issue("JENKINS-44039")
+    @Test
+    public void singleQuoteInMultiline() throws Exception {
+        successfulJson("singleQuoteInMultiline");
+    }
 }

--- a/pipeline-model-definition/src/test/resources/json/singleQuoteInMultiline.json
+++ b/pipeline-model-definition/src/test/resources/json/singleQuoteInMultiline.json
@@ -1,0 +1,31 @@
+{"pipeline": {
+  "agent": {
+    "type": "any"
+  },
+  "stages": [{
+    "name": "Build",
+    "branches": [{
+      "name": "default",
+      "steps": [{
+        "name": "sh",
+        "arguments": [{
+          "key": "script",
+          "value": {
+            "isLiteral": true,
+            "value": "echo \"42\""
+          }
+        }]
+      }, {
+        "name": "script",
+        "arguments": [{
+          "key": "scriptBlock",
+          "value": {
+            "isLiteral": true,
+            "value": "def initialize = load('jenkins/pipeline/initialize.groovy')\ninitialize()\n\necho 'done initializing'"
+          }
+        }]
+      }]
+    }]
+  }]
+}
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-44039](https://issues.jenkins-ci.org/browse/JENKINS-44039)
* Description:
    * We were only escaping `'''` in a multiline `script` block coming from JSON, when we should have been escaping `'`. Oops.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
