### PR TITLE
[FIXED JENKINS-51932] Add config.jelly for isRestartedRun

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/IsRestartedRunConditional/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/IsRestartedRunConditional/config.jelly
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+</j:jelly>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
@@ -54,6 +54,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.when.impl.BranchConditiona
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.impl.ChangeLogConditional;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.impl.ChangeSetConditional;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.impl.EnvironmentConditional;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.impl.IsRestartedRunConditional;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.impl.NotConditional;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.DescribableParameter;
@@ -517,6 +518,15 @@ public class DirectiveGeneratorTest {
                 "      // One or more steps need to be included within each condition's block.\n" +
                 "    }\n" +
                 "  }\n" +
+                "}");
+    }
+
+    @Issue("JENKINS-51932")
+    @Test
+    public void whenIsRestartedRun() throws Exception {
+        WhenDirective when = new WhenDirective(new IsRestartedRunConditional(), false);
+        assertGenerateDirective(when, "when {\n" +
+                "  isRestartedRun()\n" +
                 "}");
     }
 


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-51932](https://issues.jenkins-ci.org/browse/JENKINS-51932)
* Description:
    * `isRestartedRun` wasn't showing up in the Directive Generator because it didn't have a `config.jelly`. So, here's a `config.jelly`.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
