### PR TITLE
[JENKINS-48304] Invalidate option type caches after extensions augmented

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
@@ -99,6 +99,15 @@ class Options implements Serializable {
             }
         )
 
+    /**
+     * Invalidate our type caches.
+     */
+    static void invalidateCaches() {
+        wrapperStepsTypeCache.invalidateAll()
+        propertyTypeCache.invalidateAll()
+        optionTypeCache.invalidateAll()
+    }
+
     static Map<String,String> getEligibleWrapperStepClasses() {
         return wrapperStepsTypeCache.get(WRAPPER_STEPS_KEY)
     }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
@@ -24,6 +24,9 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.Extension;
+import hudson.init.InitMilestone;
+import hudson.init.Initializer;
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Options;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.CpsThread;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
@@ -57,6 +60,16 @@ public class ModelStepLoader extends GlobalVariable {
                 .loadClass("org.jenkinsci.plugins.pipeline.modeldefinition.ModelInterpreter")
                 .getConstructor(CpsScript.class)
                 .newInstance(script);
+    }
+
+    /**
+     * Make sure we've invalidated the option type caches due to potential race conditions with their population.
+     * Because we're using {@link Initializer}, we need this to be triggered in an {@link Extension}, so here is as good
+     * a place as any.
+     */
+    @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
+    public static void invalidateOptionTypeCaches() {
+        Options.invalidateCaches();
     }
 
 }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-48304](https://issues.jenkins-ci.org/browse/JENKINS-48304)
* Description:
    * This may not be perfect, but it should hopefully eliminate the potential race condition of not all types being in the caches due to plugin loading order.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
