### PR TITLE
[FIXED JENKINS-50645] Move failure to run after other status checks

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull
  *
  * @author Andrew Bayer
  */
-@Extension(ordinal=600d) @Symbol("success")
+@Extension(ordinal=700d) @Symbol("success")
 class Success extends BuildCondition {
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull
  *
  * @author Andrew Bayer
  */
-@Extension(ordinal=500d) @Symbol("unstable")
+@Extension(ordinal=600d) @Symbol("unstable")
 class Unstable extends BuildCondition {
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -72,6 +72,26 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-50645")
+    @Test
+    public void postFailureAfterSuccess() throws Exception {
+        // NOTE: Not checking log in order because "I AM FAILING NOW" doesn't actually show up until the end of the Pipeline.
+        // That's expected/normal behavior for the error step.
+        expect(Result.FAILURE, "postFailureAfterSuccess")
+                .logContains("I AM FAILING NOW", "I FAILED")
+                .go();
+    }
+
+    @Issue("JENKINS-50645")
+    @Test
+    public void postFailureAfterUnstable() throws Exception {
+        // NOTE: Not checking log in order because "I AM FAILING NOW" doesn't actually show up until the end of the Pipeline.
+        // That's expected/normal behavior for the error step.
+        expect(Result.FAILURE, "postFailureAfterUnstable")
+                .logContains("I AM FAILING NOW", "I FAILED")
+                .go();
+    }
+
     @Test
     public void postOnChanged() throws Exception {
         WorkflowRun b = getAndStartNonRepoBuild("postOnChangeFailed");

--- a/pipeline-model-definition/src/test/resources/postFailureAfterSuccess.groovy
+++ b/pipeline-model-definition/src/test/resources/postFailureAfterSuccess.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,34 +21,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 
-import hudson.Extension
-import hudson.model.Result
-import org.jenkinsci.Symbol
-import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
-import org.jenkinsci.plugins.workflow.job.WorkflowRun
-
-import javax.annotation.Nonnull
-
-/**
- * A {@link BuildCondition} for matching failed builds.
- *
- * @author Andrew Bayer
- */
-@Extension(ordinal=500d) @Symbol("failure")
-class Failure extends BuildCondition {
-    @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
-        Result execResult = getExecutionResult(r)
-        return execResult != Result.ABORTED &&
-            (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
     }
-
-    @Override
-    String getDescription() {
-        return Messages.Failure_Description()
+    post {
+        success {
+            error "I AM FAILING NOW"
+        }
+        failure {
+            echo "I FAILED"
+        }
     }
-
-    public static final long serialVersionUID = 1L
 }
+
+
+

--- a/pipeline-model-definition/src/test/resources/postFailureAfterUnstable.groovy
+++ b/pipeline-model-definition/src/test/resources/postFailureAfterUnstable.groovy
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2018, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,34 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 
-import hudson.Extension
-import hudson.model.Result
-import org.jenkinsci.Symbol
-import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
-import org.jenkinsci.plugins.workflow.job.WorkflowRun
-
-import javax.annotation.Nonnull
-
-/**
- * A {@link BuildCondition} for matching failed builds.
- *
- * @author Andrew Bayer
- */
-@Extension(ordinal=500d) @Symbol("failure")
-class Failure extends BuildCondition {
-    @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
-        Result execResult = getExecutionResult(r)
-        return execResult != Result.ABORTED &&
-            (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+                script {
+                    currentBuild.result = "UNSTABLE"
+                }
+            }
+        }
     }
-
-    @Override
-    String getDescription() {
-        return Messages.Failure_Description()
+    post {
+        unstable {
+            error "I AM FAILING NOW"
+        }
+        failure {
+            echo "I FAILED"
+        }
     }
-
-    public static final long serialVersionUID = 1L
 }
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-50645](https://issues.jenkins-ci.org/browse/JENKINS-50645)
* Description:
    * This way failure will still evaluate even if the actual failure doesn't occur until in the success or unstable blocks.
* Documentation changes:
    * Docs will need to reflect the changed order.
* Users/aliases to notify:
    * @reviewbybees 
