### PR TITLE
[FIXED JENKINS-47197] Make sure we don't end up with Java 8 bits

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/MappedClosure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/MappedClosure.groovy
@@ -41,13 +41,21 @@ import groovy.transform.ToString
 @SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 public abstract class MappedClosure<O,M extends MappedClosure<O,M>> implements Serializable {
 
-    @Delegate Map<String,O> resultMap = [:]
+    Map<String,O> resultMap = [:]
 
     public MappedClosure() {
     }
 
     public MappedClosure(Map<String,O> inMap) {
         this.resultMap.putAll(inMap)
+    }
+
+    public O remove(String p) {
+        return resultMap.remove(p)
+    }
+
+    public add(String k, O v) {
+        resultMap.add(k, v)
     }
 
     public Map<String, Object> getMap() {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/MappedClosure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/MappedClosure.groovy
@@ -55,7 +55,7 @@ public abstract class MappedClosure<O,M extends MappedClosure<O,M>> implements S
     }
 
     public put(String k, O v) {
-        resultMap.add(k, v)
+        resultMap.put(k, v)
     }
 
     public Map<String, Object> getMap() {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/MappedClosure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/MappedClosure.groovy
@@ -54,7 +54,7 @@ public abstract class MappedClosure<O,M extends MappedClosure<O,M>> implements S
         return resultMap.remove(p)
     }
 
-    public add(String k, O v) {
+    public put(String k, O v) {
         resultMap.add(k, v)
     }
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-47197](https://issues.jenkins-ci.org/browse/JENKINS-47197)
* Description:
    * Groovy does something weird with `@Delegate` on a `Map` with Java 8 but targeting Java 7, resulting in a whole lot of additional methods created using `java.util.function.Function` and friends. That's annoying. To say the least.  Took me a while to find where that reference was being inserted, but yeah, it was `MappedClosure` and its `@Delegate`, so I got rid of `@Delegate` and now things are fine. Phew.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
