### PR TITLE
[FIXED JENKINS-47600] Avoid recursive hell for env.VALUE

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -266,8 +266,19 @@ class RuntimeASTTransformer {
             if (propExpr.objectExpression instanceof VariableExpression &&
                 ((VariableExpression) propExpr.objectExpression).name == "env" &&
                     keys.contains(propExpr.propertyAsString)) {
-                // If the property this expression refers to is env.whatever, replace with the env getter.
-                body = environmentValueGetterCall(propExpr.propertyAsString)
+                if (propExpr.propertyAsString == targetVar) {
+                    // If this is the same variable we're setting, use getScriptPropOrParam, which will first try
+                    // script.getProperty(name), then script.getProperty('params').get(name).
+                    body = callX(
+                        varX("this"),
+                        constX("getScriptPropOrParam"),
+                        args(constX(propExpr.propertyAsString))
+                    )
+
+                } else {
+                    // If the property this expression refers to is env.whatever, replace with the env getter.
+                    body = environmentValueGetterCall(propExpr.propertyAsString)
+                }
             } else {
                 // Otherwise, if the property is still on a variable, translate everything
                 return propX(

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -300,4 +300,12 @@ public class EnvironmentTest extends AbstractModelDefTest {
                 .logContains("Version is BANANA")
                 .go();
     }
+
+    @Issue("JENKINS-47600")
+    @Test
+    public void environmentOverwriteReference() throws Exception {
+        expect("environmentOverwriteReference")
+                .logContains("value: first second", "value: first third")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/environmentOverwriteReference.groovy
+++ b/pipeline-model-definition/src/test/resources/environmentOverwriteReference.groovy
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    environment {
+        VALUE = "first"
+    }
+    stages {
+        stage("foo") {
+            environment {
+                VALUE = "${VALUE} second"
+            }
+            steps {
+                echo "value: ${VALUE}"
+            }
+        }
+        stage("bar") {
+            environment {
+                // Note that this will use the top-level VALUE. not the first stage VALUE. That's expected.
+                VALUE = "${env.VALUE} third"
+            }
+            steps {
+                echo "value: ${VALUE}"
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-47600](https://issues.jenkins-ci.org/browse/JENKINS-47600)
* Description:
    * If we try `VALUE = "${env.VALUE}"` or similar (with `env.` prefix), we're actually getting the getter call rather than the property directly, which leads to recursive hell. So switch that scenario to use the `getScriptPropOrParam` value instead, as we do for `VALUE = "${VALUE}"`.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
