### PR TITLE
[JENKINS-42688] More powerful conditions in post

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
             parallel {
                 stage("linux") {
                     agent {
-                        label "java"
+                        label "highmem"
                     }
                     steps {
                         sh 'mvn clean install -Dmaven.test.failure.ignore=true'
@@ -66,7 +66,7 @@ pipeline {
                 }
                 stage("linux-newer-core") {
                     agent {
-                        label "java"
+                        label "highmem"
                     }
                     steps {
                         sh "mvn clean install -Dmaven.test.failure.ignore=true -Djava.level=8 -Djenkins.version=${NEWER_CORE_VERSION}"

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBranchHolder.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBranchHolder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,20 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugins.pipeline.modeldefinition.model
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
+package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 
-/**
- * Conditions and step blocks to be run after the stages but before the notifications, depending on build status.
- *
- * @author Andrew Bayer
- */
-@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
-class PostBuild extends AbstractBuildConditionResponder<PostBuild> {
-    @Whitelisted
-    PostBuild(Map<String,StepsBlock> m, Map<StageConditionals,StepsBlock> w) {
-        super(m, w)
-    }
+public interface ModelASTBranchHolder extends ModelASTMarkerInterface {
+    ModelASTBranch getBranch();
 }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildCondition.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildCondition.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
  *
  * @author Andrew Bayer
  */
-public final class ModelASTBuildCondition extends ModelASTElement {
+public final class ModelASTBuildCondition extends ModelASTElement implements ModelASTBranchHolder {
     private String condition;
     private ModelASTBranch branch;
 

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildConditionsContainer.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildConditionsContainer.java
@@ -19,6 +19,7 @@ import javax.annotation.Nonnull;
  */
 public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
     private List<ModelASTBuildCondition> conditions = new ArrayList<>();
+    private List<ModelASTPostWhenCondition> whenConditions = new ArrayList<>();
 
     protected ModelASTBuildConditionsContainer(Object sourceLocation) {
         super(sourceLocation);
@@ -28,11 +29,18 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
 
     @Override
     public JSONObject toJSON() {
+        JSONObject o = new JSONObject();
         final JSONArray a = new JSONArray();
         for (ModelASTBuildCondition condition: conditions) {
             a.add(condition.toJSON());
         }
-        return new JSONObject().accumulate("conditions", a);
+        o.accumulate("conditions", a);
+        final JSONArray w = new JSONArray();
+        for (ModelASTPostWhenCondition whenCondition : whenConditions) {
+            w.add(whenCondition.toJSON());
+        }
+        o.accumulate("whenConditions", w);
+        return o;
     }
 
     @Override
@@ -40,6 +48,9 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
         validator.validateElement(this);
         for (ModelASTBuildCondition condition: conditions) {
             condition.validate(validator);
+        }
+        for (ModelASTPostWhenCondition w : whenConditions) {
+            w.validate(validator);
         }
         super.validate(validator);
     }
@@ -51,6 +62,9 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
         for (ModelASTBuildCondition condition : conditions) {
             result.append(condition.toGroovy()).append('\n');
         }
+        for (ModelASTPostWhenCondition w : whenConditions) {
+            result.append(w.toGroovy()).append("\n");
+        }
         result.append("}\n");
         return result.toString();
     }
@@ -60,6 +74,9 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
         super.removeSourceLocation();
         for (ModelASTBuildCondition condition : conditions) {
             condition.removeSourceLocation();
+        }
+        for (ModelASTPostWhenCondition w : whenConditions) {
+            w.removeSourceLocation();
         }
     }
 
@@ -71,10 +88,19 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
         this.conditions = conditions;
     }
 
+    public List<ModelASTPostWhenCondition> getWhenConditions() {
+        return whenConditions;
+    }
+
+    public void setWhenConditions(List<ModelASTPostWhenCondition> whenConditions) {
+        this.whenConditions = whenConditions;
+    }
+
     @Override
     public String toString() {
         return "ModelASTBuildConditionsContainer{" +
                 "conditions=" + conditions +
+                ", whenConditions=" + whenConditions +
                 "}";
     }
 
@@ -92,6 +118,9 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
 
         ModelASTBuildConditionsContainer that = (ModelASTBuildConditionsContainer) o;
 
+        if (getWhenConditions() != null ? !getWhenConditions().equals(that.getWhenConditions()) : that.getWhenConditions() != null) {
+            return false;
+        }
         return getConditions() != null ? getConditions().equals(that.getConditions()) : that.getConditions() == null;
 
     }
@@ -100,6 +129,7 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + (getConditions() != null ? getConditions().hashCode() : 0);
+        result = 31 * result + (getWhenConditions() != null ? getWhenConditions().hashCode() : 0);
         return result;
     }
 }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPostWhenCondition.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPostWhenCondition.java
@@ -1,0 +1,127 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
+
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a single when condition to be checked and possibly executed in the post sections.
+ *
+ * @author Andrew Bayer
+ */
+public final class ModelASTPostWhenCondition extends ModelASTElement implements ModelASTBranchHolder {
+    private ModelASTWhen when;
+    private ModelASTBranch branch;
+
+    public ModelASTPostWhenCondition(Object sourceLocation) {
+        super(sourceLocation);
+    }
+
+    @Override
+    public JSONObject toJSON() {
+        return new JSONObject().accumulate("when", when.toJSON()).accumulate("branch", branch.toJSON());
+    }
+
+    @Override
+    public void validate(@Nonnull ModelValidator validator) {
+        validator.validateElement(this);
+        when.validate(validator);
+        branch.validate(validator);
+    }
+
+    @Override
+    public String toGroovy() {
+        StringBuilder result = new StringBuilder();
+        result.append("condition {\n");
+        result.append(when.toGroovy()).append("\n");
+        result.append("steps {\n");
+        result.append(branch.toGroovy());
+        result.append("\n}\n}\n");
+        return result.toString();
+    }
+
+    @Override
+    public void removeSourceLocation() {
+        super.removeSourceLocation();
+        when.removeSourceLocation();
+        branch.removeSourceLocation();
+    }
+
+    public ModelASTWhen getWhen() {
+        return when;
+    }
+
+    public void setWhen(ModelASTWhen when) {
+        this.when = when;
+    }
+
+    public ModelASTBranch getBranch() {
+        return branch;
+    }
+
+    public void setBranch(ModelASTBranch branch) {
+        this.branch = branch;
+    }
+
+    @Override
+    public String toString() {
+        return "ModelASTPostWhenCondition{" +
+                "condition='" + when + '\'' +
+                ", branch=" + branch +
+                "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ModelASTPostWhenCondition that = (ModelASTPostWhenCondition) o;
+
+        if (getWhen() != null ? !getWhen().equals(that.getWhen()) : that.getWhen() != null) {
+            return false;
+        }
+        return getBranch() != null ? getBranch().equals(that.getBranch()) : that.getBranch() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getWhen() != null ? getWhen().hashCode() : 0);
+        result = 31 * result + (getBranch() != null ? getBranch().hashCode() : 0);
+        return result;
+    }
+}

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
@@ -40,6 +40,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostBuild;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostWhenCondition;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStageInput;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
@@ -102,4 +103,6 @@ public interface ModelValidator {
     boolean validateElement(ModelASTStageInput input);
 
     boolean validateElement(ModelASTValue value);
+
+    boolean validateElement(ModelASTPostWhenCondition condition);
 }

--- a/pipeline-model-api/src/main/resources/ast-schema.json
+++ b/pipeline-model-api/src/main/resources/ast-schema.json
@@ -435,21 +435,42 @@
       ],
       "additionalProperties": false
     },
+    "postWhenCondition": {
+      "description": "A when condition and block of steps to run if the when condition is satisfied, to be used in post sections",
+      "type": "object",
+      "properties": {
+        "when": {
+          "$ref": "#/definitions/when"
+        },
+        "branch": {
+          "$ref": "#/definitions/branch"
+        }
+      },
+      "required": [
+        "condition",
+        "branch"
+      ],
+      "additionalProperties": false
+    },
     "post": {
       "description": "An array of build conditions with blocks of steps to run if those conditions are satisfied at the end of the build while still on the image/node the build ran on",
       "type": "object",
       "properties": {
         "conditions": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 0,
           "items": {
             "$ref": "#/definitions/buildCondition"
           }
+        },
+        "whenConditions": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "$ref": "#/definitions/postWhenCondition"
+          }
         }
       },
-      "required": [
-        "conditions"
-      ],
       "additionalProperties": false
     },
     "input": {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/AbstractBuildConditionResponder.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/AbstractBuildConditionResponder.groovy
@@ -31,18 +31,20 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
  * @author Andrew Bayer
  */
 @SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
-abstract class AbstractBuildConditionResponder<T extends AbstractBuildConditionResponder<T>>
-    extends MappedClosure<StepsBlock,T> {
+abstract class AbstractBuildConditionResponder<T extends AbstractBuildConditionResponder<T>> implements Serializable {
+    private Map<String,StepsBlock> conditions
+    private Map<StageConditionals,StepsBlock> whenConditions
 
-    AbstractBuildConditionResponder(Map<String,StepsBlock> m) {
-        super(m)
+    AbstractBuildConditionResponder(Map<String,StepsBlock> conditions, Map<StageConditionals,StepsBlock> whenConditions) {
+        this.conditions = conditions
+        this.whenConditions = whenConditions
     }
 
     Closure closureForSatisfiedCondition(String conditionName, Object runWrapperObj) {
-        if (getMap().containsKey(conditionName)) {
+        if (conditions.containsKey(conditionName)) {
             BuildCondition condition = BuildCondition.getConditionMethods().get(conditionName)
             if (condition != null && condition.meetsCondition(runWrapperObj)) {
-                return ((StepsBlock)getMap().get(conditionName)).getClosure()
+                return ((StepsBlock)conditions.get(conditionName)).getClosure()
             }
         }
 
@@ -53,7 +55,11 @@ abstract class AbstractBuildConditionResponder<T extends AbstractBuildConditionR
         Map<String,BuildCondition> conditions = BuildCondition.getConditionMethods()
 
         return BuildCondition.orderedConditionNames.any { conditionName ->
-            getMap().containsKey(conditionName) && conditions.get(conditionName).meetsCondition(runWrapperObj)
+            conditions.containsKey(conditionName) && conditions.get(conditionName).meetsCondition(runWrapperObj)
         }
+    }
+
+    Map<StageConditionals,StepsBlock> getWhenConditions() {
+        return whenConditions
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/PostStage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/PostStage.groovy
@@ -33,7 +33,7 @@ import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
 @SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
 class PostStage extends AbstractBuildConditionResponder<PostStage> {
     @Whitelisted
-    PostStage(Map<String,StepsBlock> m) {
-        super(m)
+    PostStage(Map<String,StepsBlock> m, Map<StageConditionals,StepsBlock> w) {
+        super(m, w)
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -566,6 +566,14 @@ class JSONParser implements Parser {
         return condition
     }
 
+    @CheckForNull ModelASTPostWhenCondition parsePostWhenCondition(JsonTree j) {
+        ModelASTPostWhenCondition condition = new ModelASTPostWhenCondition(j)
+        condition.when = parseWhen(j.append(JsonPointer.of("when")))
+        condition.branch = parseBranch(j.append(JsonPointer.of("branch")))
+
+        return condition
+    }
+
     @CheckForNull ModelASTPostBuild parsePostBuild(JsonTree j) {
         ModelASTPostBuild postBuild = new ModelASTPostBuild(j)
         return parseBuildConditionResponder(j, postBuild)
@@ -582,6 +590,12 @@ class JSONParser implements Parser {
         conds.node.eachWithIndex { JsonNode entry, int i ->
             responder.conditions.add(parseBuildCondition(conds.append(JsonPointer.of(i))))
         }
+
+        JsonTree whens = j.append(JsonPointer.of("whenConditions"))
+        whens.node.eachWithIndex { JsonNode entry, int i ->
+            responder.whenConditions.add(parsePostWhenCondition(conds.append(JsonPointer.of(i))))
+        }
+
         return responder
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -1103,7 +1103,7 @@ class ModelParser implements Parser {
             eachStatement(m.body.code) {
                 def condBlock = matchBlockStatement(it)
                 if (condBlock == null) {
-                    errorCollector.error(responder, Messages.ModelParser_ExpectedBlock())
+                    errorCollector.error(responder, Messages.ModelParser_InvalidBuildCondition(BuildCondition.getOrderedConditionNames()))
                 } else {
                     if (condBlock.methodName == "condition") {
                         ModelASTPostWhenCondition pwc = parsePostWhenCondition(it)

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -762,6 +762,21 @@ class ModelValidatorImpl implements ModelValidator {
         return validateFromContributors(value, true)
     }
 
+    boolean validateElement(@Nonnull ModelASTPostWhenCondition postWhen) {
+        boolean valid = true
+
+        if (postWhen.when == null) {
+            errorCollector.error(postWhen, Messages.ModelValidatorImpl_PostWhenConditionMissingDirective("when"))
+            valid = false
+        }
+        if (postWhen.branch == null) {
+            errorCollector.error(postWhen, Messages.ModelValidatorImpl_PostWhenConditionMissingDirective("steps"))
+            valid = false
+        }
+
+        return validateFromContributors(postWhen, valid)
+    }
+
     private boolean validateFromContributors(ModelASTElement element, boolean isValid, boolean isNested = false) {
         boolean contributorsValid = DeclarativeValidatorContributor.all().collect { contributor ->
             List<String> errors

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/StatusConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/StatusConditional.java
@@ -118,10 +118,13 @@ public class StatusConditional extends DeclarativeStageConditional<StatusConditi
         FlowExecution execution = r.getExecution();
         if (execution instanceof CpsFlowExecution) {
             return ((CpsFlowExecution) execution).getResult();
-        } else if (r.getResult() != null) {
-            return r.getResult();
         } else {
-            return Result.SUCCESS;
+            Result result = r.getResult();
+            if (result == null) {
+                result = Result.SUCCESS;
+            }
+
+            return result;
         }
     }
 

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/StatusConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/StatusConditional.java
@@ -1,0 +1,136 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.when.impl;
+
+import hudson.Extension;
+import hudson.model.Result;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenContent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.parser.ASTParserUtils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * Stage/post condition based on the current build status, aping the legacy post conditionals.
+ */
+public class StatusConditional extends DeclarativeStageConditional<StatusConditional> {
+    private String status;
+    private boolean always;
+    private boolean changed;
+
+    @DataBoundConstructor
+    public StatusConditional() {
+    }
+
+    public boolean isAlways() {
+        return always;
+    }
+
+    @DataBoundSetter
+    public void setAlways(boolean always) {
+        this.always = always;
+    }
+
+    public boolean isChanged() {
+        return changed;
+    }
+
+    @DataBoundSetter
+    public void setChanged(boolean changed) {
+        this.changed = changed;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    @DataBoundSetter
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public boolean statusMatches(RunWrapper runWrapper) {
+        if (always) {
+            return true;
+        }
+        WorkflowRun r = (WorkflowRun) runWrapper.getRawBuild();
+        if (r != null) {
+            Result runResult = r.getResult() != null ? r.getResult() : Result.SUCCESS;
+            if (changed) {
+                Result execResult = getExecutionResult(r);
+                // Only look at the previous completed build.
+                WorkflowRun prev = r.getPreviousCompletedBuild();
+
+                Result combinedResult = execResult.combine(runResult);
+
+                if (prev == null) {
+                    return true;
+                } else {
+                    return !combinedResult.equals(prev.getResult());
+                }
+            } else if (status != null) {
+                return runResult.equals(Result.fromString(status));
+            } else {
+                // In practice, we can never reach this, since at least one of always/changed/status needs to be specified.
+                return true;
+            }
+        } else {
+            // Something has gone weirdly wrong.
+            // TODO: Logging of that.
+            return false;
+        }
+    }
+
+    @Nonnull
+    private Result getExecutionResult(@Nonnull WorkflowRun r) {
+        FlowExecution execution = r.getExecution();
+        if (execution instanceof CpsFlowExecution) {
+            return ((CpsFlowExecution) execution).getResult();
+        } else if (r.getResult() != null) {
+            return r.getResult();
+        } else {
+            return Result.SUCCESS;
+        }
+    }
+
+    @Extension
+    @Symbol("buildStatus")
+    public static class DescriptorImpl extends DeclarativeStageConditionalDescriptor<StatusConditional> {
+        @Override
+        public Expression transformToRuntimeAST(@CheckForNull ModelASTWhenContent original) {
+            return ASTParserUtils.transformWhenContentToRuntimeAST(original);
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -65,6 +65,7 @@ ModelParser.InvalidEnvironmentConcatValue=Environment variable values to be conc
 ModelParser.InvalidEnvironmentValue=Environment variable values must either be single quoted, double quoted, or function calls.
 ModelParser.InvalidInputField=Not a valid field for input: "{0}"
 ModelParser.InvalidInternalFunctionArg=Internal function call parameters must be strings.
+ModelParser.InvalidPostWhenConditionField=Not a valid field for post conditions: "{0}"
 ModelParser.InvalidSectionDefinition=Not a valid section definition: "{0}". Some extra configuration is required.
 ModelParser.InvalidStageSectionDefinition=Not a valid stage section definition: "{0}". Some extra configuration is required.
 ModelParser.MapNotAllowed={0} cannot be defined as maps
@@ -148,8 +149,13 @@ ModelValidatorImpl.ToolsInNestedStages="tools" is not allowed in stage "{0}" as 
 ModelValidatorImpl.NoNestedWithinNestedStages=Parallel stages or branches can only be included in a top-level stage.
 ModelValidatorImpl.CompilationErrorInCodeBlock=Groovy compilation error(s) in {0}. Error(s): "{1}"
 ModelValidatorImpl.MissingInputMessage=No message specified for input
+ModelValidatorImpl.PostWhenConditionMissingDirective=Post condition missing required "{0}" block.
 
 WhenConditionalValidator.changelog.missingParameter=Changelog is missing required parameter "pattern".
 WhenConditionalValidator.changelog.badPattern="{0}" is not a valid regular expression. {1}
+WhenConditionalValidator.StatusCondition.TooFewParameters=One of "status", "always", or "changed" is required.
+WhenConditionalValidator.StatusCondition.TooManyParameters=Only one of "status", "always", or "changed" is allowed.
+WhenConditionalValidator.StatusCondition.InvalidStatusValue="{0}" is not a valid status. Please specify one of {1}.
+
 
 ModelInterpreter.NoNodeContext=Attempted to execute a step that requires a node context while 'agent none' was specified. Be sure to specify your own 'node { ... }' blocks when using 'agent none'.

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -184,7 +184,7 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
 
         result.add(new Object[]{"emptyStages", Messages.JSONParser_TooFewItems(0, 1)});
         result.add(new Object[]{"emptyEnvironment", Messages.JSONParser_TooFewItems(0, 1)});
-        result.add(new Object[]{"emptyPostBuild", Messages.JSONParser_TooFewItems(0, 1)});
+        result.add(new Object[]{"emptyPostBuild", Messages.ModelValidatorImpl_EmptySection("post")});
 
         result.add(new Object[]{"rejectStageInSteps", Messages.ModelValidatorImpl_BlockedStep("stage",
                 BlockedStepsAndMethodCalls.blockedInSteps().get("stage"))});

--- a/pipeline-model-definition/src/test/resources/json/errors/emptyPostBuild.json
+++ b/pipeline-model-definition/src/test/resources/json/errors/emptyPostBuild.json
@@ -15,6 +15,8 @@
       }]
     }]
   }],
-  "post": {"conditions": []},
+  "post": {"conditions": [],
+    "whenConditions": []
+  },
   "agent": {"type": "none"}
 }}

--- a/pipeline-model-definition/src/test/resources/json/parallelStagesFailFast.json
+++ b/pipeline-model-definition/src/test/resources/json/parallelStagesFailFast.json
@@ -60,7 +60,9 @@
               }]
             }]
           }
-        }]}
+        }],
+          "whenConditions": []
+        }
       }
     ],
     "failFast": true

--- a/pipeline-model-definition/src/test/resources/json/simplePostBuild.json
+++ b/pipeline-model-definition/src/test/resources/json/simplePostBuild.json
@@ -64,6 +64,8 @@
         }]
       }
     }
-  ]},
+  ],
+    "whenConditions": []
+  },
   "agent": {"type": "none"}
 }}

--- a/pipeline-model-definition/src/test/resources/json/stagePost.json
+++ b/pipeline-model-definition/src/test/resources/json/stagePost.json
@@ -29,7 +29,9 @@
           }]
         }]
       }
-    }]}
+    }],
+      "whenConditions": []
+    }
   }],
   "agent": {"type": "none"}
 }}

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/StepRuntimeTransformerContributor.java
@@ -37,6 +37,7 @@ import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.AbstractModelASTCodeBlock;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranchHolder;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildCondition;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
@@ -93,9 +94,19 @@ public abstract class StepRuntimeTransformerContributor implements ExtensionPoin
     /**
      * Construct the new {@link ClosureExpression} for the given build condition.
      */
+    @Deprecated
     @Nonnull
     public final ClosureExpression handleBuildCondition(@Nonnull ModelASTBuildCondition condition, @Nonnull ClosureExpression body) {
         body.setCode(handleBranch(condition.getBranch()));
+        return body;
+    }
+
+    /**
+     * Construct the new {@link ClosureExpression} for the given branch holder.
+     */
+    @Nonnull
+    public final ClosureExpression handleBranchHolder(@Nonnull ModelASTBranchHolder holder, @Nonnull ClosureExpression body) {
+        body.setCode(handleBranch(holder.getBranch()));
         return body;
     }
 
@@ -212,11 +223,25 @@ public abstract class StepRuntimeTransformerContributor implements ExtensionPoin
     /**
      * Apply step transformation to the given build condition for all {@link StepRuntimeTransformerContributor}s.
      */
+    @Deprecated
     @Nonnull
     public static ClosureExpression transformBuildCondition(@Nonnull ModelASTBuildCondition condition,
                                                             @Nonnull ClosureExpression body) {
         for (StepRuntimeTransformerContributor c : all()) {
             body = c.handleBuildCondition(condition, body);
+        }
+
+        return body;
+    }
+
+    /**
+     * Apply step transformation to the given branch holder for all {@link StepRuntimeTransformerContributor}s.
+     */
+    @Nonnull
+    public static ClosureExpression transformBranchHolder(@Nonnull ModelASTBranchHolder holder,
+                                                          @Nonnull ClosureExpression body) {
+        for (StepRuntimeTransformerContributor c : all()) {
+            body = c.handleBranchHolder(holder, body);
         }
 
         return body;

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/DeclarativeValidatorContributor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/DeclarativeValidatorContributor.java
@@ -42,6 +42,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostBuild;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostWhenCondition;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
@@ -441,6 +442,21 @@ public abstract class DeclarativeValidatorContributor implements ExtensionPoint 
     @Nonnull
     public List<String> validateElementAll(@Nonnull ModelASTValue element, @CheckForNull FlowExecution execution) {
         String r = validateElement(element, execution);
+        List<String> result = new ArrayList<>();
+        if (r != null) {
+            result.add(r);
+        }
+        return result;
+    }
+
+    @CheckForNull
+    public String validateElement(@Nonnull ModelASTPostWhenCondition postWhenCondition, @CheckForNull FlowExecution execution) {
+        return null;
+    }
+
+    @Nonnull
+    public List<String> validateElementAll(@Nonnull ModelASTPostWhenCondition postWhenCondition, @CheckForNull FlowExecution execution) {
+        String r = validateElement(postWhenCondition, execution);
         List<String> result = new ArrayList<>();
         if (r != null) {
             result.add(r);


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-42688](https://issues.jenkins-ci.org/browse/JENKINS-42688)
* Description:
    * Specifically, allow reusing `when` conditions in `post`. The syntax is still up for negotiation, but we do need to be able to specify both the `when` condition and the `steps`, so I think the syntax I've got is as good as it gets. See below for an example.
   * Old-school `success`, `always`, etc will still work as well. To retain backwards compatibility with some...idiosyncratic behavior, we'll first check to see if *any* conditions (traditional `post` or the new `when`-based ones) are satisified, then process the satisfied `when`-based conditions, and *then* iterate over the traditional `post` conditions, checking if it's satisified, and then executing. This is for cases, like, say, doing `junit` in `always` and wanting to fire something in `unstable`.
    * Might be worth considering adding an ordinal of some sort to the `when`-based `conditional`s, so that you can control order of execution and evaluation there too?
    * Still needs testing of the new conditions - right now I've just got backwards compat testing.

```
post {
  condition {
    when {
      allOf {
        branch "master"
        buildStatus status:"SUCCESS"
      }
    }
    steps {
      echo "tada"
    }
  }
}
```

* Documentation changes:
    * Oh my yes.
* Users/aliases to notify:
    * @reviewbybees 
