### PR TITLE
[JENKINS-47928] Skip parallel stage post steps for previous errors

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -177,6 +177,7 @@ public class ModelInterpreter implements Serializable {
 
     def evaluateStage(Root root, Agent parentAgent, Stage thisStage, Throwable firstError, Stage parentStage = null) {
         return {
+            def thisError = null
             script.stage(thisStage.name) {
                 try {
                     if (firstError != null) {
@@ -228,9 +229,13 @@ public class ModelInterpreter implements Serializable {
                     if (firstError == null) {
                         firstError = e
                     }
+                    thisError = e
                 } finally {
                     // And finally, run the post stage steps if this was a parallel parent.
-                    if (thisStage.parallel != null && root.hasSatisfiedConditions(thisStage.post, script.getProperty("currentBuild"))) {
+                    // JENKINS-47928: Do not run if the error was not thrown from this stage
+                    if (thisError != null &&
+                            thisStage.parallel != null &&
+                            root.hasSatisfiedConditions(thisStage.post, script.getProperty("currentBuild"))) {
                         Utils.logToTaskListener("Post stage")
                         firstError = runPostConditions(thisStage.post, thisStage.agent ?: parentAgent, firstError, thisStage.name)
                     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -122,6 +122,13 @@ public class PostStageTest extends AbstractModelDefTest {
                 .logNotContains("Required context class hudson.FilePath is missing").go();
     }
 
+    @Issue("JENKINS-47928")
+    @Test
+    public void parallelParentPostFailure() throws Exception {
+        expect(Result.FAILURE, "parallelParentPostFailure")
+                .logNotContains("PARALLEL STAGE POST").go();
+    }
+
     @Override
     protected ExpectationsBuilder expect(String resource) {
         return super.expect("postStage", resource);

--- a/pipeline-model-definition/src/test/resources/postStage/parallelParentPostFailure.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/parallelParentPostFailure.groovy
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("one") {
+            steps {
+                error "Failure"
+            }
+        }
+        stage("two") {
+            parallel {
+                stage("child") {
+                    steps {
+                        echo "Shouldn't run"
+                    }
+                }
+            }
+            post {
+                failure {
+                    echo "PARALLEL STAGE POST"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes [JENKINS-47298](https://issues.jenkins-ci.org/browse/JENKINS-47928)

Avoid running `post` steps for parallel stage parents that did not throw errors.