### PR TITLE
[FIXED JENKINS-46597] Eradicate TreeMap from runtime

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Tools.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Tools.groovy
@@ -55,16 +55,18 @@ public class Tools extends MappedClosure<Closure,Tools> implements Serializable 
     /**
      * Merges the tool entries from another instance into this one, defaulting to the current instance's values.
      *
-     * @return A map of type/name
+     * @return A list of type/name
      */
     @Nonnull
-    public Map<String,Closure> mergeToolEntries(@CheckForNull Tools other) {
-        Map<String,Closure> mergedMap = [:]
+    public List<List<Object>> mergeToolEntries(@CheckForNull Tools other) {
+        Map<String,Object> mergedMap = [:]
         if (other != null) {
             mergedMap.putAll(other.getMap())
         }
         mergedMap.putAll(getMap())
-        return mergedMap
+        return mergedMap.collect { k, v ->
+            [k, v]
+        }
     }
 
     /**


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-46597](https://issues.jenkins-ci.org/browse/JENKINS-46597)
* Description:
    * This was the last lurking bit of TreeMap, which almost certainly was causing the NotSerializableException. So let's get rid of it and switch to the ugly but functional list-of-pairs.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
    * @kshultzCB
