### PR TITLE
[FIXED JENKINS-51383] Handle Throwables, not just Exceptions

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -492,7 +492,7 @@ class Utils {
      * @param e The exception.
      * @return The result.
      */
-    static Result getResultFromException(Exception e) {
+    static Result getResultFromException(Throwable e) {
         if (e instanceof FlowInterruptedException) {
             return ((FlowInterruptedException)e).result
         } else {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -83,7 +83,7 @@ class ModelInterpreter implements Serializable {
                                     try {
                                         postBuildRun = true
                                         executePostBuild(root)
-                                    } catch (Exception e) {
+                                    } catch (Throwable e) {
                                         if (firstError == null) {
                                             firstError = e
                                         }
@@ -98,7 +98,7 @@ class ModelInterpreter implements Serializable {
                         }
                     }
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 // Catch any errors that may have been thrown outside of the parallel proper and make sure we set
                 // firstError accordingly.
                 if (firstError == null) {
@@ -109,7 +109,7 @@ class ModelInterpreter implements Serializable {
                 if (!postBuildRun) {
                     try {
                         executePostBuild(root)
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         if (firstError == null) {
                             firstError = e
                         }
@@ -166,7 +166,7 @@ class ModelInterpreter implements Serializable {
                     }
                     try {
                         evaluateStage(root, thisStage.agent ?: root.agent, thisStage, firstError, parent, skippedReason).call()
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                         Utils.markStageFailedAndContinued(thisStage.name)
                         if (firstError == null) {
@@ -308,7 +308,7 @@ class ModelInterpreter implements Serializable {
                             }
                         }
                     }
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     script.getProperty("currentBuild").result = Result.FAILURE
                     Utils.markStageFailedAndContinued(thisStage.name)
                     if (firstError == null) {
@@ -657,7 +657,7 @@ class ModelInterpreter implements Serializable {
             catchRequiredContextForNode(thisStage.agent ?: parentAgent) {
                 delegateAndExecute(thisStage.steps.closure)
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             script.getProperty("currentBuild").result = Utils.getResultFromException(e)
             Utils.markStageFailedAndContinued(thisStage.name)
             if (stageError == null) {
@@ -752,7 +752,7 @@ class ModelInterpreter implements Serializable {
                         delegateAndExecute(c)
                     }
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                 if (stageName != null) {
                     Utils.markStageFailedAndContinued(stageName)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -326,4 +326,16 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
     public void sequentialPostNode() throws Exception {
         expect("sequentialPostNode").go();
     }
+
+    @Issue("JENKINS-51383")
+    @Test
+    public void postSuccessNoSuchMethodError() throws Exception {
+        expect(Result.FAILURE, "postSuccessNoSuchMethodError")
+                .logContains("[Pipeline] { (foo)",
+                        "before missing")
+                .logNotContains("MOST DEFINITELY FINISHED",
+                        "after missing")
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/postSuccessNoSuchMethodError.groovy
+++ b/pipeline-model-definition/src/test/resources/postSuccessNoSuchMethodError.groovy
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "before missing"
+                doesNotExist ""
+                echo "after missing"
+            }
+        }
+    }
+    post {
+        success {
+            echo "MOST DEFINITELY FINISHED"
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-51383](https://issues.jenkins-ci.org/browse/JENKINS-51383)
* Description:
    * Previously, we only caught and handled `Exception`s in `ModelInterpreter`. Which was fine in 99% of cases, but not `NoSuchMethodError` - that's an `Error`, not an `Exception`, and so it slipped through the cracks, resulting in `post` still firing for `success` even though the build would end up failed. So let's fix that.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
