### PR TITLE
Add an extension point for runtime transformation of steps.

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -411,7 +411,6 @@ class Utils {
      * @param c The closure to wrap.
      */
     @Whitelisted
-    @Restricted(NoExternalUse.class)
     static StepsBlock createStepsBlock(Closure c) {
         // Jumping through weird hoops to get around the ejection for cases of JENKINS-26481.
         StepsBlock wrapper = new StepsBlock()

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -749,8 +749,9 @@ class RuntimeASTTransformer {
                 if (stepsMethod != null) {
                     BlockStatementMatch stepsMatch = matchBlockStatement(stepsMethod)
                     if (stepsMatch != null) {
+                        ClosureExpression transformedBody = StepRuntimeTransformerContributor.transformStage(original, stepsMatch.body)
                         return callX(ClassHelper.make(Utils.class), "createStepsBlock",
-                            args(stepsMatch.body))
+                            args(transformedBody))
                     }
                 }
             }
@@ -769,8 +770,9 @@ class RuntimeASTTransformer {
     Expression transformStepsFromBuildCondition(@CheckForNull ModelASTBuildCondition original) {
         if (isGroovyAST(original)) {
             BlockStatementMatch condMatch = matchBlockStatement((Statement) original.sourceLocation)
+            ClosureExpression transformedBody = StepRuntimeTransformerContributor.transformBuildCondition(original, condMatch.body)
             return callX(ClassHelper.make(Utils.class), "createStepsBlock",
-                args(condMatch.body))
+                args(transformedBody))
         }
         return constX(null)
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributorTest.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser;
+
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MapEntryExpression;
+import org.codehaus.groovy.ast.expr.MapExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.TupleExpression;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.jenkinsci.plugins.pipeline.modeldefinition.SyntheticStageNames;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
+import org.junit.Test;
+import org.jvnet.hudson.test.TestExtension;
+
+import javax.annotation.Nonnull;
+
+import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
+
+public class StepRuntimeTransformerContributorTest extends AbstractModelDefTest {
+
+    @Test
+    public void simpleTransform() throws Exception {
+        expect("simplePipeline")
+                .logContains("HELLO")
+                .go();
+    }
+
+    @Test
+    public void nestedTransform() throws Exception {
+        expect("nestedTreeSteps")
+                .logContains("HELLO", "Timeout set to expire in 10 sec")
+                .go();
+    }
+
+    @Test
+    public void transformPost() throws Exception {
+        expect("transformPost")
+                .logContains("[Pipeline] { (foo)",
+                        "HELLO",
+                        "I HAVE FINISHED",
+                        "MOST DEFINITELY FINISHED")
+                .logNotContains("I FAILED")
+                .go();
+    }
+
+    @TestExtension
+    public static class EchoTransformer extends StepRuntimeTransformerContributor {
+        @Override
+        @Nonnull
+        public MethodCallExpression transformStep(@Nonnull ModelASTStep step, @Nonnull MethodCallExpression methodCall) {
+            if (step.getName().equals("echo")) {
+                ArgumentListExpression newArgs = new ArgumentListExpression();
+                TupleExpression oldArgs = (TupleExpression)methodCall.getArguments();
+
+                for (Expression expr : oldArgs.getExpressions()) {
+                    if (expr instanceof ConstantExpression && ((ConstantExpression) expr).getValue() instanceof String) {
+                        String origVal = (String)((ConstantExpression)expr).getValue();
+                        newArgs.addExpression(constX(origVal.toUpperCase()));
+                    }
+                }
+                methodCall.setArguments(newArgs);
+            }
+
+            return methodCall;
+        }
+    }
+
+    @TestExtension
+    public static class TimeoutTransformer extends StepRuntimeTransformerContributor {
+        @Override
+        @Nonnull
+        public MethodCallExpression transformStep(@Nonnull ModelASTStep step, @Nonnull MethodCallExpression methodCall) {
+            if (step.getName().equals("timeout")) {
+                ArgumentListExpression newArgs = new ArgumentListExpression();
+                TupleExpression oldArgs = (TupleExpression)methodCall.getArguments();
+
+                for (Expression expr : oldArgs.getExpressions()) {
+                    if (expr instanceof MapExpression) {
+                        MapExpression originalMap = (MapExpression) expr;
+                        MapExpression newMap = new MapExpression();
+
+                        for (MapEntryExpression origEntry : originalMap.getMapEntryExpressions()) {
+                            if (origEntry.getKeyExpression() instanceof ConstantExpression &&
+                                    ((ConstantExpression) origEntry.getKeyExpression()).getValue().equals("time")) {
+                                newMap.addMapEntryExpression(constX("time"), constX(10));
+                            } else {
+                                newMap.addMapEntryExpression(origEntry);
+                            }
+                        }
+                        newArgs.addExpression(newMap);
+                    } else {
+                        newArgs.addExpression(expr);
+                    }
+                }
+                methodCall.setArguments(newArgs);
+            }
+
+            return methodCall;
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/transformPost.groovy
+++ b/pipeline-model-definition/src/test/resources/transformPost.groovy
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+    post {
+        always {
+            echo "i have finished"
+        }
+        success {
+            echo "most definitely finished"
+        }
+        failure {
+            echo "i failed"
+        }
+    }
+}
+
+
+

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributor.java
@@ -1,0 +1,211 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser;
+
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.MapExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.TupleExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.AbstractModelASTCodeBlock;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildCondition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTreeStep;
+
+import javax.annotation.Nonnull;
+
+import static org.codehaus.groovy.ast.tools.GeneralUtils.*;
+
+public abstract class StepRuntimeTransformerContributor implements ExtensionPoint {
+
+    /**
+     * Construct the new {@link ClosureExpression} for the given stage.
+     */
+    @Nonnull
+    public final ClosureExpression handleStage(@Nonnull ModelASTStage stage, @Nonnull ClosureExpression body) {
+        if (stage.getBranches().size() == 1) {
+            ModelASTBranch branch = stage.getBranches().get(0);
+            body.setCode(handleBranch(branch));
+        } else {
+            // Parallel case - multiple branches yay. Let's do some safety checks, though.
+            Statement stmt = body.getCode();
+            // Make sure we've got a block.
+            if (stmt instanceof BlockStatement) {
+                BlockStatement block = (BlockStatement)stmt;
+                // Make sure that block has one statement and that one statement is an expression
+                if (block.getStatements().size() == 1 && block.getStatements().get(0) instanceof ExpressionStatement) {
+                    ExpressionStatement exprStmt = (ExpressionStatement) block.getStatements().get(0);
+                    // Make sure the expression in there is a method call.
+                    if (exprStmt.getExpression() instanceof MethodCallExpression) {
+                        MethodCallExpression methExpr = (MethodCallExpression) exprStmt.getExpression();
+                        // Make sure the method is "parallel", the receiver is "this", and the arguments are a tuple
+                        if ("parallel".equals(methExpr.getMethodAsString()) &&
+                                methExpr.getReceiver() instanceof VariableExpression &&
+                                "this".equals(((VariableExpression) methExpr.getReceiver()).getName()) &&
+                                methExpr.getArguments() instanceof TupleExpression) {
+                            TupleExpression parallelArgs = (TupleExpression)methExpr.getArguments();
+
+                            // Make sure the arguments consist of a single entry in a tuple, and that single entry is a map.
+                            if (parallelArgs.getExpressions().size() == 1 &&
+                                    parallelArgs.getExpression(0) instanceof MapExpression) {
+                                MapExpression newParallelMap = new MapExpression();
+
+                                for (ModelASTBranch b : stage.getBranches()) {
+                                    newParallelMap.addMapEntryExpression(constX(b.getName()), closureX(handleBranch(b)));
+                                }
+
+                                body.setCode(
+                                        block(
+                                                stmt(
+                                                        callX(
+                                                                varX("this"),
+                                                                constX("parallel"),
+                                                                args(newParallelMap)
+                                                        )
+                                                )
+                                        )
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return body;
+    }
+
+    /**
+     * Construct the new {@link ClosureExpression} for the given build condition.
+     */
+    @Nonnull
+    public final ClosureExpression handleBuildCondition(@Nonnull ModelASTBuildCondition condition, @Nonnull ClosureExpression body) {
+        body.setCode(handleBranch(condition.getBranch()));
+        return body;
+    }
+
+    /**
+     * Construct the new {@link BlockStatement} for the given branch.
+     */
+    @Nonnull
+    public final BlockStatement handleBranch(@Nonnull ModelASTBranch branch) {
+        BlockStatement newBlock = block();
+
+        for (ModelASTStep s : branch.getSteps()) {
+            // Don't process script blocks or a step that for some reason isn't an expression statement at all
+            if (s instanceof AbstractModelASTCodeBlock || !(s.getSourceLocation() instanceof ExpressionStatement)) {
+                newBlock.addStatement((Statement)s.getSourceLocation());
+            } else {
+                ExpressionStatement es = (ExpressionStatement) s.getSourceLocation();
+
+                if (es.getExpression() instanceof MethodCallExpression) {
+                    MethodCallExpression methodCall = (MethodCallExpression) es.getExpression();
+                    newBlock.addStatement(stmt(handleStep(s, methodCall)));
+                } else {
+                    newBlock.addStatement(es);
+                }
+            }
+        }
+
+        return newBlock;
+    }
+
+    /**
+     * Call {@link #transformStep(ModelASTStep, MethodCallExpression)} if appropriate, after handling any nested steps as well.
+     */
+    @Nonnull
+    public final MethodCallExpression handleStep(@Nonnull ModelASTStep step, @Nonnull MethodCallExpression methodCall) {
+        if (step instanceof AbstractModelASTCodeBlock) {
+            return methodCall;
+        }
+
+        if (step instanceof ModelASTTreeStep) {
+            TupleExpression originalArgs = (TupleExpression) methodCall.getArguments();
+            ArgumentListExpression newArgs = new ArgumentListExpression();
+            for (int i = 0; i < originalArgs.getExpressions().size() - 1; i++) {
+                newArgs.addExpression(originalArgs.getExpression(i));
+            }
+            ClosureExpression originalClosure = (ClosureExpression) originalArgs.getExpression(originalArgs.getExpressions().size() - 1);
+            BlockStatement newBlock = block();
+
+            for (ModelASTStep nested : ((ModelASTTreeStep) step).getChildren()) {
+                ExpressionStatement es = (ExpressionStatement) nested.getSourceLocation();
+                newBlock.addStatement(stmt(handleStep(nested, (MethodCallExpression)es.getExpression())));
+            }
+
+            originalClosure.setCode(newBlock);
+
+            newArgs.addExpression(originalClosure);
+            methodCall.setArguments(newArgs);
+        }
+
+        return transformStep(step, methodCall);
+    }
+
+    @Nonnull
+    public abstract MethodCallExpression transformStep(@Nonnull ModelASTStep step, @Nonnull MethodCallExpression methodCall);
+
+    /**
+     * Get all {@link StepRuntimeTransformerContributor}s.
+     *
+     * @return a list of all {@link StepRuntimeTransformerContributor}s registered.
+     */
+    public static ExtensionList<StepRuntimeTransformerContributor> all() {
+        return ExtensionList.lookup(StepRuntimeTransformerContributor.class);
+    }
+
+    /**
+     * Apply step transformation to the given stage for all {@link StepRuntimeTransformerContributor}s.
+     */
+    @Nonnull
+    public static ClosureExpression transformStage(@Nonnull ModelASTStage stage, @Nonnull ClosureExpression body) {
+        for (StepRuntimeTransformerContributor c : all()) {
+            body = c.handleStage(stage, body);
+        }
+
+        return body;
+    }
+
+    /**
+     * Apply step transformation to the given build condition for all {@link StepRuntimeTransformerContributor}s.
+     */
+    @Nonnull
+    public static ClosureExpression transformBuildCondition(@Nonnull ModelASTBuildCondition condition,
+                                                            @Nonnull ClosureExpression body) {
+        for (StepRuntimeTransformerContributor c : all()) {
+            body = c.handleBuildCondition(condition, body);
+        }
+
+        return body;
+    }
+}

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributor.java
@@ -152,6 +152,7 @@ public abstract class StepRuntimeTransformerContributor implements ExtensionPoin
         if (step instanceof ModelASTTreeStep) {
             TupleExpression originalArgs = (TupleExpression) methodCall.getArguments();
             ArgumentListExpression newArgs = new ArgumentListExpression();
+            // Technically we can't get here if there 0 expressions, so the loop below is safe.
             for (int i = 0; i < originalArgs.getExpressions().size() - 1; i++) {
                 newArgs.addExpression(originalArgs.getExpression(i));
             }


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * This'll end up getting used in `jx-pipelines-plugin` to avoid the same kind of closure->model transformation we got rid of when we switched to `RuntimeASTTransformer` here.
    * Also unrestricted `Utils#createStepsBlock(Closure)` because that'll probably end up used in implementations of this.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @rsandell 
