### PR TITLE
[FIXED JENKINS-48229] Use the agent's dir separator for Dockerfile path

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfile.java
@@ -81,11 +81,15 @@ public class DockerPipelineFromDockerfile extends AbstractDockerAgent<DockerPipe
     }
 
     @Nonnull
-    public String getDockerfilePath() {
+    public String getDockerfilePath(boolean isUnix) {
         StringBuilder fullPath = new StringBuilder();
         if (!StringUtils.isEmpty(dir)) {
             fullPath.append(dir);
-            fullPath.append(IOUtils.DIR_SEPARATOR);
+            if (isUnix) {
+                fullPath.append(IOUtils.DIR_SEPARATOR_UNIX);
+            } else {
+                fullPath.append(IOUtils.DIR_SEPARATOR_WINDOWS);
+            }
         }
         fullPath.append(getDockerfileAsString());
         return fullPath.toString();

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -78,7 +78,7 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
                 def imgName = "${hash}"
                 def additionalBuildArgs = describable.getAdditionalBuildArgs() ? " ${describable.additionalBuildArgs}" : ""
                 script.sh "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
-                script.dockerFingerprintFrom dockerfile: describable.dockerfilePath, image: imgName, toolName: script.env.DOCKER_TOOL_NAME
+                script.dockerFingerprintFrom dockerfile: dockerfilePath, image: imgName, toolName: script.env.DOCKER_TOOL_NAME
                 return script.getProperty("docker").image(imgName)
             } catch (FileNotFoundException f) {
                 script.error("No Dockerfile found at ${dockerfilePath} in repository - failing.")

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -72,15 +72,16 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
 
     private Closure buildImage() {
         return {
+            def dockerfilePath = describable.getDockerfilePath(script.isUnix())
             try {
-                def hash = Utils.stringToSHA1(script.readFile("${describable.getDockerfilePath()}"))
+                def hash = Utils.stringToSHA1(script.readFile("${dockerfilePath}"))
                 def imgName = "${hash}"
                 def additionalBuildArgs = describable.getAdditionalBuildArgs() ? " ${describable.additionalBuildArgs}" : ""
-                script.sh "docker build -t ${imgName}${additionalBuildArgs} -f \"${describable.getDockerfilePath()}\" \"${describable.getActualDir()}\""
+                script.sh "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
                 script.dockerFingerprintFrom dockerfile: describable.dockerfilePath, image: imgName, toolName: script.env.DOCKER_TOOL_NAME
                 return script.getProperty("docker").image(imgName)
             } catch (FileNotFoundException f) {
-                script.error("No Dockerfile found at ${describable.getDockerfilePath()} in repository - failing.")
+                script.error("No Dockerfile found at ${dockerfilePath} in repository - failing.")
                 return null
             }
         }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-48229](https://issues.jenkins-ci.org/browse/JENKINS-48229)
* Description:
    * I'm not sure how to test this - the issue occurs when the master's got different directory separators than the agent, which isn't something I can easily do in a unit test.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
