### PR TITLE
[FIXED JENKINS-48266] Skip post for skipped parallel stages

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 import hudson.model.Result;
 import hudson.model.Slave;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 
@@ -121,12 +122,20 @@ public class PostStageTest extends AbstractModelDefTest {
         expect("withAgentNoneAndAgentAny")
                 .logNotContains("Required context class hudson.FilePath is missing").go();
     }
-
+    
     @Issue("JENKINS-47928")
     @Test
     public void parallelParentPostFailure() throws Exception {
         expect(Result.FAILURE, "parallelParentPostFailure")
                 .logNotContains("PARALLEL STAGE POST").go();
+    }
+
+    @Issue("JENKINS-48266")
+    @Test
+    public void postAfterParallel() throws Exception {
+        expect("postAfterParallel")
+                .logContains("Post ran")
+                .go();
     }
 
     @Override

--- a/pipeline-model-definition/src/test/resources/postStage/postAfterParallel.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/postAfterParallel.groovy
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage('Parallel') {
+            parallel {
+                stage('Child 1') {
+                    agent any
+                    steps { echo 'Child 1' }
+                }
+                stage('Child 2') {
+                    agent any
+                    steps { echo 'Child 2' }
+                }
+            }
+            post {
+                always {
+                    echo 'Post ran'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-48266](https://issues.jenkins-ci.org/browse/JENKINS-48266)
* Description:
    * The JENKINS-47928 fix (in #217) was actually not right - it disabled calling post entirely for parallel parent stages if they weren't the source of an error themselves. That means they weren't called at all if there was no failure!
    * The proper fix is to track whether a parallel parent stage has been skipped, and if so, skip post execution as well. Which is what's done here. Tada.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
