### PR TITLE
Fix PCT issues caused by newer durable task step

### DIFF
--- a/pipeline-model-definition/src/test/resources/environmentWithWorkspace.groovy
+++ b/pipeline-model-definition/src/test/resources/environmentWithWorkspace.groovy
@@ -25,7 +25,7 @@
 pipeline {
     environment {
         FOO = "FOO"
-        BAR = '${WORKSPACE}BAR'
+        BAR = "${WORKSPACE}BAR"
     }
     agent {
         label "some-label"
@@ -34,7 +34,7 @@ pipeline {
     stages {
         stage("foo") {
             environment {
-                BAZ = "\${FOO}BAZ"
+                BAZ = "${FOO}BAZ"
             }
 
             steps {

--- a/pipeline-model-definition/src/test/resources/nonLiteralEnvironment.groovy
+++ b/pipeline-model-definition/src/test/resources/nonLiteralEnvironment.groovy
@@ -32,7 +32,7 @@ pipeline {
         FOO = "BAR"
         BUILD_NUM_ENV = currentBuild.getNumber()
         ANOTHER_ENV = "${currentBuild.getNumber()}"
-        INHERITED_ENV = "\${BUILD_NUM_ENV} is inherited"
+        INHERITED_ENV = "${BUILD_NUM_ENV} is inherited"
         ACME_FUNC = returnAThing("banana")
         JUST_A_CONSTANT = "${1 + 2}"
         FROM_OUTSIDE = "${someVar}. ${someFunc()}"

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.18</version>
+        <version>2.20</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -111,7 +111,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-durable-task-step</artifactId>
-        <version>2.5</version>
+        <version>2.9</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -206,7 +206,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.10</version>
+        <version>2.11</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * Newer durable task step plugin doesn't seem to know what to do with an escaped $ in an env var, so...bugger the lazy evaluation tricks I was doing, just do the simple thing.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @kshultzCB
