### PR TITLE
[FIXED JENKINS-47193] Ignore other classes in Jenkinsfiles

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GroovyShellDecoratorImpl.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GroovyShellDecoratorImpl.java
@@ -47,11 +47,12 @@ public class GroovyShellDecoratorImpl extends GroovyShellDecorator {
             @Override
             public void call(SourceUnit source, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
                 boolean doModelParsing = false;
-
                 // First, we'll parse anything that's not coming from an actual source file on disk - i.e., Jenkinsfiles
                 // (which are read in as strings and then compiled), dynamically loaded/evaluated strings, etc. We can
-                // tell when we've got one of those by looking to see if the code source's location is "file:/groovy/shell".
-                if (context.getCompileUnit().getCodeSource().getLocation().toString().equals("file:/groovy/shell")) {
+                // tell when we've got one of those by looking to see if the code source's location is "file:/groovy/shell"
+                // and if the classNode is a script.
+                if (context.getCompileUnit().getCodeSource().getLocation().toString().equals("file:/groovy/shell") &&
+                        classNode.isScript()) {
                     doModelParsing = true;
                 } else if (execution != null && classNode.getPackageName() == null) {
                     // Second, if we've got an execution and there's no package name, we'll parse if this is a global

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -1132,6 +1132,14 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .logContains("[Pipeline] { (One)", "[Pipeline] { (Two)")
                 .logNotContains("World")
                 .go();
+    }
 
+    @Issue("JENKINS-47193")
+    @Test
+    public void classInJenkinsfile() throws Exception {
+        expect("classInJenkinsfile")
+                .logContains("[Pipeline] { (foo)", "hello")
+                .logNotContains("[Pipeline] { (" + SyntheticStageNames.postBuild() + ")")
+                .go();
     }
 }

--- a/pipeline-model-definition/src/test/resources/classInJenkinsfile.groovy
+++ b/pipeline-model-definition/src/test/resources/classInJenkinsfile.groovy
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+class SomeClass {
+    String someField
+}
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/classInJenkinsfile.groovy
+++ b/pipeline-model-definition/src/test/resources/classInJenkinsfile.groovy
@@ -26,6 +26,8 @@ class SomeClass {
     String someField
 }
 
+enum Modes { Debug, Release }
+
 pipeline {
     agent none
     stages {


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-47193](https://issues.jenkins-ci.org/browse/JENKINS-47193)
* Description:
    * For transformation purposes, we only are looking at the top level of the Jenkinsfile for pipeline blocks. So ignore classes defined in the Jenkinsfile as well, or we get errors due to things already having been transformed.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
