### PR TITLE
[FIXED JENKINS-50652] Don't fire post failure for aborted durable task

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -41,7 +41,8 @@ class Failure extends BuildCondition {
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r) {
         Result execResult = getExecutionResult(r)
-        return execResult == Result.FAILURE || r.getResult() == Result.FAILURE
+        return execResult != Result.ABORTED &&
+            (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)
     }
 
     @Override

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -254,7 +254,7 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 "        stage('foo') {\n" +
                 "            steps {\n" +
                 "                echo 'hello'\n" +
-                "                semaphore 'wait'\n" +
+                "                semaphore 'wait-again'\n" +
                 "                sh 'sleep 15'\n" +
                 "            }\n" +
                 "        }\n" +
@@ -270,8 +270,8 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 "}\n", true));
 
         WorkflowRun run1 = job.scheduleBuild2(0).waitForStart();
-        SemaphoreStep.waitForStart("wait/1", run1);
-        SemaphoreStep.success("wait/1", null);
+        SemaphoreStep.waitForStart("wait-again/1", run1);
+        SemaphoreStep.success("wait-again/1", null);
         Thread.sleep(1000);
         run1.doStop();
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -242,4 +242,44 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         j.assertLogNotContains("I FAILED", b3);
     }
 
+    @Issue("JENKINS-50652")
+    @Test
+    public void abortedShouldNotTriggerFailure() throws Exception {
+        onAllowedOS(PossibleOS.LINUX, PossibleOS.MAC);
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "abort");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "pipeline {\n" +
+                "    agent any\n" +
+                "    stages {\n" +
+                "        stage('foo') {\n" +
+                "            steps {\n" +
+                "                echo 'hello'\n" +
+                "                semaphore 'wait'\n" +
+                "                sh 'sleep 15'\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "    post {\n" +
+                "        aborted {\n" +
+                "            echo 'I AM ABORTED'\n" +
+                "        }\n" +
+                "        failure {\n" +
+                "            echo 'I FAILED'\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n", true));
+
+        WorkflowRun run1 = job.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait/1", run1);
+        SemaphoreStep.success("wait/1", null);
+        Thread.sleep(1000);
+        run1.doStop();
+
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run1));
+
+        j.assertLogContains("I AM ABORTED", run1);
+
+        j.assertLogNotContains("I FAILED", run1);
+
+    }
 }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-50652](https://issues.jenkins-ci.org/browse/JENKINS-50652)
* Description:
    * It appears that an aborted durable task like sh results in `CpsFlowExecution#result` being `ABORTED`, but `WorkflowRun#result` being `FAILURE`, until the whole build actually finishes and the run gets updated accordingly. So the `failure` `post` condition shouldn't fire if `CpsFlowExecution#result` is `ABORTED`.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
