### PR TITLE
[FIXED JENKINS-44993] Don't swallow errors in post

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -40,6 +40,8 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 import javax.annotation.CheckForNull
 import javax.annotation.Nonnull
 
+import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace
+
 /**
  * CPS-transformed code for actually performing the build.
  *
@@ -668,6 +670,8 @@ class ModelInterpreter implements Serializable {
                 if (stageName != null) {
                     Utils.markStageFailedAndContinued(stageName)
                 }
+                Utils.logToTaskListener("Error when executing ${conditionName} post condition:")
+                Utils.logToTaskListener(getFullStackTrace(e))
                 if (stageError == null) {
                     stageError = e
                 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -41,7 +41,6 @@ import org.apache.commons.lang.StringUtils;
 import org.hamcrest.Matcher;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
-import org.jenkinsci.plugins.pipeline.modeldefinition.model.StageOptions;
 import org.jenkinsci.plugins.pipeline.modeldefinition.util.HasArchived;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.BlockedStepsAndMethodCalls;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -368,7 +367,7 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
         private boolean runFromRepo = true;
         private Folder folder; //We use the real stuff here, no mocking fluff
         private boolean hasFailureCause;
-        private List<String> inLogInOrder;
+        private List<String> logContainsInOrder;
         private List<Matcher<Run>> buildMatchers;
 
         private ExpectationsBuilder(String resourceParent, String resource) {
@@ -388,8 +387,8 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
             return this;
         }
 
-        public ExpectationsBuilder inLogInOrder(String... msgsInOrder) {
-            this.inLogInOrder = Arrays.asList(msgsInOrder);
+        public ExpectationsBuilder logContainsInOrder(String... msgsInOrder) {
+            this.logContainsInOrder = Arrays.asList(msgsInOrder);
             return this;
         }
 
@@ -499,9 +498,9 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
             if (hasFailureCause) {
                 assertNotNull(run.getExecution().getCauseOfFailure());
             }
-            if (inLogInOrder != null && !inLogInOrder.isEmpty()) {
+            if (logContainsInOrder != null && !logContainsInOrder.isEmpty()) {
                 String buildLog = JenkinsRule.getLog(run);
-                assertThat(buildLog, stringContainsInOrder(inLogInOrder));
+                assertThat(buildLog, stringContainsInOrder(logContainsInOrder));
             }
 
             for (Matcher<Run> matcher : buildMatchers) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -138,7 +138,7 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
     public void buildConditionOrdering() throws Exception {
         expect("buildConditionOrdering")
                 .logContains("[Pipeline] { (foo)", "hello")
-                .inLogInOrder("I AM ALWAYS", "I CHANGED", "I SUCCEEDED")
+                .logContainsInOrder("I AM ALWAYS", "I CHANGED", "I SUCCEEDED")
                 .go();
     }
 
@@ -312,6 +312,7 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                         "hello",
                         "[Pipeline] { (" + SyntheticStageNames.postBuild() + ")",
                         "I FAILED",
+                        "CLEANUP RAN",
                         "Error when executing failure post condition",
                         "Error when executing always post condition",
                         "No such property: otherUndefined for class",

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -303,4 +303,20 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         j.assertLogNotContains("I FAILED", run1);
 
     }
+
+    @Issue("JENKINS-44993")
+    @Test
+    public void failureInPostBlock() throws Exception {
+        expect(Result.FAILURE, "failureInPostBlock")
+                .logContains("[Pipeline] { (foo)",
+                        "hello",
+                        "[Pipeline] { (" + SyntheticStageNames.postBuild() + ")",
+                        "I FAILED",
+                        "Error when executing failure post condition",
+                        "Error when executing always post condition",
+                        "No such property: otherUndefined for class",
+                        "No such property: undefined for class")
+                .logNotContains("MOST DEFINITELY FINISHED")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/failureInPostBlock.groovy
+++ b/pipeline-model-definition/src/test/resources/failureInPostBlock.groovy
@@ -42,6 +42,9 @@ pipeline {
             echo "I FAILED"
             echo "SOME ${otherUndefined} VAR"
         }
+        cleanup {
+            echo "CLEANUP RAN"
+        }
     }
 }
 

--- a/pipeline-model-definition/src/test/resources/failureInPostBlock.groovy
+++ b/pipeline-model-definition/src/test/resources/failureInPostBlock.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+    post {
+        always {
+            echo "SOME ${undefined} VAR"
+        }
+        success {
+            echo "MOST DEFINITELY FINISHED"
+        }
+        failure {
+            echo "I FAILED"
+            echo "SOME ${otherUndefined} VAR"
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-44993](https://issues.jenkins-ci.org/browse/JENKINS-44993)
* Description:
    * We only throw one exception for a failure in a stage, whether that failure is in the `steps` block or in a `post` condition's execution. Any subsequent exceptions get swallowed and never logged. This will change that, so that we'll start logging any exceptions encountered in executing `post` blocks even if the stage has already hit an error before getting to the `post` blocks.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
