### PR TITLE
[FIXED JENKINS-41239] Add new cleanup post condition

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Cleanup.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Cleanup.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,31 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 
-pipeline {
-    agent none
-    stages {
-        stage("foo") {
-            steps {
-                echo "hello"
-            }
-        }
+import hudson.Extension
+import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
+
+import javax.annotation.Nonnull
+
+/**
+ * A {@link BuildCondition} for matching all builds regardless of status, running *after* all other conditions.
+ *
+ * @author Andrew Bayer
+ */
+@Extension(ordinal=-10000d) @Symbol("cleanup")
+class Cleanup extends BuildCondition {
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return true
     }
-    post {
-        always {
-            error "I AM FAILING NOW"
-        }
-        success {
-            echo "MOST DEFINITELY FINISHED"
-        }
-        failure {
-            echo "I FAILED"
-        }
-        cleanup {
-            echo "I RAN ANYWAY"
-        }
+
+    @Override
+    String getDescription() {
+        return Messages.Finally_Description()
     }
+
+    static final long serialVersionUID = 1L
+
 }
-
-
-

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
@@ -31,3 +31,4 @@ Success.Description=Run if the build status is "Success" or hasn't been set yet
 Unstable.Description=Run if the build status is "Unstable"
 Fixed.Description=Run if the current build is "Success" and the previous build is "Failure" or "Unstable"
 Regression.Description=Run if the current build\'s status is worse than the previous build\'s status
+Cleanup.Description=Always run after all other conditions, regardless of build status

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -66,7 +66,8 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                         "hello",
                         "[Pipeline] { (" + SyntheticStageNames.postBuild() + ")",
                         "I AM FAILING NOW",
-                        "I FAILED")
+                        "I FAILED",
+                        "I RAN ANYWAY")
                 .logNotContains("MOST DEFINITELY FINISHED")
                 .go();
     }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-41239](https://issues.jenkins-ci.org/browse/JENKINS-41239)
* Description:
    * The new `cleanup` condition will always run regardless of build status, like `always`, but runs *after* all other `post` conditions have been evaluated, rather than before.
    * I wanted to call this `finally` but that actually breaks Groovy parsing because `finally` is a reserved word. Dang. So for now, I'm calling it `cleanup`, but am open to suggestions.
* Documentation changes:
    * TODO
* Users/aliases to notify:
    * @reviewbybees 
