### PR TITLE
WIP: Create our own per-test timeout rule.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                         label "highmem"
                     }
                     steps {
-                        sh 'mvn clean install -Dmaven.test.failure.ignore=true -Djenkins.test.timeout=360'
+                        sh 'mvn clean install -Dmaven.test.failure.ignore=true'
                     }
                     post {
                         // No matter what the build status is, run this step. There are other conditions
@@ -69,7 +69,7 @@ pipeline {
                         label "highmem"
                     }
                     steps {
-                        sh "mvn clean install -Dmaven.test.failure.ignore=true -Djava.level=8 -Djenkins.test.timeout=360 -Djenkins.version=${NEWER_CORE_VERSION}"
+                        sh "mvn clean install -Dmaven.test.failure.ignore=true -Djava.level=8 -Djenkins.version=${NEWER_CORE_VERSION}"
                     }
                     post {
                         // No matter what the build status is, run this step. There are other conditions

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -85,6 +85,8 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
     public static JenkinsRule j = new JenkinsRule();
     @Rule public GitSampleRepoRule otherRepo = new GitSampleRepoRule();
     @Rule public GitSampleRepoRule thirdRepo = new GitSampleRepoRule();
+    @Rule
+    public TimeoutPerTestRule timeoutRule = new TimeoutPerTestRule();
 
     protected static String legalAgentTypes = "";
 
@@ -96,6 +98,9 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
 
     @BeforeClass
     public static void setUpPreClass() throws Exception {
+        // Disable the timeout on the ClassRule, because it applies across the whole class, not individual tests.
+        j.timeout = 0;
+
         List<String> agentTypes = new ArrayList<>();
 
         for (DeclarativeAgentDescriptor d : j.jenkins.getExtensionList(DeclarativeAgentDescriptor.class)) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TimeoutPerTestRule.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TimeoutPerTestRule.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition;
+
+import hudson.Functions;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestTimedOutException;
+
+import java.lang.management.ThreadInfo;
+import java.util.logging.Logger;
+
+public class TimeoutPerTestRule implements TestRule {
+    private static final Logger LOGGER = Logger.getLogger(TimeoutPerTestRule.class.getName());
+
+    private int seconds;
+
+    public TimeoutPerTestRule() {
+        this.seconds = Integer.getInteger("jenkins.test.timeout", System.getProperty("maven.surefire.debug") == null ? 180 : 0);
+    }
+
+    public Statement apply(final Statement base, final Description description) {
+        if (seconds <= 0) {
+            System.out.println("Test timeout disabled.");
+            return base;
+        } else {
+            final Statement timeoutStatement = Timeout.seconds(seconds).apply(base, description);
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    try {
+                        timeoutStatement.evaluate();
+                    } catch (TestTimedOutException x) {
+                        // withLookingForStuckThread does not work well; better to just have a full thread dump.
+                        LOGGER.warning(String.format("Test timed out (after %d seconds).", seconds));
+                        dumpThreads();
+                        throw x;
+                    }
+                }
+            };
+        }
+    }
+
+    private static void dumpThreads() {
+        ThreadInfo[] threadInfos = Functions.getThreadInfos();
+        Functions.ThreadGroupMap m = Functions.sortThreadsAndGetGroupMap(threadInfos);
+        for (ThreadInfo ti : threadInfos) {
+            System.err.println(Functions.dumpThreadInfo(ti, m));
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * JenkinsRule's timeout logic goes batty when JenkinsRule is used as a ClassRule - it ends up applying to the *entire* test class, not just the individual test. So that's annoying. Here, I copy-pasted some stuff around to create a per-test Rule that still does the nice thread-dump stuff on timeout. This is just a hack, mind you. Still trying to think how I'd actually do this in JenkinsRule...
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
