### PR TITLE
[FIXED JENKINS-51872] Fix tool dropdown

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/symbol-hetero-list.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/symbol-hetero-list.jelly
@@ -129,7 +129,7 @@
         <div name="${attrs.name}" title="${symbol}: ${descriptor.displayName}" tooltip="${descriptor.tooltip}" descriptorId="${descriptor.id}">
           <j:set var="capture" value="${attrs.capture?:''}" />
           <local:body deleteCaption="${attrs.deleteCaption}">
-            <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,${capture}">
+            <l:renderOnDemand tag="tr" clazz="config-page" capture="descriptor,it,instance,h,${capture}">
               <l:ajax>
                 <st:include from="${descriptor}" page="${descriptor.configPage}" optional="true" />
               </l:ajax>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ToolsDirective/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ToolsDirective/config.jelly
@@ -73,7 +73,7 @@
                     <div name="tools" title="${symbol}: ${d.displayName}" tooltip="${d.tooltip}" descriptorId="${d.id}">
                         <j:set var="capture" value="" />
                         <local:body>
-                            <l:renderOnDemand tag="tr" clazz="config-page" capture="d,it,instance,symbol,${capture}">
+                            <l:renderOnDemand tag="tr" clazz="config-page" capture="d,it,instance,symbol,h,${capture}">
                                 <f:entry title="${%Version}">
                                     <select class="setting-input" name="symbolAndName">
                                         <j:forEach var="inst" items="${d.installations}">


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-51872](https://issues.jenkins-ci.org/browse/JENKINS-51872?filter=15813)
* Description:
    * SECURITY-624 resulted in the `<f:option>` body going through `h.xmlUnescape`...which is fine, except that when it's being specified inside a `l:renderOnDemand` block, the `h` variable isn't captured! Which results in `h.xmlUnescape('literally anything')` being null. So let's capture `h` when we call `l:renderOnDemand`, just to be safe.
    * Note that this only is relevant for core 2.89.4 and >2.107, once SECURITY-624 was fixed.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
