### PR TITLE
[FIXED JENKINS-46544] Error on usage of unquoted ${...}

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -480,6 +480,12 @@ class JSONParser implements Parser {
             }
         } else {
             val = ModelASTValue.fromGString(o.node.get("value").textValue(), o)
+            String valToGroovy = val.toGroovy()
+            // Make sure we don't allow ${whatever} without being in quotes, since that's actually going to translate as
+            // $() { whatever } which is...not what we wanted.
+            if (valToGroovy.startsWith('${')) {
+                errorCollector.error(val, Messages.ModelParser_BareDollarCurly(valToGroovy))
+            }
         }
 
         return val;

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -1065,7 +1065,13 @@ class ModelParser implements Parser {
         }
 
         // for other composite expressions, treat it as in-place GString
-        return ModelASTValue.fromGString("\${"+getSourceText(e)+"}", e)
+        ModelASTValue val = ModelASTValue.fromGString("\${"+getSourceText(e)+"}", e)
+
+        if (val.toGroovy().startsWith('${')) {
+            errorCollector.error(val, Messages.ModelParser_BareDollarCurly(val.toGroovy()))
+        }
+
+        return val
     }
 
     protected String parseStringLiteral(Expression exp) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -33,6 +33,7 @@ Parser.MultipleOfSection=Multiple occurrences of the {0} section
 Parser.Triggers=Triggers
 Parser.UndefinedSection=Undefined section "{0}"
 
+ModelParser.BareDollarCurly={0} cannot be used as a value directly. Did you mean "{0}"?
 ModelParser.CannotHaveBlocks={0} definitions cannot have blocks
 ModelParser.DuplicateEnvVar=Duplicate environment variable name: "{0}"
 ModelParser.ExpectedAgent=Expected an agent

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -753,4 +753,13 @@ public class ValidatorTest extends AbstractModelDefTest {
                         Messages.ModelParser_ExpectedBlockFor("tools"))
                 .go();
     }
+
+    @Issue("JENKINS-46544")
+    @Test
+    public void bareDollarCurly() throws Exception {
+        expectError("bareDollarCurly")
+                .logContains(Messages.ModelParser_BareDollarCurly("${env.BUILD_NUMBER}"),
+                        Messages.ModelParser_BareDollarCurly("${FOO}"))
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/JSONValidationTest.java
@@ -100,4 +100,11 @@ public class JSONValidationTest extends BaseParserLoaderTest {
     public void singleQuoteInMultiline() throws Exception {
         successfulJson("singleQuoteInMultiline");
     }
+
+    @Issue("JENKINS-46544")
+    @Test
+    public void bareDollarCurly() throws Exception {
+        findErrorInJSON(Messages.ModelParser_BareDollarCurly("${env.BUILD_NUMBER}"), "bareDollarCurly");
+        findErrorInJSON(Messages.ModelParser_BareDollarCurly("${FOO}"), "bareDollarCurly");
+    }
 }

--- a/pipeline-model-definition/src/test/resources/errors/bareDollarCurly.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/bareDollarCurly.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO = ${env.BUILD_NUMBER}
+    }
+
+    agent {
+        label "some-label"
+    }
+
+    stages {
+        stage("foo") {
+            steps {
+                sh 'echo "FOO is $FOO"'
+                sh ${FOO}
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/json/errors/bareDollarCurly.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/bareDollarCurly.json
@@ -1,0 +1,44 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps":       [
+        {
+          "name": "sh",
+          "arguments": [          {
+            "key": "script",
+            "value":             {
+              "isLiteral": true,
+              "value": "echo \"FOO is $FOO\""
+            }
+          }]
+        },
+        {
+          "name": "sh",
+          "arguments": [          {
+            "key": "script",
+            "value":             {
+              "isLiteral": false,
+              "value": "${${FOO}}"
+            }
+          }]
+        }
+      ]
+    }]
+  }],
+  "environment": [  {
+    "key": "FOO",
+    "value":     {
+      "isLiteral": false,
+      "value": "${${env.BUILD_NUMBER}}"
+    }
+  }],
+  "agent":   {
+    "type": "label",
+    "argument":     {
+      "isLiteral": true,
+      "value": "some-label"
+    }
+  }
+}}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-46544](https://issues.jenkins-ci.org/browse/JENKINS-46544)
* Description:
    * This isn't something we should allow, so now we check for it and do something about it. The problem isn't specific to the ticket's case of `environment`, so we're going to error out on any non-literal `ModelASTValue` that has a `toGroovy()` value starting with `${`.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @kshultzCB
