### PR TITLE
Make the plugin name match user expectations

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.jenkinsci.plugins</groupId>
   <artifactId>pipeline-model-definition</artifactId>
   <packaging>hpi</packaging>
-  <name>Pipeline: Model Definition</name>
+  <name>Pipeline: Declarative</name>
   <description>An opinionated, declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 


### PR DESCRIPTION
When somebody hears about "Declarative Pipeline" they will logically go look for it in the plugins site or Update Center :smile: