### PR TITLE
[JENKINS-49135] Add support for passing Options var/method to options

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTOptions.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTOptions.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
 
 import javax.annotation.Nonnull;
@@ -16,6 +18,8 @@ import javax.annotation.Nonnull;
 public final class ModelASTOptions extends ModelASTElement {
     private List<ModelASTOption> options = new ArrayList<>();
     private boolean inStage = false;
+    private transient VariableExpression optionsVar;
+    private transient MethodCallExpression optionsCall;
 
     public ModelASTOptions(Object sourceLocation) {
         super(sourceLocation);
@@ -71,6 +75,23 @@ public final class ModelASTOptions extends ModelASTElement {
     public void setInStage(boolean inStage) {
         this.inStage = inStage;
     }
+
+    public VariableExpression getOptionsVar() {
+        return optionsVar;
+    }
+
+    public void setOptionsVar(VariableExpression optionsVar) {
+        this.optionsVar = optionsVar;
+    }
+
+    public MethodCallExpression getOptionsCall() {
+        return optionsCall;
+    }
+
+    public void setOptionsCall(MethodCallExpression optionsCall) {
+        this.optionsCall = optionsCall;
+    }
+
 
     @Override
     public String toString() {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Options.groovy
@@ -33,6 +33,7 @@ import hudson.FilePath
 import hudson.Launcher
 import hudson.model.JobProperty
 import hudson.model.JobPropertyDescriptor
+import org.jenkinsci.plugins.pipeline.modeldefinition.Messages
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor
@@ -65,6 +66,18 @@ class Options implements Serializable {
         this.properties.addAll(properties)
         this.options.putAll(options)
         this.wrappers.putAll(wrappers)
+    }
+
+    @Whitelisted
+    Options(@Nonnull Object obj) {
+        if (obj instanceof Options) {
+            Options original = (Options) obj
+            this.properties.addAll(original.properties)
+            this.options.putAll(original.options)
+            this.wrappers.putAll(original.wrappers)
+        } else {
+            throw new IllegalArgumentException(Messages.ModelInterpreter_InvalidDirectiveArgument(this.class, obj.class))
+        }
     }
 
     List<JobProperty> getProperties() {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/StageOptions.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/StageOptions.groovy
@@ -28,6 +28,7 @@ import com.google.common.cache.LoadingCache
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
+import org.jenkinsci.plugins.pipeline.modeldefinition.Messages
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor
@@ -53,6 +54,19 @@ class StageOptions implements Serializable {
         this.options.putAll(options)
         this.wrappers.putAll(wrappers)
     }
+
+    @Whitelisted
+    StageOptions(@Nonnull Object obj) {
+        if (obj instanceof StageOptions) {
+            StageOptions original = (StageOptions) obj
+            this.options.putAll(original.options)
+            this.wrappers.putAll(original.wrappers)
+        } else {
+            throw new IllegalArgumentException(Messages.ModelInterpreter_InvalidDirectiveArgument(this.class, obj.class))
+        }
+    }
+
+
 
     Map<String, DeclarativeOption> getOptions() {
         return options

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -511,7 +511,10 @@ class ModelValidatorImpl implements ModelValidator {
 
     boolean validateElement(@Nonnull ModelASTOptions opts) {
         boolean valid = true
-        if (opts.options.isEmpty()) {
+        // TODO: If this pans out, want to find a way to validate var/call.
+        if (opts.optionsCall != null || opts.optionsVar != null) {
+            valid = true
+        } else if (opts.options.isEmpty()) {
             errorCollector.error(opts, Messages.ModelValidatorImpl_EmptySection("options"))
             valid = false
         } else {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -90,6 +90,7 @@ ModelParser.TooManyArgsForField=Too many arguments for field "{0}"
 ModelParser.TooManyArgsForMapMethodKey=Too many arguments for map key "{0}"
 ModelParser.TooManyArgsForTool=Too many arguments for tool "{0}"
 ModelParser.UnknownStageSection=Unknown stage section "{0}". Starting with version 0.5, steps in a stage must be in a 'steps' block.
+ModelParser.WrongArgsForDirective=The "{0}" directive must have either a block or an instance of {1} as its sole argument.
 
 JSONParser.InvalidValueType=Invalid value type
 JSONParser.InvalidArgumentSyntax=Invalid argument syntax
@@ -152,4 +153,5 @@ ModelValidatorImpl.MissingInputMessage=No message specified for input
 WhenConditionalValidator.changelog.missingParameter=Changelog is missing required parameter "pattern".
 WhenConditionalValidator.changelog.badPattern="{0}" is not a valid regular expression. {1}
 
+ModelInterpreter.InvalidDirectiveArgument=Method or variable argument to options is not of type {0}, and is instead of type {1}.
 ModelInterpreter.NoNodeContext=Attempted to execute a step that requires a node context while 'agent none' was specified. Be sure to specify your own 'node { ... }' blocks when using 'agent none'.

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -416,6 +416,46 @@ public class OptionsTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-49135")
+    @Test
+    public void optionsObject() throws Exception {
+        WorkflowRun b = expect("optionsObject")
+                .logContains("[Pipeline] { (foo)", "hello")
+                .logNotContains("[Pipeline] { (" + SyntheticStageNames.postBuild() + ")")
+                .go();
+
+        WorkflowJob p = b.getParent();
+
+        BuildDiscarderProperty bdp = p.getProperty(BuildDiscarderProperty.class);
+        assertNotNull(bdp);
+        BuildDiscarder strategy = bdp.getStrategy();
+        assertNotNull(strategy);
+        assertEquals(LogRotator.class, strategy.getClass());
+        LogRotator lr = (LogRotator) strategy;
+        assertEquals(1, lr.getNumToKeep());
+
+    }
+
+    @Issue("JENKINS-49135")
+    @Test
+    public void optionsMethodCall() throws Exception {
+        WorkflowRun b = expect("optionsMethodCall")
+                .logContains("[Pipeline] { (foo)", "hello")
+                .logNotContains("[Pipeline] { (" + SyntheticStageNames.postBuild() + ")")
+                .go();
+
+        WorkflowJob p = b.getParent();
+
+        BuildDiscarderProperty bdp = p.getProperty(BuildDiscarderProperty.class);
+        assertNotNull(bdp);
+        BuildDiscarder strategy = bdp.getStrategy();
+        assertNotNull(strategy);
+        assertEquals(LogRotator.class, strategy.getClass());
+        LogRotator lr = (LogRotator) strategy;
+        assertEquals(1, lr.getNumToKeep());
+
+    }
+
     private static class DummyPrivateKey extends BaseCredentials implements SSHUserPrivateKey, Serializable {
 
         private final String id;

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -799,7 +799,7 @@ public class ValidatorTest extends AbstractModelDefTest {
         expectError("nonBlockSections")
                 .logContains(Messages.ModelParser_ExpectedBlockFor("environment"),
                         Messages.ModelParser_ExpectedBlockFor("libraries"),
-                        Messages.ModelParser_ExpectedBlockFor("options"),
+                        Messages.ModelParser_WrongArgsForDirective("options", Options.class),
                         Messages.ModelParser_ExpectedBlockFor("triggers"),
                         Messages.ModelParser_ExpectedBlockFor("parameters"),
                         Messages.ModelParser_ExpectedBlockFor("tools"))
@@ -925,4 +925,35 @@ public class ValidatorTest extends AbstractModelDefTest {
         }
     }
 
+    @Issue("JENKINS-49135")
+    @Test
+    public void invalidOptionsObject() throws Exception {
+        expectError("invalidOptionsObject")
+                .logContains(Messages.ModelInterpreter_InvalidDirectiveArgument(Options.class, String.class))
+                .go();
+    }
+
+    @Issue("JENKINS-49135")
+    @Test
+    public void invalidOptionsMethodCall() throws Exception {
+        expectError("invalidOptionsMethodCall")
+                .logContains(Messages.ModelInterpreter_InvalidDirectiveArgument(Options.class, String.class))
+                .go();
+    }
+
+    @Issue("JENKINS-49135")
+    @Test
+    public void optionsEmptyArgs() throws Exception {
+        expectError("optionsEmptyArgs")
+                .logContains(Messages.ModelParser_WrongArgsForDirective("options", Options.class))
+                .go();
+    }
+
+    @Issue("JENKINS-49135")
+    @Test
+    public void optionsInvalidExpression() throws Exception {
+        expectError("optionsInvalidExpression")
+                .logContains(Messages.ModelParser_WrongArgsForDirective("options", Options.class))
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/errors/invalidOptionsMethodCall.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidOptionsMethodCall.groovy
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+def genOpts() {
+    return "pants"
+}
+pipeline {
+    agent none
+    options genOpts()
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/invalidOptionsObject.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/invalidOptionsObject.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+def opts = "pants"
+
+pipeline {
+    agent none
+    options opts
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/optionsEmptyArgs.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/optionsEmptyArgs.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    options()
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/errors/optionsInvalidExpression.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/optionsInvalidExpression.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    options "pants"
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/optionsMethodCall.groovy
+++ b/pipeline-model-definition/src/test/resources/optionsMethodCall.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Options
+
+def genOpts() {
+    return new Options([buildDiscarder(logRotator(numToKeepStr: '1'))], [:], [:])
+}
+pipeline {
+    agent none
+    options genOpts()
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/optionsObject.groovy
+++ b/pipeline-model-definition/src/test/resources/optionsObject.groovy
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Options
+
+def opts = new Options([buildDiscarder(logRotator(numToKeepStr: '1'))], [:], [:])
+pipeline {
+    agent none
+    options opts
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-49135](https://issues.jenkins-ci.org/browse/JENKINS-49135)
* Description:
    * This is very preliminary (and even the minimal approach still needs tests for `StageOptions` as well as `Options`) and may not actually land. The idea is that you'd be able to either declare a variable of type `Options` or have a method that returns an instance of `Options`, and use that variable or method call as the argument to `options`, like this:

```
def opts = new Options([buildDiscarder(logRotator(numToKeepStr:'1'))], [:], [:])

pipeline {
  ...
  options opts
  ...
}

// or

def genOpts() {
    return new Options([buildDiscarder(logRotator(numToKeepStr: '1'))], [:], [:])
}

pipeline {
  ...
  options getOpts()
  ...
}
```
* Description continued
    * This would *not* allow for validation of the `options` contents, it *would* require actually instantiating an `Options` instance, rather than defining a closure like you'd normally specify for `options`, and it would not work in the editor (i.e., translating to JSON would just result in an empty `options` directive). This is necessary because the transformation behind the scenes from `options { ... }` to an `Options` instance requires runtime AST transformation, which means we need to treat any `options` method call anywhere in the Jenkinsfile or a shared library specially. Which is not optimal, to say the least.
    * Note that this would require declaring the *whole* `options` directive - no combining with explicitly specified entries as laid out in the JIRA.
    * If this ever actually lands, it'll be a power-user feature anyway, so I'd be ok with this requirement. That said, this is a good reason why I'm unsure about this landing.
    * Oh, and if we decide to move forward for this, I'll add support for some other directives (i.e., `triggers`, `parameters`, probably `agent`, `tools`), but not *all* (i.e., definitely *not* `stage`, `stages`, `when`, `post`, `steps`...).
* Documentation changes:
    * Good question. This is the kind of power-user feature that I wouldn't want documented on jenkins.io...which of course is another suggestion that this probably shouldn't land.
* Users/aliases to notify:
    * @reviewbybees 
