### PR TITLE
[JENKINS-43911] Process creds and env before agent

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -63,6 +63,22 @@ public class AgentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43911")
+    @Test
+    public void agentLabelFromExternalVariable() throws Exception {
+        expect("agentLabelFromExternalVariable")
+                .logContains("[Pipeline] { (foo)", "ONAGENT=true")
+                .go();
+    }
+
+    @Issue("JENKINS-43911")
+    @Test
+    public void agentLabelFromEnv() throws Exception {
+        expect("agentLabelFromEnv")
+                .logContains("[Pipeline] { (foo)", "ONAGENT=true")
+                .go();
+    }
+
     @Issue("JENKINS-37932")
     @Test
     public void agentAny() throws Exception {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -43,7 +43,7 @@ public class EnvironmentTest extends AbstractModelDefTest {
     public static void setUpAgent() throws Exception {
         s = j.createOnlineSlave();
         s.setLabelString("some-label docker");
-        s.getNodeProperties().add(
+        j.jenkins.getGlobalNodeProperties().add(
                 new EnvironmentVariablesNodeProperty(
                         new EnvironmentVariablesNodeProperty.Entry("HAS_BACKSLASHES", "C:\\Windows"),
                         new EnvironmentVariablesNodeProperty.Entry("FOO", "OTHER")));

--- a/pipeline-model-definition/src/test/resources/agentLabelFromEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/agentLabelFromEnv.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label "${env.SOME_LABEL}"
+    }
+    environment {
+        SOME_LABEL = "some-label"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo ONAGENT=$ONAGENT')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/agentLabelFromExternalVariable.groovy
+++ b/pipeline-model-definition/src/test/resources/agentLabelFromExternalVariable.groovy
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+def testLabel = "some-label"
+
+pipeline {
+    agent {
+        label "${testLabel}"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo ONAGENT=$ONAGENT')
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43911](https://issues.jenkins-ci.org/browse/JENKINS-43911)
* Description:
    * This allows use of environment variables in agent fields.
    * I'm not yet sure about this - this creates some potential problems with, say, file-based `credentials`, which would no longer work, or node environment variable properties on an agent, which you could no longer refer to in `environment`. So...need to make some decisions. It's also possible that we could do some kind of repeat injection of `environment` and `credentials`, but I don't love that idea either. And it'd still flop for file-based credentials, actually. So...yeah. I'd like some discussion on this.
* Documentation changes:
    * Depends on what we end up doing - we may want to clarify the ordering.
* Users/aliases to notify:
    * @reviewbybees 
