### PR TITLE
[FIXED JENKINS-47064] Get rid of .every call for when evaluation

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -193,6 +193,12 @@
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-utility-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-milestone-step</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -87,6 +87,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
     </dependency>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -514,9 +514,12 @@ public class ModelInterpreter implements Serializable {
         } else {
             // To allow for referencing environment variables that have not yet been declared pre-parse time, we need
             // to actually instantiate the conditional now, via a closure.
-            return instancesFromClosure(when.rawClosure, DeclarativeStageConditional.class).every {
-                it.getScript(script).evaluate()
+            for (DeclarativeStageConditional conditional : instancesFromClosure(when.rawClosure, DeclarativeStageConditional.class)) {
+                if (conditional.getScript(script).evaluate() == false) {
+                    return false
+                }
             }
+            return true
         }
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
@@ -385,4 +385,13 @@ public class WhenStageTest extends AbstractModelDefTest {
             return false;
         }
     }
+
+    @Issue("JENKINS-47064")
+    @Test
+    public void booleanClosureWrapperInExpression() throws Exception {
+        expect("booleanClosureWrapperInExpression")
+                .otherResource("testPom.xml", "pom.xml")
+                .logContains("[Pipeline] { (One)", "[Pipeline] { (Two)", "World")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/booleanClosureWrapperInExpression.groovy
+++ b/pipeline-model-definition/src/test/resources/booleanClosureWrapperInExpression.groovy
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    environment {
+        FOO = "BAR"
+    }
+
+    stages {
+        stage("One") {
+            steps {
+                echo "Hello"
+            }
+        }
+        stage("Two") {
+            when {
+                expression {
+                    def pom = readMavenPom file: 'pom.xml'
+                    return pom != null
+                }
+            }
+            steps {
+                script {
+                    echo "World"
+                    echo "Heal it"
+                }
+
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/testPom.xml
+++ b/pipeline-model-definition/src/test/resources/testPom.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.jenkinsci.plugins</groupId>
+    <artifactId>pipeline-model-test-pom</artifactId>
+    <version>1.2-beta-6-SNAPSHOT</version>
+    <packaging>pom</packaging>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>script-security</artifactId>
+        <version>1.34</version>
+      </dependency>
+      <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
         <version>2.36.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,11 @@
         <artifactId>ant</artifactId>
         <version>1.5</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>pipeline-utility-steps</artifactId>
+        <version>1.4.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-47064](https://issues.jenkins-ci.org/browse/JENKINS-47064)
* Description:
    * This can lead to a serialization error in some cases. I haven't nailed down exactly what's distinct about those cases, though, so while this solves the symptom, it doesn't address whatever the underlying problem is that makes `.every` freak out in some situations. More investigation needed there, probably at the `groovy-cps` level.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
