### PR TITLE
[FIXED JENKINS-41060] Add new fixed/regression post conditions

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching aborted builds.
  *
@@ -37,7 +39,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=800d) @Symbol("aborted")
 class Aborted extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.ABORTED || r.getResult() == Result.ABORTED
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Always.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Always.groovy
@@ -28,6 +28,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching all builds regardless of status.
  *
@@ -36,7 +38,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=1000d) @Symbol("always")
 class Always extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         return true
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching builds with a different status than the previous build.
  *
@@ -37,14 +39,13 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=900d) @Symbol("changed")
 class Changed extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
-        Result execResult = getExecutionResult(r)
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 
         // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
         // SUCCESS.
-        Result runResult = execResult.combine(r.getResult() ?: Result.SUCCESS)
+        Result runResult = combineResults(r)
 
         // If there's no previous build, we're inherently changed.
         if (prev == null) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching failed builds.
  *
@@ -37,7 +39,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=700d) @Symbol("failure")
 class Failure extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.FAILURE || r.getResult() == Result.FAILURE
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
+
+import hudson.Extension
+import hudson.model.Result
+import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+
+/**
+ * A {@link BuildCondition} for matching builds where the previous build was not SUCCESS but the current build is.
+ *
+ * @author Andrew Bayer
+ */
+@Extension(ordinal=900d) @Symbol("fixed")
+class Fixed extends BuildCondition {
+    @Override
+    boolean meetsCondition(WorkflowRun r) {
+        Result execResult = getExecutionResult(r)
+        // Only look at the previous completed build.
+        WorkflowRun prev = r.getPreviousCompletedBuild()
+
+        // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
+        // SUCCESS.
+        Result runResult = execResult.combine(r.getResult() ?: Result.SUCCESS)
+
+        // If there's no previous build, we can't exactly be fixed, can we?
+        if (prev == null) {
+            return false
+        } else {
+            return runResult == Result.SUCCESS && prev.getResult() != Result.SUCCESS
+        }
+    }
+
+    @Override
+    String getDescription() {
+        return Messages.Fixed_Description()
+    }
+
+
+    static final long serialVersionUID = 1L
+
+}

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching builds where the previous build was not SUCCESS but the current build is.
  *
@@ -37,20 +39,19 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=890d) @Symbol("fixed")
 class Fixed extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
-        Result execResult = getExecutionResult(r)
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 
         // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
         // SUCCESS.
-        Result runResult = execResult.combine(r.getResult() ?: Result.SUCCESS)
+        Result runResult = combineResults(r)
 
         // If there's no previous build, we can't exactly be fixed, can we?
         if (prev == null) {
             return false
         } else {
-            return runResult == Result.SUCCESS && prev.getResult() != Result.SUCCESS
+            return runResult == Result.SUCCESS && prev.getResult() in [Result.FAILURE, Result.UNSTABLE]
         }
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
@@ -34,7 +34,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
  *
  * @author Andrew Bayer
  */
-@Extension(ordinal=900d) @Symbol("fixed")
+@Extension(ordinal=890d) @Symbol("fixed")
 class Fixed extends BuildCondition {
     @Override
     boolean meetsCondition(WorkflowRun r) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching unbuilt builds, such as those stopped by milestones.
  *
@@ -37,7 +39,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=400d) @Symbol("notBuilt")
 class NotBuilt extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.NOT_BUILT || r.getResult() == Result.NOT_BUILT
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
@@ -1,0 +1,65 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
+
+import hudson.Extension
+import hudson.model.Result
+import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+
+/**
+ * A {@link BuildCondition} for matching builds where the previous build was better than the current build.
+ *
+ * @author Andrew Bayer
+ */
+@Extension(ordinal=900d) @Symbol("regression")
+class Regression extends BuildCondition {
+    @Override
+    boolean meetsCondition(WorkflowRun r) {
+        Result execResult = getExecutionResult(r)
+        // Only look at the previous completed build.
+        WorkflowRun prev = r.getPreviousCompletedBuild()
+
+        // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
+        // SUCCESS.
+        Result runResult = execResult.combine(r.getResult() ?: Result.SUCCESS)
+
+        // If there's no previous build, we can't exactly be regressing, can we?
+        if (prev == null) {
+            return false
+        } else {
+            return runResult.isWorseThan(prev.getResult())
+        }
+    }
+
+    @Override
+    String getDescription() {
+        return Messages.Regression_Description()
+    }
+
+
+    static final long serialVersionUID = 1L
+
+}

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
@@ -34,7 +34,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
  *
  * @author Andrew Bayer
  */
-@Extension(ordinal=900d) @Symbol("regression")
+@Extension(ordinal=880d) @Symbol("regression")
 class Regression extends BuildCondition {
     @Override
     boolean meetsCondition(WorkflowRun r) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching builds where the previous build was better than the current build.
  *
@@ -37,14 +39,13 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=880d) @Symbol("regression")
 class Regression extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
-        Result execResult = getExecutionResult(r)
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 
         // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
         // SUCCESS.
-        Result runResult = execResult.combine(r.getResult() ?: Result.SUCCESS)
+        Result runResult = combineResults(r)
 
         // If there's no previous build, we can't exactly be regressing, can we?
         if (prev == null) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching successful builds.
  *
@@ -37,7 +39,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=600d) @Symbol("success")
 class Success extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         Result execResult = getExecutionResult(r)
         return (execResult == null || execResult.isBetterOrEqualTo(Result.SUCCESS)) &&
             (r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS))

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
@@ -29,6 +29,8 @@ import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
+import javax.annotation.Nonnull
+
 /**
  * A {@link BuildCondition} for matching unstable builds.
  *
@@ -37,7 +39,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 @Extension(ordinal=500d) @Symbol("unstable")
 class Unstable extends BuildCondition {
     @Override
-    boolean meetsCondition(WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.UNSTABLE || r.getResult() == Result.UNSTABLE
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
@@ -29,5 +29,5 @@ Failure.Description=Run if the build status is "Failure"
 NotBuilt.Description=Run if the build status is "Not Built"
 Success.Description=Run if the build status is "Success" or hasn't been set yet
 Unstable.Description=Run if the build status is "Unstable"
-Fixed.Description=Run if the current build is "Success" and the previous build is not
-Regression.Description=Run if the current build's status is worse than the previous build's status
+Fixed.Description=Run if the current build is "Success" and the previous build is "Failure" or "Unstable"
+Regression.Description=Run if the current build\'s status is worse than the previous build\'s status

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
@@ -29,3 +29,5 @@ Failure.Description=Run if the build status is "Failure"
 NotBuilt.Description=Run if the build status is "Not Built"
 Success.Description=Run if the build status is "Success" or hasn't been set yet
 Unstable.Description=Run if the build status is "Unstable"
+Fixed.Description=Run if the current build is "Success" and the previous build is not
+Regression.Description=Run if the current build's status is worse than the previous build's status

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -77,6 +77,7 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b));
         j.assertLogContains("[Pipeline] { (foo)", b);
         j.assertLogContains("I FAILED", b);
+        j.assertLogNotContains("I REGRESSED", b);
 
         WorkflowJob job = b.getParent();
         job.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources("postOnChangeChanged"), true));
@@ -84,6 +85,7 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         j.assertLogContains("[Pipeline] { (foo)", b2);
         j.assertLogContains("hello", b2);
         j.assertLogContains("I CHANGED", b2);
+        j.assertLogContains("I AM FIXED", b2);
 
         // Now make sure we don't get any alert this time.
         WorkflowRun b3 = j.buildAndAssertSuccess(job);
@@ -91,6 +93,15 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         j.assertLogContains("hello", b3);
         j.assertLogNotContains("I CHANGED", b3);
         j.assertLogNotContains("I FAILED", b3);
+        j.assertLogNotContains("I AM FIXED", b3);
+
+        // And one more time for regression
+        job.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources("postOnChangeFailed"), true));
+        WorkflowRun b4 = job.scheduleBuild2(0).waitForStart();
+        j.assertBuildStatus(Result.FAILURE, j.waitForCompletion(b4));
+        j.assertLogContains("[Pipeline] { (foo)", b4);
+        j.assertLogContains("I FAILED", b4);
+        j.assertLogContains("I REGRESSED", b4);
     }
 
     @Test

--- a/pipeline-model-definition/src/test/resources/postOnChangeChanged.groovy
+++ b/pipeline-model-definition/src/test/resources/postOnChangeChanged.groovy
@@ -35,6 +35,9 @@ pipeline {
         changed {
             echo "I CHANGED"
         }
+        fixed {
+            echo "I AM FIXED"
+        }
         failure {
             echo "I FAILED"
         }

--- a/pipeline-model-definition/src/test/resources/postOnChangeFailed.groovy
+++ b/pipeline-model-definition/src/test/resources/postOnChangeFailed.groovy
@@ -35,6 +35,9 @@ pipeline {
         changed {
             echo "I CHANGED"
         }
+        regression {
+            echo "I REGRESSED"
+        }
         failure {
             echo "I FAILED"
         }

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
@@ -50,13 +50,23 @@ import java.util.Set;
  */
 public abstract class BuildCondition implements Serializable, ExtensionPoint {
 
-    public abstract boolean meetsCondition(WorkflowRun r);
+    public abstract boolean meetsCondition(@Nonnull WorkflowRun r);
 
     public boolean meetsCondition(Object runWrapperObj) {
         RunWrapper runWrapper = (RunWrapper)runWrapperObj;
         WorkflowRun run = (WorkflowRun)runWrapper.getRawBuild();
 
         return meetsCondition(run);
+    }
+
+    @Nonnull
+    protected final Result combineResults(@Nonnull WorkflowRun run) {
+        Result execResult = getExecutionResult(run);
+        if (execResult == null) {
+            return Result.SUCCESS;
+        } else {
+            return execResult.combine(run.getResult() != null ? run.getResult() : Result.SUCCESS);
+        }
     }
 
     @CheckForNull

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
@@ -52,20 +52,23 @@ public abstract class BuildCondition implements Serializable, ExtensionPoint {
 
     public abstract boolean meetsCondition(@Nonnull WorkflowRun r);
 
-    public boolean meetsCondition(Object runWrapperObj) {
+    public boolean meetsCondition(@Nonnull Object runWrapperObj) {
         RunWrapper runWrapper = (RunWrapper)runWrapperObj;
         WorkflowRun run = (WorkflowRun)runWrapper.getRawBuild();
-
-        return meetsCondition(run);
+        return run != null && meetsCondition(run);
     }
 
     @Nonnull
     protected final Result combineResults(@Nonnull WorkflowRun run) {
         Result execResult = getExecutionResult(run);
+        Result prevResult = run.getResult();
+        if (prevResult == null) {
+            prevResult = Result.SUCCESS;
+        }
         if (execResult == null) {
             return Result.SUCCESS;
         } else {
-            return execResult.combine(run.getResult() != null ? run.getResult() : Result.SUCCESS);
+            return execResult.combine(prevResult);
         }
     }
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-41060](https://issues.jenkins-ci.org/browse/JENKINS-41060)
* Description:
    * Rather than trying to make `changed` take an additional parameter and break a bunch of parsing, let's make it simpler: here's two new `post` conditions: `fixed` and `regression`. 
    * `fixed` runs if the previous build exists and wasn't `SUCCESS`, and the current build is `SUCCESS`.
    * `regression` runs if the previous build exists and the current build's status is worse than the previous build - i.e., `currentResult.isWorseThan(previousResult)`.
* Documentation changes:
    * https://github.com/jenkins-infra/jenkins.io/pull/1444
* Users/aliases to notify:
    * @reviewbybees 
