### PR TITLE
[FIXED JENKINS-47421] Make sure we init stagesList in readResolve

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/ExecutionModelAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/ExecutionModelAction.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class ExecutionModelAction extends InvisibleAction {
     private ModelASTStages stages;
     private String stagesUUID;
-    private final List<ModelASTStages> stagesList = new ArrayList<>();
+    private List<ModelASTStages> stagesList = new ArrayList<>();
 
     public ExecutionModelAction(ModelASTStages s) {
         this.stagesList.add(s);
@@ -49,7 +49,11 @@ public class ExecutionModelAction extends InvisibleAction {
 
     protected Object readResolve() throws IOException {
         if (this.stages != null) {
+            if (this.stagesList == null) {
+                this.stagesList = new ArrayList<>();
+            }
             this.stagesList.add(stages);
+            
             this.stages = null;
         }
         return this;


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-47421](https://issues.jenkins-ci.org/browse/JENKINS-47421)
* Description:
    * This is a very minor issue in practice - the ExecutionModelAction isn't really used by anything but our own check for multiple executed pipeline blocks, which itself can't ever be the case on builds that started before Declarative 1.2 in the first place. Buuuuut it does result in some weird unreadable data messages in Jenkins, so let's play things very safe.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
