### PR TITLE
[FIXED JENKINS-47559] Don't do full validation for non-conditions

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -871,7 +871,7 @@ class ModelParser implements Parser {
         def mc = matchMethodCall(st);
         if (mc == null) {
             // Not sure of a better way to deal with this - it's a full-on parse-time failure.
-            errorCollector.error(condition, Messages.ModelParser_ExpectedStep());
+            errorCollector.error(condition, Messages.ModelParser_ExpectedWhen());
             return condition
         };
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -210,6 +210,11 @@ class ModelValidatorImpl implements ModelValidator {
         boolean valid = true
         def allNames = DeclarativeStageConditionalDescriptor.allNames()
 
+        // Short-circuit in cases where the condition didn't parse right in the first place.
+        if (condition?.name == null) {
+            return false
+        }
+        
         if (!(condition.name in allNames)) {
             errorCollector.error(condition, Messages.ModelValidatorImpl_UnknownWhenConditional(condition.name, allNames.join(", ")))
             valid = false

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -762,4 +762,12 @@ public class ValidatorTest extends AbstractModelDefTest {
                         Messages.ModelParser_BareDollarCurly("${FOO}"))
                 .go();
     }
+
+    @Issue("JENKINS-47559")
+    @Test
+    public void whenContainingNonCondition() throws Exception {
+        expectError("whenContainingNonCondition")
+                .logContains(Messages.ModelParser_ExpectedWhen())
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/errors/whenContainingNonCondition.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/whenContainingNonCondition.groovy
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+
+    parameters {
+        stringParam(name: 'someParam', defaultValue: 'foo', description: '')
+    }
+
+    stages {
+
+        stage('Fix Me') {
+            when {
+                params.someParam == 'CI'
+            }
+
+            steps {
+                echo "Hello World"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-47559](https://issues.jenkins-ci.org/browse/JENKINS-47559)
* Description:
    * This has actually always been a potential problem but nothing in validation until 1.2 actually checked condition names via `.equals`. That'll end up null if you've got a non-method for the condition, so...tada. This fixes that by skipping the rest of validation in that case (since there's nothing more to validate!) and uses a better error message.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
