### PR TITLE
JENKINS-46403 - fix infinite loop running jobs with a logRotator

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -547,8 +547,8 @@ public class Utils {
             jobPropertiesToApply.each { p ->
                 // Remove the existing instance(s) of the property class before we add the new one. We're looping and
                 // removing multiple to deal with the results of JENKINS-44809.
-                while (j.getProperty(p.class) != null) {
-                    j.removeProperty(p.class)
+                while (j.removeProperty(p.class) != null) {
+                    // removed one, try again in case there is more
                 }
                 j.addProperty(p)
             }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-46403](https://issues.jenkins-ci.org/browse/JENKINS-46403)
* Description:
    * a Declarative Pipeline job can live-lock on startup when the (deprecated) Job.logRotator field has a value
    * see [my explanation](https://issues.jenkins-ci.org/browse/JENKINS-46403?focusedCommentId=316154#comment-316154) in the JENKINS issue
* Documentation changes:
    * N/A
* Users/aliases to notify:
    * ?
