### PR TITLE
[FIXED JENKINS-46252] Mark Declarative jobs with DeclarativeJobAction

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -33,6 +33,7 @@ import hudson.BulkChange
 import hudson.ExtensionList
 import hudson.model.Describable
 import hudson.model.Descriptor
+import hudson.model.Job
 import hudson.model.JobProperty
 import hudson.model.ParameterDefinition
 import hudson.model.ParametersDefinitionProperty
@@ -46,6 +47,7 @@ import org.codehaus.groovy.control.SourceUnit
 import org.jenkinsci.plugins.pipeline.StageStatus
 import org.jenkinsci.plugins.pipeline.StageTagsMetadata
 import org.jenkinsci.plugins.pipeline.SyntheticStage
+import org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobPropertyTrackerAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildParameter
@@ -270,7 +272,7 @@ public class Utils {
         return nodes
     }
 
-    static void markExecutedStagesOnAction(CpsScript script, String astUUID) throws Exception {
+    static void updateRunAndJobActions(CpsScript script, String astUUID) throws Exception {
         WorkflowRun r = script.$build()
         ExecutionModelAction action = r.getAction(ExecutionModelAction.class)
         if (action != null) {
@@ -279,6 +281,10 @@ public class Utils {
             }
             action.setStagesUUID(astUUID)
             r.save()
+            Job<?,?> job = r.getParent()
+            if (job.getAction(DeclarativeJobAction.class) == null) {
+                job.addAction(new DeclarativeJobAction())
+            }
         }
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.parser
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import hudson.model.Job
 import hudson.model.JobProperty
 import hudson.model.ParameterDefinition
 import hudson.model.Run
@@ -43,6 +44,7 @@ import org.codehaus.groovy.ast.stmt.TryCatchStatement
 import org.codehaus.groovy.ast.stmt.WhileStatement
 import org.codehaus.groovy.syntax.Types
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+import org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.*
@@ -82,6 +84,10 @@ class RuntimeASTTransformer {
             } else {
                 action.addStages(stages)
                 run.save()
+            }
+            Job<?,?> job = run.getParent()
+            if (job.getAction(DeclarativeJobAction.class) == null) {
+                job.addAction(new DeclarativeJobAction())
             }
         }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.parser
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import hudson.model.Job
 import hudson.model.JobProperty
 import hudson.model.ParameterDefinition
 import hudson.model.Run
@@ -44,7 +43,6 @@ import org.codehaus.groovy.ast.stmt.TryCatchStatement
 import org.codehaus.groovy.ast.stmt.WhileStatement
 import org.codehaus.groovy.syntax.Types
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
-import org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.*
@@ -84,10 +82,6 @@ class RuntimeASTTransformer {
             } else {
                 action.addStages(stages)
                 run.save()
-            }
-            Job<?,?> job = run.getParent()
-            if (job.getAction(DeclarativeJobAction.class) == null) {
-                job.addAction(new DeclarativeJobAction())
             }
         }
 

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/DeclarativeJobAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/DeclarativeJobAction.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.actions;
+
+import hudson.model.InvisibleAction;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DeclarativeJobAction extends InvisibleAction {
+    public DeclarativeJobAction() {
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -57,7 +57,7 @@ public class ModelInterpreter implements Serializable {
         if (root != null) {
             boolean postBuildRun = false
 
-            Utils.markExecutedStagesOnAction(script, root.astUUID)
+            Utils.updateRunAndJobActions(script, root.astUUID)
 
             try {
                 loadLibraries(root)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -35,6 +35,7 @@ import jenkins.model.BuildDiscarderProperty;
 import jenkins.plugins.git.GitSCMSource;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.pipeline.StageStatus;
+import org.jenkinsci.plugins.pipeline.modeldefinition.actions.DeclarativeJobAction;
 import org.jenkinsci.plugins.pipeline.modeldefinition.actions.ExecutionModelAction;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTNamedArgumentList;
@@ -48,6 +49,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue;
 import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.actions.TagsAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepAtomNode;
 import org.jenkinsci.plugins.workflow.cps.nodes.StepStartNode;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -1244,4 +1246,16 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-46252")
+    @Test
+    public void declarativeJobAction() throws Exception {
+        WorkflowRun r1 = expect("simplePipeline").go();
+        WorkflowJob j1 = r1.getParent();
+        assertNotNull(j1.getAction(DeclarativeJobAction.class));
+
+        WorkflowJob j2 = j.createProject(WorkflowJob.class, "nonDeclarative");
+        j2.setDefinition(new CpsFlowDefinition("echo 'hi'", true));
+        j.buildAndAssertSuccess(j2);
+        assertNull(j2.getAction(DeclarativeJobAction.class));
+    }
 }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-46252](https://issues.jenkins-ci.org/browse/JENKINS-46252)
* Description:
    * If we are in a Declarative run, mark the parent job as a Declarative job via DeclarativeJobAction, if it's not already present. Note that we never remove this - if a job was ever once Declarative, we still count it as such. Imperfect, but close enough.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
