### PR TITLE
Plugin parent POM build now requires Maven 3.3.1 or newer

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ToolsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ToolsTest.java
@@ -86,11 +86,7 @@ public class ToolsTest extends AbstractModelDefTest {
 
     @Test
     public void buildPluginParentPOM() throws Exception {
-
-        Maven.MavenInstallation mvn = configureDefaultMaven("apache-maven-3.1.0", Maven.MavenInstallation.MAVEN_30);
-
-        Maven.MavenInstallation m3 = new Maven.MavenInstallation("apache-maven-3.1.0", mvn.getHome(), JenkinsRule.NO_PROPERTIES);
-        j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(m3);
+        Maven.MavenInstallation maven350 = ToolInstallations.configureMaven35();
         JDK[] jdks = j.jenkins.getDescriptorByType(JDK.DescriptorImpl.class).getInstallations();
         JDK thisJdk = null;
         for (JDK j : jdks) {
@@ -103,7 +99,7 @@ public class ToolsTest extends AbstractModelDefTest {
         expect("buildPluginParentPOM")
                 .logContains("[Pipeline] { (build)",
                         "[INFO] BUILD SUCCESS",
-                        "M2_HOME: " + m3.getHome(),
+                        "M2_HOME: " + maven350.getHome(),
                         "JAVA_HOME: " + thisJdk.getHome())
                 .go();
     }

--- a/pipeline-model-definition/src/test/resources/buildPluginParentPOM.groovy
+++ b/pipeline-model-definition/src/test/resources/buildPluginParentPOM.groovy
@@ -1,6 +1,6 @@
 pipeline {
     tools {
-        maven "apache-maven-3.1.0"
+        maven "apache-maven-3.5.0"
         jdk "default"
     }
 


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * This is breaking `ToolsTest#buildPluginParentPom`, so let's change that to use Maven 3.5.0 and we're all good.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
