### PR TITLE
[FIXED JENKINS-48115] Work around badly configured metasteps

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -172,6 +172,11 @@
       <artifactId>htmlpublisher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jira-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
@@ -422,7 +422,10 @@ class ASTParserUtils {
         Descriptor<? extends Describable> funcDesc = lookupCache.lookupFunction(methodName, descClass)
         StepDescriptor stepDesc = lookupCache.lookupStepDescriptor(methodName)
         // This is the case where we've got a wrapper in options
-        if (stepDesc != null || (funcDesc != null && !StepDescriptor.metaStepsOf(methodName).isEmpty())) {
+        if (stepDesc != null ||
+            (funcDesc != null &&
+                // Deal with cases like jira-steps that claim to be metasteps without any metastep arguments!
+                StepDescriptor.metaStepsOf(methodName)?.first()?.metaStepArgumentType != Object.class)) {
             MapExpression m = new MapExpression()
             m.addMapEntryExpression(constX("name"), constX(methodName))
             m.addMapEntryExpression(constX("args"), argsMap(methArgs))

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -108,7 +108,7 @@ public class OptionsTest extends AbstractModelDefTest {
         WorkflowJob p = b.getParent();
 
         // We test for skipDefaultCheckout() in the Jenkinsfile itself by verifying that Jenkinsfile isn't in the workspace
-        
+
         // Job properties
         BuildDiscarderProperty bdp = p.getProperty(BuildDiscarderProperty.class);
         assertNotNull(bdp);
@@ -332,5 +332,17 @@ public class OptionsTest extends AbstractModelDefTest {
         expect(Result.FAILURE, "retryOptions")
                 .logContains("Retrying")
                 .go();
+    }
+
+    @Issue("JENKINS-48115")
+    @Test
+    public void disableConcurrentBuilds() throws Exception {
+        WorkflowRun b = expect("disableConcurrentBuilds")
+                .go();
+        WorkflowJob p = b.getParent();
+
+        DisableConcurrentBuildsJobProperty prop = p.getProperty(DisableConcurrentBuildsJobProperty.class);
+        assertNotNull(prop);
+
     }
 }

--- a/pipeline-model-definition/src/test/resources/disableConcurrentBuilds.groovy
+++ b/pipeline-model-definition/src/test/resources/disableConcurrentBuilds.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    options {
+        disableConcurrentBuilds()
+        buildDiscarder(logRotator(numToKeepStr:'1'))
+        timeout(time: 30, unit: 'MINUTES')
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,11 @@
         <artifactId>copyartifact</artifactId>
         <version>1.39</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>jira-steps</artifactId>
+        <version>1.3.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-48115](https://issues.jenkins-ci.org/browse/JENKINS-48115)
* Description:
    * jira-steps has `isMetaStep()` returning true for all its step descriptors, which is...wrong. As a result, literally every symbol has at least one erstwhile metastep, breaking our logic for determining whether we're looking at a function or a describable. Sigh. While this should be fixed in jira-steps too, we should definitely be working around the super-broad cases like this.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
