### PR TITLE
[JENKINS-43016] Convert empty string label agent to agent any in JSON

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
@@ -51,9 +51,9 @@ public final class ModelASTAgent extends ModelASTElement {
                 Map<ModelASTKey, ModelASTMethodArg> vars = ((ModelASTClosureMap) variables).getVariables();
                 // Don't actually switch to "agent any" if there are any additional options besides the label.
                 if (vars.size() == 1) {
-                    for (ModelASTKey argKey : vars.keySet()) {
-                        if (argKey.getKey().equals("label")) {
-                            ModelASTMethodArg argValue = vars.get(argKey);
+                    for (Map.Entry<ModelASTKey,ModelASTMethodArg> entry : vars.entrySet()) {
+                        if (entry.getKey().getKey().equals("label")) {
+                            ModelASTMethodArg argValue = entry.getValue();
                             if (argValue instanceof ModelASTValue && ((ModelASTValue) argValue).getValue().equals("")) {
                                 return true;
                             }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
@@ -4,6 +4,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 
 /**
  * Represents what context in which to run the build - i.e., which label to run on, what Docker agent to run in, etc.
@@ -22,17 +23,47 @@ public final class ModelASTAgent extends ModelASTElement {
     @Override
     public JSONObject toJSON() {
         final JSONObject j = new JSONObject();
-        j.accumulate("type", agentType.toJSON());
 
-        if (variables != null) {
-            if (variables instanceof ModelASTClosureMap &&
-                    !((ModelASTClosureMap) variables).getVariables().isEmpty()) {
-                j.accumulate("arguments", variables.toJSON());
-            } else if (variables instanceof ModelASTValue) {
-                j.accumulate("argument", variables.toJSON());
+        // Handle JENKINS-43016 - round-trip empty-string label agent into agent any.
+        if (isEmptyStringLabelAgent()) {
+            j.accumulate("type", "any");
+        } else {
+            j.accumulate("type", agentType.toJSON());
+
+            if (variables != null) {
+                if (variables instanceof ModelASTClosureMap &&
+                        !((ModelASTClosureMap) variables).getVariables().isEmpty()) {
+                    j.accumulate("arguments", variables.toJSON());
+                } else if (variables instanceof ModelASTValue) {
+                    j.accumulate("argument", variables.toJSON());
+                }
             }
         }
         return j;
+    }
+
+    private boolean isEmptyStringLabelAgent() {
+        if (agentType.getKey().equals("label") || agentType.getKey().equals("node")) {
+            if (variables instanceof ModelASTValue && ((ModelASTValue) variables).getValue().equals("")) {
+                return true;
+            }
+            if (variables instanceof ModelASTClosureMap) {
+                Map<ModelASTKey, ModelASTMethodArg> vars = ((ModelASTClosureMap) variables).getVariables();
+                // Don't actually switch to "agent any" if there are any additional options besides the label.
+                if (vars.size() == 1) {
+                    for (ModelASTKey argKey : vars.keySet()) {
+                        if (argKey.getKey().equals("label")) {
+                            ModelASTMethodArg argValue = vars.get(argKey);
+                            if (argValue instanceof ModelASTValue && ((ModelASTValue) argValue).getValue().equals("")) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
@@ -44,7 +44,7 @@ public final class ModelASTAgent extends ModelASTElement {
 
     private boolean isEmptyStringLabelAgent() {
         if (agentType.getKey().equals("label") || agentType.getKey().equals("node")) {
-            if (variables instanceof ModelASTValue && ((ModelASTValue) variables).getValue().equals("")) {
+            if (variables instanceof ModelASTValue && "".equals(((ModelASTValue) variables).getValue())) {
                 return true;
             }
             if (variables instanceof ModelASTClosureMap) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParserTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParserTest.java
@@ -35,7 +35,7 @@ public class ModelParserTest extends BaseParserLoaderTest {
         assertFalse(msg.contains("Exception")); // we don't want stack trace please
     }
 
-    @Issue("JENKINS-41118")
+    @Issue({"JENKINS-41118","JENKINS-43016"})
     @Test
     public void labelWithOptionsBecomesNode() throws Exception {
         ModelASTPipelineDef origRoot = Converter.urlToPipelineDef(getClass().getResource("/inRelativeCustomWorkspace.groovy"));
@@ -61,6 +61,35 @@ public class ModelParserTest extends BaseParserLoaderTest {
         assertNotNull("Pipeline null for inRelativeCustomWorkspace", nodeRoot);
 
         assertEquals(nodeRoot, newRoot);
+    }
+
+    @Issue("JENKINS-43016")
+    @Test
+    public void labelWithEmptyStringBecomesAny() throws Exception {
+        ModelASTPipelineDef origRoot = Converter.urlToPipelineDef(getClass().getResource("/agentLabelEmptyString.groovy"));
+
+        assertNotNull(origRoot);
+
+        JSONObject origJson = origRoot.toJSON();
+        assertNotNull(origJson);
+
+        JSONParser jp = new JSONParser(Converter.jsonTreeFromJSONObject(origJson));
+        ModelASTPipelineDef newRoot = jp.parse();
+
+        assertEquals(getJSONErrorReport(jp, "agentLabelEmptyString"), 0, jp.getErrorCollector().getErrorCount());
+        assertNotNull("Pipeline null for agentLabelEmptyString", newRoot);
+
+        JSONObject anyJson = JSONObject.fromObject(fileContentsFromResources("json/agentAny.json"));
+
+        JSONParser anyParser = new JSONParser(Converter.jsonTreeFromJSONObject(anyJson));
+        ModelASTPipelineDef anyRoot = anyParser.parse();
+
+        assertEquals(getJSONErrorReport(anyParser, "agentAny"),
+                0, anyParser.getErrorCollector().getErrorCount());
+        assertNotNull("Pipeline null for agentAny", anyRoot);
+
+        assertEquals(anyRoot, newRoot);
+
     }
 
     @Test

--- a/pipeline-model-definition/src/test/resources/agentLabelEmptyString.groovy
+++ b/pipeline-model-definition/src/test/resources/agentLabelEmptyString.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label ''
+    }
+    stages {
+        stage("foo") {
+            steps {
+                script {
+                    if (isUnix()) {
+                        sh('echo "THIS WORKS"')
+                    } else {
+                        bat('echo "THIS WORKS"')
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-43016](https://issues.jenkins-ci.org/browse/JENKINS-43016)
* Description:
    * This'll make the editor happier - the label agent type does require an argument, but an empty string *is* a valid (but weird) use case. The editor, however, has no way of distinguishing between "you didn't specify a label" and "you specified an empty string for the label". There still should be work in the editor to figure out how to actually handle this situation, but this fix at least will unbreak existing Jenkinsfiles with empty string label agents being opened in the editor, by converting the JSON in that case to be `agent any`, which is functionally equivalent if no additional options are specified.
    * However, if additional options are specified (such as `customWorkspace`), we have to punt and keep using the empty string label agent.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @reviewbybees 
