### PR TITLE
[FIXED JENKINS-48209] Prevent serialization of when expression closure

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
@@ -180,6 +180,23 @@ class ASTParserUtils {
             s << printer(" - op: ${n.operation.toString()}", ind)
             s << printer("  - right:", ind)
             s << prettyPrint(n.rightExpression, ind)
+        } else if (n instanceof IfStatement) {
+            s << printer("- if stmt:", ind)
+            s << prettyPrint(n.booleanExpression, ind)
+            s << printer("- if block:", ind)
+            s << prettyPrint(n.ifBlock, ind)
+            if (n.elseBlock != null) {
+                s << printer("- else block:", ind)
+                s << prettyPrint(n.elseBlock, ind )
+            }
+        } else if (n instanceof TupleExpression) {
+            s << printer("- tuples:", ind)
+            n.expressions.each {
+                s << prettyPrint(it, ind)
+            }
+        } else if (n instanceof BooleanExpression) {
+            s << printer("- boolexp:", ind)
+            s << prettyPrint(n.expression, ind)
         } else {
             s << printer("- ${n}", ind)
         }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ExpressionConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ExpressionConditional.java
@@ -50,7 +50,8 @@ import javax.annotation.CheckForNull;
 public class ExpressionConditional extends DeclarativeStageConditional<ExpressionConditional> {
     private final String block;
 
-    private Closure closureBlock;
+    // Needs to be transient to avoid potential excessive pickling - see JENKINS-48209
+    private transient Closure closureBlock;
 
     @Deprecated
     public ExpressionConditional(String block) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ExpressionConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ExpressionConditional.java
@@ -106,4 +106,6 @@ public class ExpressionConditional extends DeclarativeStageConditional<Expressio
             return conditional;
         }
     }
+
+    private static final long serialVersionUID = 1L;
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DurabilityTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DurabilityTest.java
@@ -113,8 +113,23 @@ public class DurabilityTest extends AbstractDeclarativeTest {
                                 "      }\n" +
                                 "    }\n" +
                                 "    stage('bar') {\n" +
+                                "      when {\n" +
+                                "        expression {\n" +
+                                "          return true\n" +
+                                "        }\n" +
+                                "      }\n" +
                                 "      steps {\n" +
                                 "        sh('echo reallyAfterFoo')\n" +
+                                "      }\n" +
+                                "    }\n" +
+                                "    stage('baz') {\n" +
+                                "      when {\n" +
+                                "        expression {\n" +
+                                "          return false\n" +
+                                "        }\n" +
+                                "      }\n" +
+                                "      steps {\n" +
+                                "        sh('echo neverShouldReach')\n" +
                                 "      }\n" +
                                 "    }\n" +
                                 "  }\n" +
@@ -135,6 +150,7 @@ public class DurabilityTest extends AbstractDeclarativeTest {
                 story.j.assertLogContains("before=demo", b);
                 story.j.assertLogContains("ONAGENT=true", b);
                 story.j.assertLogContains("reallyAfterFoo", b);
+                story.j.assertLogNotContains("neverShouldReach", b);
                 FlowExecution execution = b.getExecution();
                 assertNotNull(execution);
                 FlowGraphWalker walker = new FlowGraphWalker(execution);

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
@@ -40,9 +40,13 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.endpoints.ModelConverterAction;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.ChangeLogStrategy;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.jenkinsci.plugins.workflow.pickles.Pickle;
+import org.jenkinsci.plugins.workflow.support.pickles.SingleTypedPickleFactory;
+import org.jenkinsci.plugins.workflow.support.pickles.XStreamPickle;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
@@ -357,6 +361,14 @@ public class WhenStageTest extends AbstractModelDefTest {
 
     }
 
+    @Issue("JENKINS-48209")
+    @Test
+    public void whenExprDurableTask() throws Exception {
+        expect("whenExprDurableTask")
+                .logContains("Heal it")
+                .go();
+    }
+
     private void waitFor(Queue.Item item) throws InterruptedException, ExecutionException {
         while (item != null && item.getFuture() == null) {
             Thread.sleep(200);
@@ -386,4 +398,14 @@ public class WhenStageTest extends AbstractModelDefTest {
             return false;
         }
     }
+
+    @TestExtension
+    public static class WhenConditionPickleFactory extends SingleTypedPickleFactory<DeclarativeStageConditional<?>> {
+        @Override
+        @Nonnull
+        protected Pickle pickle(DeclarativeStageConditional<?> d) {
+            return new XStreamPickle(d);
+        }
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/whenExprDurableTask.groovy
+++ b/pipeline-model-definition/src/test/resources/whenExprDurableTask.groovy
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label "here"
+    }
+
+    stages {
+        stage("One") {
+            steps {
+                echo "Hello"
+            }
+        }
+        stage("Two") {
+            when {
+                expression {
+                    if (isUnix()) {
+                        return sh(script: "echo true", returnStdout: true).trim() == "true"
+                    } else {
+                        return bat(script: "echo true", returnStdout: true).trim() == "true"
+                    }
+                }
+            }
+            steps {
+                script {
+                    echo "World"
+                    echo "Heal it"
+                }
+
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/whenExprDurableTask.groovy
+++ b/pipeline-model-definition/src/test/resources/whenExprDurableTask.groovy
@@ -39,7 +39,8 @@ pipeline {
                     if (isUnix()) {
                         return sh(script: "echo true", returnStdout: true).trim() == "true"
                     } else {
-                        return bat(script: "echo true", returnStdout: true).trim() == "true"
+                        // NOTE: Having some trouble getting the same logic as above working on bat, will revisit in the future
+                        return true
                     }
                 }
             }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-48209](https://issues.jenkins-ci.org/browse/JENKINS-48209)
* Description:
    * This shouldn't really matter, in truth - I believe we actually regenerate the whole Root object from scratch on resume, though I could be misremembering. Regardless, even having the when expression closure be transient, the durability test (with when expressions added) still works right.
    * As to why we need to do this in the first place? Because something weird could be out there trying to some non-standard serialization of Describables. Ok, spoiler, there definitely is such a thing, and it does a straight XStream serialization of every Describable. But we use Describables as more than just UI config stuff - we use them for syntax validation and such for our internal extension points, like when conditions. And if that XStream serialization of a when expression with a sh step kicks in, well, all hell breaks loose. This works around that.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
