### PR TITLE
JENKINS-50964: Fix the link to syntax documentation (was a 404)

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator.java
@@ -175,7 +175,7 @@ public class DirectiveGenerator extends Snippetizer {
         @Override
         @Nonnull
         public String getUrl() {
-            return "https://jenkins.io/doc/pipeline/syntax/";
+            return "https://jenkins.io/doc/book/pipeline/syntax/";
         }
 
         @Override

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
@@ -38,7 +38,7 @@
                     click <b>Generate Declarative Directive</b> and the Pipeline code will appear in the box below. You
                     can copy that code directly into the <code>pipeline</code> block in your <code>Jenkinsfile</code>,
                     for top-level directives, or into a <code>stage</code> block for stage directives. See
-                    <a href="https://jenkins.io/doc/pipeline/syntax/" target="_blank">the online syntax documentation</a>
+                    <a href="https://jenkins.io/doc/book/pipeline/syntax/" target="_blank">the online syntax documentation</a>
                     for more information on directives.
                 </f:block>
                 <f:section title="${%Directives}"/>


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-50964](https://issues.jenkins-ci.org/browse/JENKINS-50964)
* Description:
    * The links to external doumentation for Pipeline Syntax are 404, because part of the path `book` is missing in their URLs. 
        * Old, 404 version: `https://jenkins.io/doc/pipeline/syntax/`
        * New, working version: `https://jenkins.io/doc/book/pipeline/syntax/`
* Documentation changes:
    * None necessary. Just links to existing documentation
* Users/aliases to notify:
    * @abayer 
