### PR TITLE
[FIXED JENKINS-52084] Execute sequential stage post in correct context

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -148,29 +148,37 @@ class ModelInterpreter implements Serializable {
     def evaluateSequentialStages(Root root, Stages stages, Throwable firstError, Stage parent, String restartedStageName,
                                  SkippedStageReason skippedReason) {
         return {
-            boolean skippedForRestart = restartedStageName != null
-            stages.stages.each { thisStage ->
-                if (skippedForRestart) {
-                    // Check if we're skipping for restart but are now on the stage we're supposed to restart on.
-                    if (thisStage.name == restartedStageName) {
-                        // If so, set skippedForRestart to false, and if the skippedReason is for restart, wipe that out too.
-                        skippedForRestart = false
-                        if (skippedReason instanceof SkippedStageReason.Restart) {
-                            skippedReason = null
+            try {
+                boolean skippedForRestart = restartedStageName != null
+                stages.stages.each { thisStage ->
+                    if (skippedForRestart) {
+                        // Check if we're skipping for restart but are now on the stage we're supposed to restart on.
+                        if (thisStage.name == restartedStageName) {
+                            // If so, set skippedForRestart to false, and if the skippedReason is for restart, wipe that out too.
+                            skippedForRestart = false
+                            if (skippedReason instanceof SkippedStageReason.Restart) {
+                                skippedReason = null
+                            }
+                        } else {
+                            // If we skipped for restart and this isn't the restarted name, create a new reason.
+                            skippedReason = new SkippedStageReason.Restart(thisStage.name, restartedStageName)
                         }
-                    } else {
-                        // If we skipped for restart and this isn't the restarted name, create a new reason.
-                        skippedReason = new SkippedStageReason.Restart(thisStage.name, restartedStageName)
+                    }
+                    try {
+                        evaluateStage(root, thisStage.agent ?: root.agent, thisStage, firstError, parent, skippedReason).call()
+                    } catch (Exception e) {
+                        script.getProperty("currentBuild").result = Utils.getResultFromException(e)
+                        Utils.markStageFailedAndContinued(thisStage.name)
+                        if (firstError == null) {
+                            firstError = e
+                        }
                     }
                 }
-                try {
-                    evaluateStage(root, thisStage.agent ?: root.agent, thisStage, firstError, parent, skippedReason).call()
-                } catch (Exception e) {
-                    script.getProperty("currentBuild").result = Utils.getResultFromException(e)
-                    Utils.markStageFailedAndContinued(thisStage.name)
-                    if (firstError == null) {
-                        firstError = e
-                    }
+            } finally {
+                // And finally, run the post stage steps if this was a parallel parent.
+                if (skippedReason == null && parent != null && root.hasSatisfiedConditions(parent.post, script.getProperty("currentBuild"))) {
+                    Utils.logToTaskListener("Post stage")
+                    firstError = runPostConditions(parent.post, parent.agent ?: root.agent, firstError, parent.name)
                 }
             }
 
@@ -302,7 +310,7 @@ class ModelInterpreter implements Serializable {
                 } finally {
                     // And finally, run the post stage steps if this was a parallel parent.
                     if (skippedReason == null && root.hasSatisfiedConditions(thisStage.post, script.getProperty("currentBuild")) &&
-                        (thisStage?.parallelContent || thisStage?.stages)) {
+                        thisStage?.parallelContent) {
                         Utils.logToTaskListener("Post stage")
                         firstError = runPostConditions(thisStage.post, thisStage.agent ?: parentAgent, firstError, thisStage.name)
                     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -320,4 +320,10 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 .logNotContains("MOST DEFINITELY FINISHED")
                 .go();
     }
+
+    @Issue("JENKINS-52084")
+    @Test
+    public void sequentialPostNode() throws Exception {
+        expect("sequentialPostNode").go();
+    }
 }

--- a/pipeline-model-definition/src/test/resources/sequentialPostNode.groovy
+++ b/pipeline-model-definition/src/test/resources/sequentialPostNode.groovy
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage('Hello World') {
+            agent any
+
+            stages {
+                stage('Nested') {
+                    steps {
+                        echo 'Hi!'
+                    }
+                }
+            }
+
+            post {
+                always {
+                    deleteDir()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-52084](https://issues.jenkins-ci.org/browse/JENKINS-52084)
* Description:
    * We were executing post for a sequential stage parent the same way we do for parallel, but given that a sequential stage parent can define environment, agent, tools, etc, we should be running its post within those contexts.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
