### PR TITLE
[FIXED JENKINS-47106] Support alwaysPull in the top level agent section

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
@@ -39,7 +39,7 @@ class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPipeline> 
     @Override
     Closure runImage(Closure body) {
         return {
-            if (!Utils.withinAStage()) {
+            if (!Utils.withinAStage() && describable.alwaysPull) {
                 script.stage(SyntheticStageNames.agentSetup()) {
                     try {
                         script.getProperty("docker").image(describable.image).pull()


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins-ci.org/browse/JENKINS-47106
* Description:
    * Support `alwaysPull` in the top level agent section, was broken by https://github.com/jenkinsci/pipeline-model-definition-plugin/commit/a367db7c2a727e5ea87381777b72b4c84b52f1a2#diff-f6e51fe76a49913b4ff00606e7d4d28aL43
* Documentation changes:
    * This is a bug fix.
* Users/aliases to notify:
    * @abayer 
