### PR TITLE
[FIXED JENKINS-52261] Mark end nodes for skipped-for-restart stages properly

### DIFF
--- a/pipeline-model-definition/src/test/resources/restart/skippedParallelStagesMarkedNotExecuted.groovy
+++ b/pipeline-model-definition/src/test/resources/restart/skippedParallelStagesMarkedNotExecuted.groovy
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+
+    stages {
+        stage('skip-on-restart') {
+            parallel {
+                stage("first-parallel") {
+                    steps {
+                        echo "This shouldn't show up on second run"
+                    }
+                }
+                stage("second-parallel") {
+                    steps {
+                        echo "This also shouldn't show up on second run"
+                    }
+                }
+            }
+        }
+        stage('restart') {
+            steps {
+                script {
+                    if (currentBuild.getNumber() % 2 == 1) {
+                        error("Odd numbered build, failing")
+                    } else {
+                        echo "Even numbered build, success"
+                    }
+                }
+            }
+        }
+        stage('post-restart') {
+            steps {
+                echo "Now we're post-restart"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-52261](https://issues.jenkins-ci.org/browse/JENKINS-52261)
* Description:
    * We were marking the *start* node for stages skipped for restart with `NotExecutedNodeAction`, but not the end nodes, and it turns out, `StatusAndTiming#computeChunkStatus2` looks at the end node. So...whoops.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
