### PR TITLE
[JENKINS-49070] Avoid serializing BigDecimal and BigInteger in the model

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     environment {
         GIT_COMMITTER_NAME = "jenkins"
         GIT_COMMITTER_EMAIL = "jenkins@jenkins.io"
-        NEWER_CORE_VERSION = "2.103"
+        NEWER_CORE_VERSION = "2.89.3"
     }
     
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     environment {
         GIT_COMMITTER_NAME = "jenkins"
         GIT_COMMITTER_EMAIL = "jenkins@jenkins.io"
-        NEWER_CORE_VERSION = "2.89.2"
+        NEWER_CORE_VERSION = "2.103"
     }
     
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -1171,8 +1171,10 @@ class ModelParser implements Parser {
             } else if (val instanceof BigInteger) {
                 if (val > Long.MAX_VALUE || val < Long.MIN_VALUE) {
                     errorCollector.error(ModelASTValue.fromConstant(-1, e), Messages.ModelParser_BigIntegerValue())
+                    val = -1
+                } else {
+                    val = val.longValue()
                 }
-                val = -1
             }
             return ModelASTValue.fromConstant(val, e)
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -1165,7 +1165,16 @@ class ModelParser implements Parser {
      */
     protected ModelASTValue parseArgument(Expression e) {
         if (e instanceof ConstantExpression) {
-            return ModelASTValue.fromConstant(e.value, e)
+            Object val = e.value
+            if (val instanceof BigDecimal) {
+                val = val.doubleValue()
+            } else if (val instanceof BigInteger) {
+                if (val > Long.MAX_VALUE || val < Long.MIN_VALUE) {
+                    errorCollector.error(ModelASTValue.fromConstant(-1, e), Messages.ModelParser_BigIntegerValue())
+                }
+                val = -1
+            }
+            return ModelASTValue.fromConstant(val, e)
         }
         if (e instanceof GStringExpression) {
             String rawSrc = getSourceText(e)

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -34,6 +34,7 @@ Parser.Triggers=Triggers
 Parser.UndefinedSection=Undefined section "{0}"
 
 ModelParser.BareDollarCurly={0} cannot be used as a value directly. Did you mean "{0}"?
+ModelParser.BigIntegerValue=BigIntegers cannot be used as constants in Declarative. The maximum value for an integer is 9,223,372,036,854,775,807 and the minimum value for an integer is -9,223,372,036,854,775,808.
 ModelParser.CannotHaveBlocks={0} definitions cannot have blocks
 ModelParser.DuplicateEnvVar=Duplicate environment variable name: "{0}"
 ModelParser.ExpectedAgent=Expected an agent

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -1311,8 +1311,6 @@ public class BasicModelDefTest extends AbstractModelDefTest {
 
         Object realVal = val.getValue();
 
-        assertTrue(realVal instanceof Double);
-
         assertEquals(new Double("1.0"), realVal);
 
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -874,4 +874,12 @@ public class ValidatorTest extends AbstractModelDefTest {
                         Parameters.getAllowedParameterTypes().keySet()))
                 .go();
     }
+
+    @Issue("JENKINS-49070")
+    @Test
+    public void bigIntegerFailure() throws Exception {
+        expectError("bigIntegerFailure")
+                .logContains(Messages.ModelParser_BigIntegerValue())
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/bigDecimalConverts.groovy
+++ b/pipeline-model-definition/src/test/resources/bigDecimalConverts.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    stages {
+        stage("foo") {
+            steps {
+                junit allowEmptyResults: true, testResults: 'junitResult.xml', healthScaleFactor: 1.0
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/bigIntegerFailure.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/bigIntegerFailure.groovy
@@ -1,0 +1,39 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                timeout(time: 9223372036854775808) {
+                    echo "hello"
+                }
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-49070](https://issues.jenkins-ci.org/browse/JENKINS-49070)
* Description:
    * Groovy parses `0.1` into a `BigDecimal`. So let's convert that to a `Double` instead in `ModelASTValue#value`. And also, just barf out if for some reason someone tries to use a `BigInteger` constant. Because no.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
