### PR TITLE
[FIXED JENKINS-51227] Add quietPeriod DeclarativeOption

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -39,6 +39,7 @@ import hudson.model.ParameterDefinition
 import hudson.model.ParametersDefinitionProperty
 import hudson.model.Result
 import hudson.triggers.Trigger
+import jenkins.model.Jenkins
 import org.apache.commons.codec.digest.DigestUtils
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.stmt.BlockStatement
@@ -58,6 +59,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.causes.RestartDeclarativeP
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Environment
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.StepsBlock
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.impl.QuietPeriod
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted
 import org.jenkinsci.plugins.structs.SymbolLookup
@@ -524,6 +526,15 @@ class Utils {
         return l
     }
 
+    @Deprecated
+    @Restricted(NoExternalUse.class)
+    static void updateJobProperties(@CheckForNull List<Object> propsOrUninstantiated,
+                                    @CheckForNull List<Object> trigsOrUninstantiated,
+                                    @CheckForNull List<Object> paramsOrUninstantiated,
+                                    @Nonnull CpsScript script) {
+        updateJobProperties(propsOrUninstantiated, trigsOrUninstantiated, paramsOrUninstantiated, null, script)
+    }
+
     /**
      * Given the values from {@link org.jenkinsci.plugins.pipeline.modeldefinition.model.Options#getProperties()},
      * {@link org.jenkinsci.plugins.pipeline.modeldefinition.model.Triggers#getTriggers()}, and
@@ -537,16 +548,20 @@ class Utils {
      *   {@link UninstantiatedDescribable}s.
      * @param paramsOrUninstantiated Newly-defined parameters, potentially a mix of {@link ParameterDefinition}s and
      *   {@link UninstantiatedDescribable}s.
+     * @param optionsOrUninstantiated Newly-defined Declarative options, potentially a mix of {@link DeclarativeOption}s and
+     *   {@link UninstantiatedDescribable}s.
      * @param script
      */
     @Restricted(NoExternalUse.class)
     static void updateJobProperties(@CheckForNull List<Object> propsOrUninstantiated,
                                     @CheckForNull List<Object> trigsOrUninstantiated,
                                     @CheckForNull List<Object> paramsOrUninstantiated,
+                                    @CheckForNull Map<String,DeclarativeOption> optionsOrUninstantiated,
                                     @Nonnull CpsScript script) {
-        List<JobProperty> rawJobProperties = instantiateList(JobProperty.class, propsOrUninstantiated)
-        List<Trigger> rawTriggers = instantiateList(Trigger.class, trigsOrUninstantiated)
-        List<ParameterDefinition> rawParameters = instantiateList(ParameterDefinition.class, paramsOrUninstantiated)
+        List<JobProperty> rawJobProperties = instantiateList(JobProperty.class, propsOrUninstantiated ?: [])
+        List<Trigger> rawTriggers = instantiateList(Trigger.class, trigsOrUninstantiated ?: [])
+        List<ParameterDefinition> rawParameters = instantiateList(ParameterDefinition.class, paramsOrUninstantiated ?: [])
+        List<DeclarativeOption> rawOptions = optionsOrUninstantiated != null ? optionsOrUninstantiated.values().asList() : []
 
         WorkflowRun r = script.$build()
         WorkflowJob j = r.getParent()
@@ -558,6 +573,7 @@ class Utils {
         Set<String> previousProperties = new HashSet<>()
         Set<String> previousTriggers = new HashSet<>()
         Set<String> previousParameters = new HashSet<>()
+        Set<String> previousOptions = new HashSet<>()
 
         // First, use the action from the job if it's present.
         DeclarativeJobPropertyTrackerAction previousAction = j.getAction(DeclarativeJobPropertyTrackerAction.class)
@@ -573,6 +589,7 @@ class Utils {
             previousProperties.addAll(previousAction.getJobProperties())
             previousTriggers.addAll(previousAction.getTriggers())
             previousParameters.addAll(previousAction.getParameters())
+            previousOptions.addAll(previousAction.getOptions())
         }
 
         List<JobProperty> jobPropertiesToApply = []
@@ -610,6 +627,19 @@ class Utils {
 
         BulkChange bc = new BulkChange(j)
         try {
+            // Check if QuietPeriod option is specified
+            QuietPeriod quietPeriod = (QuietPeriod) rawOptions.find { it instanceof QuietPeriod }
+            if (quietPeriod != null) {
+                j.setQuietPeriod(quietPeriod.quietPeriod)
+            } else {
+                String quietPeriodName = Jenkins.getActiveInstance().getDescriptorByType(QuietPeriod.DescriptorImpl.class)?.getName()
+                // If the quiet period was set by the previous build, wipe it out.
+                System.err.println("options: ${previousOptions}")
+                if (quietPeriodName != null && previousOptions.contains(quietPeriodName)) {
+                    j.setQuietPeriod(0)
+                }
+            }
+
             // Remove the triggers/parameters properties regardless.
             j.removeProperty(PipelineTriggersJobProperty.class)
             j.removeProperty(ParametersDefinitionProperty.class)
@@ -637,7 +667,7 @@ class Utils {
 
             bc.commit()
             // Add the action tracking what we added (or empty otherwise)
-            j.replaceAction(new DeclarativeJobPropertyTrackerAction(rawJobProperties, rawTriggers, rawParameters))
+            j.replaceAction(new DeclarativeJobPropertyTrackerAction(rawJobProperties, rawTriggers, rawParameters, rawOptions))
         } finally {
             bc.abort()
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -634,9 +634,8 @@ class Utils {
             } else {
                 String quietPeriodName = Jenkins.getActiveInstance().getDescriptorByType(QuietPeriod.DescriptorImpl.class)?.getName()
                 // If the quiet period was set by the previous build, wipe it out.
-                System.err.println("options: ${previousOptions}")
                 if (quietPeriodName != null && previousOptions.contains(quietPeriodName)) {
-                    j.setQuietPeriod(0)
+                    j.setQuietPeriod(Jenkins.getActiveInstance().getQuietPeriod())
                 }
             }
 

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/DeclarativeJobPropertyTrackerAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/DeclarativeJobPropertyTrackerAction.java
@@ -32,6 +32,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -45,7 +46,7 @@ public class DeclarativeJobPropertyTrackerAction extends InvisibleAction {
     private final Set<String> jobProperties = new HashSet<>();
     private final Set<String> triggers = new HashSet<>();
     private final Set<String> parameters = new HashSet<>();
-    private final Set<String> options = new HashSet<>();
+    private Set<String> options = new HashSet<>();
 
     @Deprecated
     public DeclarativeJobPropertyTrackerAction(@CheckForNull List<JobProperty> rawJobProperties,
@@ -78,6 +79,14 @@ public class DeclarativeJobPropertyTrackerAction extends InvisibleAction {
                 options.add(o.getDescriptor().getName());
             }
         }
+    }
+
+    protected Object readResolve() throws IOException {
+        if (this.options == null) {
+            this.options = new HashSet<>();
+        }
+
+        return this;
     }
 
     /**

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/DeclarativeJobPropertyTrackerAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/DeclarativeJobPropertyTrackerAction.java
@@ -28,6 +28,7 @@ import hudson.model.InvisibleAction;
 import hudson.model.JobProperty;
 import hudson.model.ParameterDefinition;
 import hudson.triggers.Trigger;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -44,10 +45,19 @@ public class DeclarativeJobPropertyTrackerAction extends InvisibleAction {
     private final Set<String> jobProperties = new HashSet<>();
     private final Set<String> triggers = new HashSet<>();
     private final Set<String> parameters = new HashSet<>();
+    private final Set<String> options = new HashSet<>();
 
+    @Deprecated
     public DeclarativeJobPropertyTrackerAction(@CheckForNull List<JobProperty> rawJobProperties,
                                                @CheckForNull List<Trigger> rawTriggers,
                                                @CheckForNull List<ParameterDefinition> rawParameters) {
+        this(rawJobProperties, rawTriggers, rawParameters, null);
+    }
+
+    public DeclarativeJobPropertyTrackerAction(@CheckForNull List<JobProperty> rawJobProperties,
+                                               @CheckForNull List<Trigger> rawTriggers,
+                                               @CheckForNull List<ParameterDefinition> rawParameters,
+                                               @CheckForNull List<DeclarativeOption> rawOptions) {
         if (rawJobProperties != null) {
             for (JobProperty p : rawJobProperties) {
                 jobProperties.add(p.getDescriptor().getId());
@@ -63,6 +73,11 @@ public class DeclarativeJobPropertyTrackerAction extends InvisibleAction {
                 parameters.add(d.getName());
             }
         }
+        if (rawOptions != null) {
+            for (DeclarativeOption o : rawOptions) {
+                options.add(o.getDescriptor().getName());
+            }
+        }
     }
 
     /**
@@ -74,6 +89,7 @@ public class DeclarativeJobPropertyTrackerAction extends InvisibleAction {
         this.jobProperties.addAll(copyFrom.getJobProperties());
         this.triggers.addAll(copyFrom.getTriggers());
         this.parameters.addAll(copyFrom.getParameters());
+        this.options.addAll(copyFrom.getOptions());
     }
 
     public Set<String> getJobProperties() {
@@ -88,8 +104,16 @@ public class DeclarativeJobPropertyTrackerAction extends InvisibleAction {
         return Collections.unmodifiableSet(parameters);
     }
 
+    public Set<String> getOptions() {
+        return Collections.unmodifiableSet(options);
+    }
+
     @Override
     public String toString() {
-        return "DeclarativeJobPropertyTrackerAction[jobProperties:" + jobProperties + ",triggers:" + triggers + ",parameters:" + parameters + "]";
+        return "DeclarativeJobPropertyTrackerAction[jobProperties:" + jobProperties
+                + ",triggers:" + triggers
+                + ",parameters:" + parameters
+                + ",options:" + options
+                + "]";
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/QuietPeriod.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/QuietPeriod.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.options.impl;
+
+import hudson.Extension;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
+import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOptionDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+
+public class QuietPeriod extends DeclarativeOption {
+    private int quietPeriod;
+
+    @DataBoundConstructor
+    public QuietPeriod(int quietPeriod) {
+        this.quietPeriod = quietPeriod;
+    }
+
+    public int getQuietPeriod() {
+        return quietPeriod;
+    }
+
+    @Extension @Symbol("quietPeriod")
+    public static class DescriptorImpl extends DeclarativeOptionDescriptor {
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Set the quiet period for the job";
+        }
+
+        @Override
+        public boolean canUseInStage() {
+            return false;
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -787,6 +787,6 @@ class ModelInterpreter implements Serializable {
      * @param root The root context we're running in
      */
     def executeProperties(Root root) {
-        Utils.updateJobProperties(root.options?.properties, root.triggers?.triggers, root.parameters?.parameters, script)
+        Utils.updateJobProperties(root.options?.properties, root.triggers?.triggers, root.parameters?.parameters, root.options?.options, script)
     }
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/QuietPeriod/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/QuietPeriod/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="quietPeriod" title="${%Quiet period}" description="${%Number of seconds}">
+        <f:number clazz="number" value="${it.quietPeriod}" min="0" step="1"/>
+    </f:entry>
+</j:jelly>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/QuietPeriod/help.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/options/impl/QuietPeriod/help.html
@@ -1,0 +1,46 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<p>
+    The <code>quietPeriod</code> option allows specifying a quiet period for this project.
+<p>
+    When this option is non-zero, newly triggered builds of this project will be
+    added to the queue, but Jenkins will wait for the specified period of time
+    (in seconds) before actually starting the build.
+<p>
+    For example, if your builds take a long time to execute, you may want to
+    prevent multiple source control commits that are made at approximately the
+    same time from triggering multiple builds.  Enabling the quiet period would
+    prevent a build from being started as soon as Jenkins discovers the first
+    commit; this would give the developer the chance to push more commits which
+    would be included in the build when it starts.  This reduces the size of the
+    queue, meaning that developers would get feedback faster for their series of
+    commits, and the load on the Jenkins system would be reduced.
+<p>
+    If a new build of this project is triggered while a build is already sitting
+    in the queue, waiting for its quiet period to end, the quiet period will not
+    be reset.  The newly triggered build will not be added to the queue, unless
+    this project is parameterized and the build has different parameters than the
+    build already in the queue.
+</p>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -409,7 +409,7 @@ public class OptionsTest extends AbstractModelDefTest {
         job.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources("propsTriggersParamsRemoved"), true));
         j.buildAndAssertSuccess(job);
 
-        assertEquals(0, job.getQuietPeriod());
+        assertEquals(j.jenkins.getQuietPeriod(), job.getQuietPeriod());
     }
 
     @Issue("JENKINS-48380")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -235,7 +235,7 @@ public class OptionsTest extends AbstractModelDefTest {
         WorkflowJob job = b.getParent();
         assertNotNull(job.getProperty(BuildDiscarderProperty.class));
         job.addProperty(new DisableConcurrentBuildsJobProperty());
-
+        job.setQuietPeriod(15);
         job.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources("propsTriggersParamsRemoved"), true));
         j.buildAndAssertSuccess(job);
 
@@ -251,6 +251,7 @@ public class OptionsTest extends AbstractModelDefTest {
         }
 
         assertEquals(1, externalPropCount);
+        assertEquals(15, job.getQuietPeriod());
     }
 
     @Issue("JENKINS-44809")
@@ -382,6 +383,33 @@ public class OptionsTest extends AbstractModelDefTest {
                 .logContains("[Pipeline] { (foo)",
                         "hello")
                 .go();
+    }
+
+    @Issue("JENKINS-51227")
+    @Test
+    public void quietPeriod() throws Exception {
+        WorkflowRun b = expect("quietPeriod")
+                .logContains("hello")
+                .go();
+
+        WorkflowJob p = b.getParent();
+        assertNotNull(p);
+        assertEquals(15, p.getQuietPeriod());
+    }
+
+    @Issue("JENKINS-51227")
+    @Test
+    public void quietPeriodRemoved() throws Exception {
+        WorkflowRun b = getAndStartNonRepoBuild("quietPeriod");
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+
+        WorkflowJob job = b.getParent();
+        assertEquals(15, job.getQuietPeriod());
+
+        job.setDefinition(new CpsFlowDefinition(pipelineSourceFromResources("propsTriggersParamsRemoved"), true));
+        j.buildAndAssertSuccess(job);
+
+        assertEquals(0, job.getQuietPeriod());
     }
 
     @Issue("JENKINS-48380")

--- a/pipeline-model-definition/src/test/resources/quietPeriod.groovy
+++ b/pipeline-model-definition/src/test/resources/quietPeriod.groovy
@@ -1,0 +1,39 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    options {
+        quietPeriod(15)
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-51227](https://issues.jenkins-ci.org/browse/JENKINS-51227)
* Description:
    * This will let you set the quiet period for the job from the options block. As with job properties, triggers, and parameters, the quiet period will only be set to the default of 0 if the previous build actually had the QuietPeriod DeclarativeOption specified and the current build does not, so that UI-configured quiet periods don't get nuked.
* Documentation changes:
    * Will be needed.
* Users/aliases to notify:
    * ...
