### PR TITLE
[FIXED JENKINS-50815] Fallback to GIT_LOCAL_BRANCH for when branch

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/BranchConditionalScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/BranchConditionalScript.groovy
@@ -37,7 +37,7 @@ class BranchConditionalScript extends DeclarativeStageConditionalScript<BranchCo
     @Override
      boolean evaluate() {
         String branchName = (String)script.getProperty("env").getProperty("BRANCH_NAME")
-        if (branchName == null) {
+        if (branchName == null || branchName == "") {
             // fall back to GIT_LOCAL_BRANCH - note that GIT_BRANCH will have the remote on it, while BRANCH_NAME doesn't.
             branchName = (String)script.getProperty("env").getProperty("GIT_LOCAL_BRANCH")
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -1051,13 +1051,9 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
-    @Ignore("This breaks on PCT, so re-enable when we depend on newer core than 2.60")
     @Issue("JENKINS-45198")
     @Test
     public void scmEnvVars() throws Exception {
-        // The change to support checkout scm returning a map and that map being added to the environment works fine with
-        // older core etc, but just doesn't do anything, since checkout scm isn't returning anything yet. But with newer
-        // core, etc, it'll Just Work.
         expect("scmEnvVars")
                 // workflow-scm-step 2.6+, git 3.3.1+
                 .logNotContains("GIT_COMMIT is null")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
@@ -350,6 +350,15 @@ public class WhenStageTest extends AbstractModelDefTest {
         expect.resetForNewRun(Result.SUCCESS).logContains("One", "Hello", "Two", "World").go();
     }
 
+    @Issue("JENKINS-50815")
+    @Test
+    public void whenBranchNotMultibranch() throws Exception {
+        expect("whenBranchNotMultibranch")
+                .logContains("[Pipeline] { (One)", "[Pipeline] { (Two)", "World")
+                .go();
+    }
+
+
     public static void waitFor(Queue.Item item) throws InterruptedException, ExecutionException {
         while (item != null && item.getFuture() == null) {
             Thread.sleep(200);

--- a/pipeline-model-definition/src/test/resources/whenBranchNotMultibranch.groovy
+++ b/pipeline-model-definition/src/test/resources/whenBranchNotMultibranch.groovy
@@ -27,7 +27,7 @@ pipeline {
     environment {
         // In a CI build of the plugin, BRANCH_NAME is getting set for the build itself, so the tests pick it up too.
         // Override that by nulling it out.
-        BRANCH_NAME ""
+        BRANCH_NAME = ""
     }
     stages {
         stage("One") {

--- a/pipeline-model-definition/src/test/resources/whenBranchNotMultibranch.groovy
+++ b/pipeline-model-definition/src/test/resources/whenBranchNotMultibranch.groovy
@@ -24,6 +24,11 @@
 
 pipeline {
     agent any
+    environment {
+        // In a CI build of the plugin, BRANCH_NAME is getting set for the build itself, so the tests pick it up too.
+        // Override that by nulling it out.
+        BRANCH_NAME ""
+    }
     stages {
         stage("One") {
             steps {

--- a/pipeline-model-definition/src/test/resources/whenBranchNotMultibranch.groovy
+++ b/pipeline-model-definition/src/test/resources/whenBranchNotMultibranch.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,25 +22,25 @@
  * THE SOFTWARE.
  */
 
-
-package org.jenkinsci.plugins.pipeline.modeldefinition.when.impl
-
-import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalScript
-import org.jenkinsci.plugins.workflow.cps.CpsScript
-
-
-class BranchConditionalScript extends DeclarativeStageConditionalScript<BranchConditional> {
-     BranchConditionalScript(CpsScript s, BranchConditional c) {
-        super(s, c)
-    }
-
-    @Override
-     boolean evaluate() {
-        String branchName = (String)script.getProperty("env").getProperty("BRANCH_NAME")
-        if (branchName == null) {
-            // fall back to GIT_LOCAL_BRANCH - note that GIT_BRANCH will have the remote on it, while BRANCH_NAME doesn't.
-            branchName = (String)script.getProperty("env").getProperty("GIT_LOCAL_BRANCH")
+pipeline {
+    agent any
+    stages {
+        stage("One") {
+            steps {
+                echo "Hello"
+            }
         }
-        return describable.branchMatches(describable.compare, branchName)
+        stage("Two") {
+            when {
+                branch "master"
+            }
+            steps {
+                script {
+                    echo "World"
+                    echo "Heal it"
+                }
+
+            }
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>2.5</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>2.5</version>
+        <version>2.6</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-50815](https://issues.jenkins-ci.org/browse/JENKINS-50815)
* Description:
    * If we're not on multibranch (meaning BRANCH_NAME is null), fallback to GIT_LOCAL_BRANCH for when branch condition. We can theoretically add other SCMs here too if needed. We're using GIT_LOCAL_BRANCH because it most closely matches BRANCH_NAME - i.e., GIT_BRANCH includes the remote, GIT_LOCAL_BRANCH does not.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
