### PR TITLE
[FIXED JENKINS-47814] Don't run post validator contirbutors twice

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -465,7 +465,7 @@ class ModelValidatorImpl implements ModelValidator {
                 }
             }
         }
-        return validateFromContributors(meth, valid)
+        return valid
     }
 
     public boolean validateElement(@Nonnull ModelASTOptions opts) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -108,7 +108,7 @@ class ModelValidatorImpl implements ModelValidator {
             valid = false
         }
 
-        return validateFromContributors(post, valid)
+        return valid
     }
 
     public boolean validateElement(@Nonnull ModelASTBuildCondition buildCondition) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -465,7 +465,11 @@ class ModelValidatorImpl implements ModelValidator {
                 }
             }
         }
-        return valid
+        if (meth.class == ModelASTMethodCall.class) {
+            return validateFromContributors(meth, valid)
+        } else {
+            return valid
+        }
     }
 
     public boolean validateElement(@Nonnull ModelASTOptions opts) {
@@ -717,7 +721,7 @@ class ModelValidatorImpl implements ModelValidator {
     }
 
     private boolean validateFromContributors(ModelASTElement element, boolean isValid, boolean isNested = false) {
-        boolean contributorsValid = DeclarativeValidatorContributor.all().every { contributor ->
+        boolean contributorsValid = DeclarativeValidatorContributor.all().collect { contributor ->
             String error
             if (!(element instanceof ModelASTStage)) {
                 error = contributor.validateElement(element, getExecution())
@@ -730,7 +734,7 @@ class ModelValidatorImpl implements ModelValidator {
             } else {
                 return true
             }
-        }
+        }.every { it }
         if (isValid) {
             return contributorsValid
         } else {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -696,6 +696,16 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-47814")
+    @Test
+    public void optionValidatorContributor() throws Exception {
+        TestDupeContributor.count = 0;
+        expectError("optionValidatorContributor")
+                .logContains("validate option 1")
+                .logNotContains("validate option 2")
+                .go();
+    }
+
     @TestExtension
     public static class TestDupeContributor extends DeclarativeValidatorContributor {
         public static int count = 0;
@@ -704,6 +714,12 @@ public class ValidatorTest extends AbstractModelDefTest {
         public String validateElement(@Nonnull ModelASTPostBuild postBuild, @CheckForNull FlowExecution execution) {
             count++;
             return "validate " + count;
+        }
+
+        @Override
+        public String validateElement(@Nonnull ModelASTOption option, @CheckForNull FlowExecution execution) {
+            count++;
+            return "validate option " + count;
         }
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -28,7 +28,7 @@ import jenkins.model.OptionalJobProperty;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption;
-import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostBuild;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Options;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Parameters;
@@ -684,6 +684,27 @@ public class ValidatorTest extends AbstractModelDefTest {
         expectError("validatorContributor")
                 .logContains("testProperty is rejected")
                 .go();
+    }
+
+    @Issue("JENKINS-47814")
+    @Test
+    public void postValidatorContributor() throws Exception {
+        TestDupeContributor.count = 0;
+        expectError("postValidatorContributor")
+                .logContains("validate 1")
+                .logNotContains("validate 2")
+                .go();
+    }
+
+    @TestExtension
+    public static class TestDupeContributor extends DeclarativeValidatorContributor {
+        public static int count = 0;
+
+        @Override
+        public String validateElement(@Nonnull ModelASTPostBuild postBuild, @CheckForNull FlowExecution execution) {
+            count++;
+            return "validate " + count;
+        }
     }
 
     @TestExtension

--- a/pipeline-model-definition/src/test/resources/errors/optionValidatorContributor.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/optionValidatorContributor.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    options {
+        buildDiscarder(logRotator(numToKeepStr:'1'))
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/postValidatorContributor.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/postValidatorContributor.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+    post {
+        always {
+            echo "hi"
+        }
+    }
+}
+
+
+

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/DeclarativeValidatorContributor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/DeclarativeValidatorContributor.java
@@ -91,12 +91,12 @@ public abstract class DeclarativeValidatorContributor implements ExtensionPoint 
 
     @CheckForNull
     public String validateElement(@Nonnull ModelASTPostBuild postBuild, @CheckForNull FlowExecution execution) {
-        return null;
+        return validateElement((ModelASTBuildConditionsContainer) postBuild, execution);
     }
 
     @CheckForNull
     public String validateElement(@Nonnull ModelASTPostStage post, @CheckForNull FlowExecution execution) {
-        return null;
+        return validateElement((ModelASTBuildConditionsContainer) post, execution);
     }
 
     @CheckForNull
@@ -146,17 +146,17 @@ public abstract class DeclarativeValidatorContributor implements ExtensionPoint 
 
     @CheckForNull
     public String validateElement(@Nonnull ModelASTOption jobProperty, @CheckForNull FlowExecution execution) {
-        return null;
+        return validateElement((ModelASTMethodCall) jobProperty, execution);
     }
 
     @CheckForNull
     public String validateElement(@Nonnull ModelASTTrigger trigger, @CheckForNull FlowExecution execution) {
-        return null;
+        return validateElement((ModelASTMethodCall) trigger, execution);
     }
 
     @CheckForNull
     public String validateElement(@Nonnull ModelASTBuildParameter buildParameter, @CheckForNull FlowExecution execution) {
-        return null;
+        return validateElement((ModelASTMethodCall) buildParameter, execution);
     }
 
     @CheckForNull


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-47814](https://issues.jenkins-ci.org/browse/JENKINS-47814)
* Description:
    * We were running contributor checks for all post containers twice. Let's only do that once per type.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
