### PR TITLE
[FIXED JENKINS-37663] Check execution result in post as well

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -213,6 +213,11 @@
       <artifactId>jcabi-matchers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -39,8 +39,7 @@ public class Aborted extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
         Result execResult = getExecutionResult(r)
-        return (execResult != null && execResult.equals(Result.ABORTED)) ||
-            (r.getResult() != null && r.getResult().equals(Result.ABORTED))
+        return execResult == Result.ABORTED || r.getResult() == Result.ABORTED
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -38,7 +38,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 public class Aborted extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
-        return r.getResult() != null && r.getResult().equals(Result.ABORTED)
+        Result execResult = getExecutionResult(r)
+        return (execResult != null && execResult.equals(Result.ABORTED)) ||
+            (r.getResult() != null && r.getResult().equals(Result.ABORTED))
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
@@ -47,7 +47,8 @@ public class Changed extends BuildCondition {
         }
         // If the current build's result isn't null (i.e., it's got a specified status), and it's different than the
         // previous build's result, we're changed.
-        else if ((execResult != null && prev.getResult() != execResult) || prev.getResult() != r.getResult()) {
+        else if ((execResult != null && prev.getResult() != execResult) ||
+            (r.getResult() != null && prev.getResult() != r.getResult())) {
             return true
         }
         // If the current build's result is null and the previous build's result is not SUCCESS, we're changed.

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
@@ -47,13 +47,12 @@ public class Changed extends BuildCondition {
         }
         // If the current build's result isn't null (i.e., it's got a specified status), and it's different than the
         // previous build's result, we're changed.
-        else if ((execResult != null && !prev.getResult().equals(execResult)) ||
-            (r.getResult() != null && !prev.getResult().equals(r.getResult()))) {
+        else if ((execResult != null && prev.getResult() != execResult) || prev.getResult() != r.getResult()) {
             return true
         }
         // If the current build's result is null and the previous build's result is not SUCCESS, we're changed.
-        else if ((execResult == Result.SUCCESS && !prev.getResult().equals(Result.SUCCESS)) ||
-            (r.getResult() == null && !prev.getResult().equals(Result.SUCCESS))) {
+        else if ((execResult == Result.SUCCESS && prev.getResult() != Result.SUCCESS) ||
+            (r.getResult() == null && prev.getResult() != Result.SUCCESS)) {
             return true
         }
         // And in any other condition, we're not changed, so return false.

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
@@ -38,6 +38,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 public class Changed extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
+        Result execResult = getExecutionResult(r)
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
         // If there's no previous build, we're inherently changed.
@@ -46,11 +47,13 @@ public class Changed extends BuildCondition {
         }
         // If the current build's result isn't null (i.e., it's got a specified status), and it's different than the
         // previous build's result, we're changed.
-        else if (r.getResult() != null && !prev.getResult().equals(r.getResult())) {
+        else if ((execResult != null && !prev.getResult().equals(execResult)) ||
+            (r.getResult() != null && !prev.getResult().equals(r.getResult()))) {
             return true
         }
         // If the current build's result is null and the previous build's result is not SUCCESS, we're changed.
-        else if (r.getResult() == null && !prev.getResult().equals(Result.SUCCESS)) {
+        else if ((execResult == Result.SUCCESS && !prev.getResult().equals(Result.SUCCESS)) ||
+            (r.getResult() == null && !prev.getResult().equals(Result.SUCCESS))) {
             return true
         }
         // And in any other condition, we're not changed, so return false.

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -38,7 +38,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 public class Failure extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
-        return r.getResult() != null && r.getResult().equals(Result.FAILURE)
+        Result execResult = getExecutionResult(r)
+        return (execResult != null && execResult.equals(Result.FAILURE)) ||
+            (r.getResult() != null && r.getResult().equals(Result.FAILURE))
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -39,8 +39,7 @@ public class Failure extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
         Result execResult = getExecutionResult(r)
-        return (execResult != null && execResult.equals(Result.FAILURE)) ||
-            (r.getResult() != null && r.getResult().equals(Result.FAILURE))
+        return execResult == Result.FAILURE || r.getResult() == Result.FAILURE
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -39,8 +39,7 @@ public class NotBuilt extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
         Result execResult = getExecutionResult(r)
-        return (execResult != null && execResult.equals(Result.NOT_BUILT)) ||
-            (r.getResult() != null && r.getResult().equals(Result.NOT_BUILT))
+        return execResult == Result.NOT_BUILT || r.getResult() == Result.NOT_BUILT
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -38,7 +38,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 public class NotBuilt extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
-        return r.getResult() != null && r.getResult().equals(Result.NOT_BUILT)
+        Result execResult = getExecutionResult(r)
+        return (execResult != null && execResult.equals(Result.NOT_BUILT)) ||
+            (r.getResult() != null && r.getResult().equals(Result.NOT_BUILT))
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
@@ -38,7 +38,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 public class Success extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
-        return r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS)
+        Result execResult = getExecutionResult(r)
+        return (execResult == null || execResult.isBetterOrEqualTo(Result.SUCCESS)) &&
+            (r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS))
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
@@ -39,8 +39,7 @@ public class Unstable extends BuildCondition {
     @Override
     public boolean meetsCondition(WorkflowRun r) {
         Result execResult = getExecutionResult(r)
-        return (execResult != null && execResult.equals(Result.UNSTABLE)) ||
-            (r.getResult() != null && r.getResult().equals(Result.UNSTABLE))
+        return execResult == Result.UNSTABLE || r.getResult() == Result.UNSTABLE
     }
 
     @Override

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -197,4 +197,14 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
 
         j.assertLogContains("Job aborted due to input", run);
     }
+
+    @Issue("JENKINS-37663")
+    @Test
+    public void contextResultOverridesRunResult() throws Exception {
+        expect(Result.UNSTABLE, "contextResultOverridesRunResult")
+                .otherResource("junitResult.xml", "junitResult.xml")
+                .logContains("I AM UNSTABLE")
+                .logNotContains("MOST DEFINITELY FINISHED")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/contextResultOverridesRunResult.groovy
+++ b/pipeline-model-definition/src/test/resources/contextResultOverridesRunResult.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2017, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,32 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 
-import hudson.Extension
-import hudson.model.Result
-import org.jenkinsci.Symbol
-import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
-import org.jenkinsci.plugins.workflow.job.WorkflowRun
-
-/**
- * A {@link BuildCondition} for matching unstable builds.
- *
- * @author Andrew Bayer
- */
-@Extension(ordinal=500d) @Symbol("unstable")
-public class Unstable extends BuildCondition {
-    @Override
-    public boolean meetsCondition(WorkflowRun r) {
-        Result execResult = getExecutionResult(r)
-        return (execResult != null && execResult.equals(Result.UNSTABLE)) ||
-            (r.getResult() != null && r.getResult().equals(Result.UNSTABLE))
+pipeline {
+    agent any
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
     }
-
-    @Override
-    public String getDescription() {
-        return Messages.Unstable_Description()
+    post {
+        always {
+            junit allowEmptyResults: true, testResults: 'junitResult.xml'
+        }
+        success {
+            echo "MOST DEFINITELY FINISHED"
+        }
+        unstable {
+            echo "I AM UNSTABLE"
+        }
     }
-
-    public static final long serialVersionUID = 1L
 }
+
+
+

--- a/pipeline-model-definition/src/test/resources/junitResult.xml
+++ b/pipeline-model-definition/src/test/resources/junitResult.xml
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<testsuite errors="3" failures="0" tests="8" time="14.398">
+    <testcase name="org.twia.vendor.VendorManagerTest.testGetVendorFirmKeyForVendorRep" time="3.377">
+        <error type="java.lang.NullPointerException">java.lang.NullPointerException&#13;
+            at org.twia.vendor.VendorManagerTest.testGetVendorFirmKeyForVendorRep(VendorManagerTest.java:104)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at junit.framework.TestCase.runTest(TestCase.java:166)&#13;
+            at org.unitils.UnitilsJUnit3.runTest(UnitilsJUnit3.java:171)&#13;
+            at junit.framework.TestCase.runBare(TestCase.java:140)&#13;
+            at org.unitils.UnitilsJUnit3.runBare(UnitilsJUnit3.java:138)&#13;
+            at junit.framework.TestResult$1.protect(TestResult.java:106)&#13;
+            at junit.framework.TestResult.runProtected(TestResult.java:124)&#13;
+            at junit.framework.TestResult.run(TestResult.java:109)&#13;
+            at junit.framework.TestCase.run(TestCase.java:131)&#13;
+            at org.unitils.UnitilsJUnit3.run(UnitilsJUnit3.java:101)&#13;
+            at junit.framework.TestSuite.runTest(TestSuite.java:173)&#13;
+            at junit.framework.TestSuite.run(TestSuite.java:168)&#13;
+            at junit.framework.TestSuite.runTest(TestSuite.java:173)&#13;
+            at junit.framework.TestSuite.run(TestSuite.java:168)&#13;
+            at junit.textui.TestRunner.doRun(TestRunner.java:74)&#13;
+            at org.twia.junit.CustomTestRunner.run(CustomTestRunner.java:76)&#13;
+            at org.twia.test.ejb.JunitCallerEJB.testSuites(JunitCallerEJB.java:136)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.invocation.Invocation.performCall(Invocation.java:359)&#13;
+            at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)&#13;
+            at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)&#13;
+            at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)&#13;
+            at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)&#13;
+            at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:315)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)&#13;
+            at org.jboss.ejb.plugins.SecurityInterceptor.invoke(SecurityInterceptor.java:168)&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)&#13;
+            at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)&#13;
+            at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)&#13;
+            at org.jboss.ejb.Container.invoke(Container.java:960)&#13;
+            at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at org.jboss.invocation.unified.server.UnifiedInvoker.invoke(UnifiedInvoker.java:231)&#13;
+            at sun.reflect.GeneratedMethodAccessor288.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:201)&#13;
+            at $Proxy16.invoke(Unknown Source)&#13;
+            at org.jboss.remoting.ServerInvoker.invoke(ServerInvoker.java:795)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.processInvocation(ServerThread.java:573)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.dorun(ServerThread.java:387)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.run(ServerThread.java:166)&#13;
+        </error>
+    </testcase>
+    <testcase name="org.twia.vendor.VendorManagerTest.testGetRevokedClaimsForAdjustingFirm" time="3.267">
+        <error message="RuntimeException; nested exception is: &#10;&#9;java.lang.IllegalArgumentException: id to load is required for loading" type="java.rmi.ServerException">java.rmi.ServerException: RuntimeException; nested exception is:
+            java.lang.IllegalArgumentException: id to load is required for loading&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.handleException(LogInterceptor.java:421)&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:209)&#13;
+            at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)&#13;
+            at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)&#13;
+            at org.jboss.ejb.Container.invoke(Container.java:960)&#13;
+            at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at org.jboss.invocation.local.LocalInvoker$MBeanServerAction.invoke(LocalInvoker.java:169)&#13;
+            at org.jboss.invocation.local.LocalInvoker.invoke(LocalInvoker.java:118)&#13;
+            at org.jboss.invocation.InvokerInterceptor.invokeLocal(InvokerInterceptor.java:209)&#13;
+            at org.jboss.invocation.InvokerInterceptor.invoke(InvokerInterceptor.java:195)&#13;
+            at org.jboss.proxy.TransactionInterceptor.invoke(TransactionInterceptor.java:61)&#13;
+            at org.jboss.proxy.SecurityInterceptor.invoke(SecurityInterceptor.java:70)&#13;
+            at org.jboss.proxy.ejb.StatelessSessionInterceptor.invoke(StatelessSessionInterceptor.java:112)&#13;
+            at org.jboss.proxy.ClientContainer.invoke(ClientContainer.java:100)&#13;
+            at $Proxy108.assignAdjustingFirmAndLocation(Unknown Source)&#13;
+            at org.twia.vendor.VendorManagerTest.testGetRevokedClaimsForAdjustingFirm(VendorManagerTest.java:120)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at junit.framework.TestCase.runTest(TestCase.java:166)&#13;
+            at org.unitils.UnitilsJUnit3.runTest(UnitilsJUnit3.java:171)&#13;
+            at junit.framework.TestCase.runBare(TestCase.java:140)&#13;
+            at org.unitils.UnitilsJUnit3.runBare(UnitilsJUnit3.java:138)&#13;
+            at junit.framework.TestResult$1.protect(TestResult.java:106)&#13;
+            at junit.framework.TestResult.runProtected(TestResult.java:124)&#13;
+            at junit.framework.TestResult.run(TestResult.java:109)&#13;
+            at junit.framework.TestCase.run(TestCase.java:131)&#13;
+            at org.unitils.UnitilsJUnit3.run(UnitilsJUnit3.java:101)&#13;
+            at junit.framework.TestSuite.runTest(TestSuite.java:173)&#13;
+            at junit.framework.TestSuite.run(TestSuite.java:168)&#13;
+            at junit.framework.TestSuite.runTest(TestSuite.java:173)&#13;
+            at junit.framework.TestSuite.run(TestSuite.java:168)&#13;
+            at junit.textui.TestRunner.doRun(TestRunner.java:74)&#13;
+            at org.twia.junit.CustomTestRunner.run(CustomTestRunner.java:76)&#13;
+            at org.twia.test.ejb.JunitCallerEJB.testSuites(JunitCallerEJB.java:136)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.invocation.Invocation.performCall(Invocation.java:359)&#13;
+            at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)&#13;
+            at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)&#13;
+            at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)&#13;
+            at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)&#13;
+            at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:315)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)&#13;
+            at org.jboss.ejb.plugins.SecurityInterceptor.invoke(SecurityInterceptor.java:168)&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)&#13;
+            at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)&#13;
+            at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)&#13;
+            at org.jboss.ejb.Container.invoke(Container.java:960)&#13;
+            at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at org.jboss.invocation.unified.server.UnifiedInvoker.invoke(UnifiedInvoker.java:231)&#13;
+            at sun.reflect.GeneratedMethodAccessor288.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:201)&#13;
+            at $Proxy16.invoke(Unknown Source)&#13;
+            at org.jboss.remoting.ServerInvoker.invoke(ServerInvoker.java:795)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.processInvocation(ServerThread.java:573)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.dorun(ServerThread.java:387)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.run(ServerThread.java:166)&#13;
+            Caused by: java.lang.IllegalArgumentException: id to load is required for loading&#13;
+            at org.hibernate.event.LoadEvent.&lt;init&gt;(LoadEvent.java:51)&#13;
+            at org.hibernate.event.LoadEvent.&lt;init&gt;(LoadEvent.java:33)&#13;
+            at org.hibernate.impl.SessionImpl.get(SessionImpl.java:812)&#13;
+            at org.hibernate.impl.SessionImpl.get(SessionImpl.java:808)&#13;
+            at org.twia.persistence.hibernate.HibernateDAO.reloadWithVersionCheck(HibernateDAO.java:712)&#13;
+            at org.twia.persistence.hibernate.HibernateDAO.reloadWithVersionCheck(HibernateDAO.java:782)&#13;
+            at org.twia.claim.ClaimManager.assignAdjustingFirmAndLocation(ClaimManager.java:3119)&#13;
+            at org.twia.claim.ClaimManager.assignAdjustingFirmAndLocation(ClaimManager.java:3092)&#13;
+            at org.twia.claim.ClaimManagerSessionEJB.assignAdjustingFirmAndLocation(ClaimManagerSessionEJB.java:547)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.invocation.Invocation.performCall(Invocation.java:359)&#13;
+            at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)&#13;
+            at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)&#13;
+            at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)&#13;
+            at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)&#13;
+            at org.jboss.ejb.plugins.AbstractInterceptor.invoke(AbstractInterceptor.java:111)&#13;
+            at org.twia.stats.StatisticsInterceptor.invoke(StatisticsInterceptor.java:79)&#13;
+            at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:350)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)&#13;
+            at org.twia.security.SecurityInterceptor.invoke(SecurityInterceptor.java:105)&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)&#13;
+            ... 81 more&#13;
+        </error>
+    </testcase>
+    <testcase name="org.twia.vendor.VendorManagerTest.testCreateVendorFirm" time="1.798"/>
+    <testcase name="org.twia.vendor.VendorManagerTest.testUpdateVendorFirm" time="0.953"/>
+    <testcase name="org.twia.vendor.VendorManagerTest.testAddVendorLocation" time="2.502"/>
+    <testcase name="org.twia.vendor.VendorManagerTest.testCreateVendor_NoPrimaryLocation" time="0.828"/>
+    <testcase name="org.twia.vendor.VendorManagerTest.testCreateVendor_NoPrimaryRep" time="0.876"/>
+    <testcase name="org.twia.vendor.VendorManagerTest.testCreateAdjustingFirm" time="0.766">
+        <error message="RuntimeException; nested exception is: &#10;&#9;org.twia.dao.DAOException: [S2001] Hibernate encountered an error updating Claim [null] : &#10;&#9;id = C0147909. Reason = The given object has a null identifier: org.twia.claim.Claim; Logon Id: tbotadauth. Claim Id: {3}." type="java.rmi.ServerException">java.rmi.ServerException: RuntimeException; nested exception is:
+            org.twia.dao.DAOException: [S2001] Hibernate encountered an error updating Claim [null] :
+            id = C0147909. Reason = The given object has a null identifier: org.twia.claim.Claim; Logon Id: tbotadauth. Claim Id: {3}.&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.handleException(LogInterceptor.java:421)&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:209)&#13;
+            at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)&#13;
+            at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)&#13;
+            at org.jboss.ejb.Container.invoke(Container.java:960)&#13;
+            at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at org.jboss.invocation.local.LocalInvoker$MBeanServerAction.invoke(LocalInvoker.java:169)&#13;
+            at org.jboss.invocation.local.LocalInvoker.invoke(LocalInvoker.java:118)&#13;
+            at org.jboss.invocation.InvokerInterceptor.invokeLocal(InvokerInterceptor.java:209)&#13;
+            at org.jboss.invocation.InvokerInterceptor.invoke(InvokerInterceptor.java:195)&#13;
+            at org.jboss.proxy.TransactionInterceptor.invoke(TransactionInterceptor.java:61)&#13;
+            at org.jboss.proxy.SecurityInterceptor.invoke(SecurityInterceptor.java:70)&#13;
+            at org.jboss.proxy.ejb.StatelessSessionInterceptor.invoke(StatelessSessionInterceptor.java:112)&#13;
+            at org.jboss.proxy.ClientContainer.invoke(ClientContainer.java:100)&#13;
+            at $Proxy108.updateClaim(Unknown Source)&#13;
+            at org.twia.vendor.VendorManagerTest.testCreateAdjustingFirm(VendorManagerTest.java:259)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at junit.framework.TestCase.runTest(TestCase.java:166)&#13;
+            at org.unitils.UnitilsJUnit3.runTest(UnitilsJUnit3.java:171)&#13;
+            at junit.framework.TestCase.runBare(TestCase.java:140)&#13;
+            at org.unitils.UnitilsJUnit3.runBare(UnitilsJUnit3.java:138)&#13;
+            at junit.framework.TestResult$1.protect(TestResult.java:106)&#13;
+            at junit.framework.TestResult.runProtected(TestResult.java:124)&#13;
+            at junit.framework.TestResult.run(TestResult.java:109)&#13;
+            at junit.framework.TestCase.run(TestCase.java:131)&#13;
+            at org.unitils.UnitilsJUnit3.run(UnitilsJUnit3.java:101)&#13;
+            at junit.framework.TestSuite.runTest(TestSuite.java:173)&#13;
+            at junit.framework.TestSuite.run(TestSuite.java:168)&#13;
+            at junit.framework.TestSuite.runTest(TestSuite.java:173)&#13;
+            at junit.framework.TestSuite.run(TestSuite.java:168)&#13;
+            at junit.textui.TestRunner.doRun(TestRunner.java:74)&#13;
+            at org.twia.junit.CustomTestRunner.run(CustomTestRunner.java:76)&#13;
+            at org.twia.test.ejb.JunitCallerEJB.testSuites(JunitCallerEJB.java:136)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.invocation.Invocation.performCall(Invocation.java:359)&#13;
+            at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)&#13;
+            at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)&#13;
+            at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)&#13;
+            at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)&#13;
+            at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:315)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)&#13;
+            at org.jboss.ejb.plugins.SecurityInterceptor.invoke(SecurityInterceptor.java:168)&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)&#13;
+            at org.jboss.ejb.plugins.ProxyFactoryFinderInterceptor.invoke(ProxyFactoryFinderInterceptor.java:138)&#13;
+            at org.jboss.ejb.SessionContainer.internalInvoke(SessionContainer.java:648)&#13;
+            at org.jboss.ejb.Container.invoke(Container.java:960)&#13;
+            at sun.reflect.GeneratedMethodAccessor289.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at org.jboss.invocation.unified.server.UnifiedInvoker.invoke(UnifiedInvoker.java:231)&#13;
+            at sun.reflect.GeneratedMethodAccessor288.invoke(Unknown Source)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.mx.interceptor.ReflectedDispatcher.invoke(ReflectedDispatcher.java:155)&#13;
+            at org.jboss.mx.server.Invocation.dispatch(Invocation.java:94)&#13;
+            at org.jboss.mx.server.Invocation.invoke(Invocation.java:86)&#13;
+            at org.jboss.mx.server.AbstractMBeanInvoker.invoke(AbstractMBeanInvoker.java:264)&#13;
+            at org.jboss.mx.server.MBeanServerImpl.invoke(MBeanServerImpl.java:659)&#13;
+            at javax.management.MBeanServerInvocationHandler.invoke(MBeanServerInvocationHandler.java:201)&#13;
+            at $Proxy16.invoke(Unknown Source)&#13;
+            at org.jboss.remoting.ServerInvoker.invoke(ServerInvoker.java:795)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.processInvocation(ServerThread.java:573)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.dorun(ServerThread.java:387)&#13;
+            at org.jboss.remoting.transport.socket.ServerThread.run(ServerThread.java:166)&#13;
+            Caused by: org.twia.dao.DAOException: [S2001] Hibernate encountered an error updating Claim [null] :
+            id = C0147909. Reason = The given object has a null identifier: org.twia.claim.Claim; Logon Id: tbotadauth. Claim Id: {3}.&#13;
+            at org.twia.persistence.hibernate.HibernateDAO.handleHibernateException(HibernateDAO.java:274)&#13;
+            at org.twia.persistence.hibernate.HibernateDAO.handleHibernateException(HibernateDAO.java:242)&#13;
+            at org.twia.persistence.hibernate.HibernateDAO.update(HibernateDAO.java:443)&#13;
+            at org.twia.claim.ClaimManager.updateClaim(ClaimManager.java:4475)&#13;
+            at org.twia.claim.ClaimManagerSessionEJB.updateClaim(ClaimManagerSessionEJB.java:68)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)&#13;
+            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)&#13;
+            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)&#13;
+            at java.lang.reflect.Method.invoke(Method.java:585)&#13;
+            at org.jboss.invocation.Invocation.performCall(Invocation.java:359)&#13;
+            at org.jboss.ejb.StatelessSessionContainer$ContainerInterceptor.invoke(StatelessSessionContainer.java:237)&#13;
+            at org.jboss.resource.connectionmanager.CachedConnectionInterceptor.invoke(CachedConnectionInterceptor.java:158)&#13;
+            at org.jboss.ejb.plugins.StatelessSessionInstanceInterceptor.invoke(StatelessSessionInstanceInterceptor.java:169)&#13;
+            at org.jboss.ejb.plugins.CallValidationInterceptor.invoke(CallValidationInterceptor.java:63)&#13;
+            at org.jboss.ejb.plugins.AbstractInterceptor.invoke(AbstractInterceptor.java:111)&#13;
+            at org.twia.stats.StatisticsInterceptor.invoke(StatisticsInterceptor.java:79)&#13;
+            at org.jboss.ejb.plugins.AbstractTxInterceptor.invokeNext(AbstractTxInterceptor.java:121)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.runWithTransactions(TxInterceptorCMT.java:350)&#13;
+            at org.jboss.ejb.plugins.TxInterceptorCMT.invoke(TxInterceptorCMT.java:181)&#13;
+            at org.twia.security.SecurityInterceptor.invoke(SecurityInterceptor.java:105)&#13;
+            at org.jboss.ejb.plugins.LogInterceptor.invoke(LogInterceptor.java:205)&#13;
+            ... 81 more&#13;
+        </error>
+    </testcase>
+</testsuite>

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
@@ -26,10 +26,15 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model;
 import hudson.ExtensionComponent;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.model.Result;
 import org.jenkinsci.plugins.structs.SymbolLookup;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +57,16 @@ public abstract class BuildCondition implements Serializable, ExtensionPoint {
         WorkflowRun run = (WorkflowRun)runWrapper.getRawBuild();
 
         return meetsCondition(run);
+    }
+
+    @CheckForNull
+    protected Result getExecutionResult(@Nonnull WorkflowRun r) {
+        FlowExecution execution = r.getExecution();
+        if (execution instanceof CpsFlowExecution) {
+            return ((CpsFlowExecution) execution).getResult();
+        } else {
+            return r.getResult();
+        }
     }
 
     public abstract String getDescription();

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>2.20</version>
+        <version>2.22</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -257,6 +257,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>copyartifact</artifactId>
         <version>1.39</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <version>1.22.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-37663](https://issues.jenkins-ci.org/browse/JENKINS-37663)
* Description:
    * The new junit step doesn't set the Run to UNSTABLE directly, it sets the context (and therefore the execution) result to UNSTABLE. We should be checking the execution result as well as the Run result.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
