### PR TITLE
[FIXED JENKINS-52114] Make success/failure use parallel stage result

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/AbstractBuildConditionResponder.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/AbstractBuildConditionResponder.groovy
@@ -38,10 +38,11 @@ abstract class AbstractBuildConditionResponder<T extends AbstractBuildConditionR
         super(m)
     }
 
-    Closure closureForSatisfiedCondition(String conditionName, Object runWrapperObj) {
+    Closure closureForSatisfiedCondition(String conditionName, Object runWrapperObj, Object context = null,
+                                         Throwable error = null) {
         if (getMap().containsKey(conditionName)) {
             BuildCondition condition = BuildCondition.getConditionMethods().get(conditionName)
-            if (condition != null && condition.meetsCondition(runWrapperObj)) {
+            if (condition != null && condition.meetsCondition(runWrapperObj, context, error)) {
                 return ((StepsBlock)getMap().get(conditionName)).getClosure()
             }
         }
@@ -49,11 +50,12 @@ abstract class AbstractBuildConditionResponder<T extends AbstractBuildConditionR
         return null
     }
 
-    boolean satisfiedConditions(Object runWrapperObj) {
+    boolean satisfiedConditions(Object runWrapperObj, Object context = null, Throwable error = null) {
         Map<String,BuildCondition> conditions = BuildCondition.getConditionMethods()
 
         return BuildCondition.orderedConditionNames.any { conditionName ->
-            getMap().containsKey(conditionName) && conditions.get(conditionName).meetsCondition(runWrapperObj)
+            getMap().containsKey(conditionName) &&
+                conditions.get(conditionName).meetsCondition(runWrapperObj, context, error)
         }
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -94,11 +94,14 @@ class Root implements Serializable {
      *
      * @param r an {@link AbstractBuildConditionResponder}, such as {@link PostStage} or {@link PostBuild}.
      * @param runWrapperObj The {@link RunWrapper} for the build.
+     * @param context The context where this is being called, which could be either a {@link Root} or a {@link Stage}, but also could be null.
+     * @param error The first error seen in the relevant context. Can be null.
      * @return True if at least one condition is satisfied, false otherwise.
      */
-    /*package*/ boolean hasSatisfiedConditions(AbstractBuildConditionResponder r, Object runWrapperObj) {
+    /*package*/ boolean hasSatisfiedConditions(AbstractBuildConditionResponder r, Object runWrapperObj, Object context = null,
+                                               Throwable error = null) {
         if (r != null) {
-            return r.satisfiedConditions(runWrapperObj)
+            return r.satisfiedConditions(runWrapperObj, context, error)
         } else {
             return false
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -38,8 +38,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=800d) @Symbol("aborted")
 class Aborted extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.ABORTED || r.getResult() == Result.ABORTED
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=800d) @Symbol("aborted")
 class Aborted extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.ABORTED || r.getResult() == Result.ABORTED
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Always.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Always.groovy
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=1000d) @Symbol("always")
 class Always extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         return true
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Always.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Always.groovy
@@ -37,8 +37,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=1000d) @Symbol("always")
 class Always extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         return true
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=900d) @Symbol("changed")
 class Changed extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
@@ -38,8 +38,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=900d) @Symbol("changed")
 class Changed extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Cleanup.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Cleanup.groovy
@@ -38,7 +38,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=-10000d) @Symbol("cleanup")
 class Cleanup extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         return true
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Cleanup.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Cleanup.groovy
@@ -37,8 +37,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=-10000d) @Symbol("cleanup")
 class Cleanup extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         return true
     }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -39,8 +39,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=500d) @Symbol("failure")
 class Failure extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
         if (context instanceof Stage && execResult != Result.ABORTED && r.getResult() != Result.ABORTED) {
             return error != null

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -27,6 +27,7 @@ import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 import javax.annotation.Nonnull
@@ -39,8 +40,11 @@ import javax.annotation.Nonnull
 @Extension(ordinal=500d) @Symbol("failure")
 class Failure extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         Result execResult = getExecutionResult(r)
+        if (context instanceof Stage && execResult != Result.ABORTED && r.getResult() != Result.ABORTED) {
+            return error != null
+        }
         return execResult != Result.ABORTED &&
             (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=890d) @Symbol("fixed")
 class Fixed extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
@@ -38,8 +38,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=890d) @Symbol("fixed")
 class Fixed extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=400d) @Symbol("notBuilt")
 class NotBuilt extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.NOT_BUILT || r.getResult() == Result.NOT_BUILT
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -38,8 +38,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=400d) @Symbol("notBuilt")
 class NotBuilt extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.NOT_BUILT || r.getResult() == Result.NOT_BUILT
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=880d) @Symbol("regression")
 class Regression extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
@@ -38,8 +38,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=880d) @Symbol("regression")
 class Regression extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         // Only look at the previous completed build.
         WorkflowRun prev = r.getPreviousCompletedBuild()
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
@@ -39,8 +39,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=700d) @Symbol("success")
 class Success extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
         if (context instanceof Stage && (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)) {
             return error == null

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
@@ -27,6 +27,7 @@ import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
+import org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 import javax.annotation.Nonnull
@@ -39,10 +40,13 @@ import javax.annotation.Nonnull
 @Extension(ordinal=700d) @Symbol("success")
 class Success extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         Result execResult = getExecutionResult(r)
+        if (context instanceof Stage && (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)) {
+            return error == null
+        }
         return (execResult == null || execResult.isBetterOrEqualTo(Result.SUCCESS)) &&
-            (r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS))
+                (r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS))
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
@@ -38,8 +38,14 @@ import javax.annotation.Nonnull
  */
 @Extension(ordinal=600d) @Symbol("unstable")
 class Unstable extends BuildCondition {
+    @Deprecated
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
+    boolean meetsCondition(@Nonnull WorkflowRun r) {
+        return meetsCondition(r, null, null)
+    }
+
+    @Override
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.UNSTABLE || r.getResult() == Result.UNSTABLE
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull
 @Extension(ordinal=600d) @Symbol("unstable")
 class Unstable extends BuildCondition {
     @Override
-    boolean meetsCondition(@Nonnull WorkflowRun r) {
+    boolean meetsCondition(@Nonnull WorkflowRun r, Object context = null, Throwable error = null) {
         Result execResult = getExecutionResult(r)
         return execResult == Result.UNSTABLE || r.getResult() == Result.UNSTABLE
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -174,11 +174,13 @@ public class PostStageTest extends AbstractModelDefTest {
                         "Found failure in Child 1",
                         "Found success in Nested 2",
                         "Found success in Child 2",
-                        "Found failure in Child 3")
+                        "Found failure in Child 3",
+                        "Parallel parent failure")
                 .logNotContains("Found success in Child 1",
                         "Found failure in Nested 2",
                         "Found failure in Child 2",
-                        "Found success in Child 3")
+                        "Found success in Child 3",
+                        "Parallel parent success")
                 .go();
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -25,6 +25,10 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.model.Result;
 import hudson.model.Slave;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -157,6 +161,71 @@ public class PostStageTest extends AbstractModelDefTest {
                         "Post Child 2 ran",
                         "Post ran")
                 .go();
+    }
+
+    @Issue("JENKINS-52114")
+    @Test
+    public void postFailureSuccessInParallel() throws Exception {
+        expect(Result.FAILURE, "postFailureSuccessInParallel")
+                .logContains("Post Nested 1 ran",
+                        "Post Nested 2 ran",
+                        "Post Child 2 ran",
+                        "Post ran",
+                        "Found failure in Child 1",
+                        "Found success in Nested 2",
+                        "Found success in Child 2",
+                        "Found failure in Child 3")
+                .logNotContains("Found success in Child 1",
+                        "Found failure in Nested 2",
+                        "Found failure in Child 2",
+                        "Found success in Child 3")
+                .go();
+    }
+
+    @Issue("JENKINS-52114")
+    @Test
+    public void abortedShouldNotTriggerFailure() throws Exception {
+        onAllowedOS(PossibleOS.LINUX, PossibleOS.MAC);
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "abort");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "pipeline {\n" +
+                "    agent any\n" +
+                "    stages {\n" +
+                "        stage('foo') {\n" +
+                "            steps {\n" +
+                "                echo 'hello'\n" +
+                "                semaphore 'wait-again'\n" +
+                "                sh 'sleep 15'\n" +
+                "            }\n" +
+                "            post {\n" +
+                "                success {\n" +
+                "                    echo 'I AM SUCCESSFUL'\n" +
+                "                }\n" +
+                "                aborted {\n" +
+                "                    echo 'I AM ABORTED'\n" +
+                "                }\n" +
+                "                failure {\n" +
+                "                    echo 'I FAILED'\n" +
+                "                }\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n", true));
+
+        WorkflowRun run1 = job.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait-again/1", run1);
+        SemaphoreStep.success("wait-again/1", null);
+        Thread.sleep(1000);
+        run1.doStop();
+
+        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run1));
+
+        j.assertLogContains("I AM ABORTED", run1);
+
+        j.assertLogNotContains("I AM SUCCESSFUL", run1);
+
+        j.assertLogNotContains("I FAILED", run1);
+
     }
 
     @Override

--- a/pipeline-model-definition/src/test/resources/postStage/localAll.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/localAll.groovy
@@ -35,6 +35,11 @@ pipeline {
                     if (res != null) {
                         echo "Setting build result ${res}"
                         currentBuild.result = res
+                        // JENKINS-52114 - can't tell the difference between setting currentBuild.result in this stage
+                        // and an error in a parallel stage, so let's error.
+                        if (res == "FAILURE") {
+                            error "Failing explicitly"
+                        }
                     } else {
                         echo "All is well"
                     }

--- a/pipeline-model-definition/src/test/resources/postStage/postFailureSuccessInParallel.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/postFailureSuccessInParallel.groovy
@@ -103,6 +103,12 @@ pipeline {
                 always {
                     echo 'Post ran'
                 }
+                success {
+                    echo "Parallel parent success"
+                }
+                failure {
+                    echo "Parallel parent failure"
+                }
             }
         }
     }

--- a/pipeline-model-definition/src/test/resources/postStage/postFailureSuccessInParallel.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/postFailureSuccessInParallel.groovy
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage('Parallel') {
+            parallel {
+                stage('Child 1') {
+                    agent any
+                    steps { error 'Fail in Child 1' }
+                    post {
+                        failure {
+                            echo "Found failure in Child 1"
+                        }
+                        success {
+                            echo "Found success in Child 1"
+                        }
+                    }
+                }
+                stage('Child 2') {
+                    agent any
+                    stages {
+                        stage('Nested 1') {
+                            steps {
+                                echo 'Nested 1'
+                            }
+                            post {
+                                always {
+                                    echo "Post Nested 1 ran"
+                                }
+                            }
+                        }
+                        stage('Nested 2') {
+                            steps {
+                                sleep 2
+                                echo 'Nested 2'
+                            }
+                            post {
+                                always {
+                                    echo "Post Nested 2 ran"
+                                }
+                                success {
+                                    echo "Found success in Nested 2"
+                                }
+                                failure {
+                                    echo "Found failure in Nested 2"
+                                }
+                            }
+                        }
+                    }
+                    post {
+                        always {
+                            echo "Post Child 2 ran"
+                        }
+                        success {
+                            echo "Found success in Child 2"
+                        }
+                        failure {
+                            echo "Found failure in Child 2"
+                        }
+                    }
+                }
+                stage('Child 3') {
+                    steps {
+                        echo "Child 3"
+                    }
+                    post {
+                        always {
+                            error "Fail Child 3"
+                        }
+                        success {
+                            echo "Found success in Child 3"
+                        }
+                        failure {
+                            echo "Found failure in Child 3"
+                        }
+                    }
+                }
+            }
+            post {
+                always {
+                    echo 'Post ran'
+                }
+            }
+        }
+    }
+}

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model;
 import hudson.ExtensionComponent;
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
+import hudson.Util;
 import hudson.model.Result;
 import org.jenkinsci.plugins.structs.SymbolLookup;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
@@ -50,12 +51,28 @@ import java.util.Set;
  */
 public abstract class BuildCondition implements Serializable, ExtensionPoint {
 
-    public abstract boolean meetsCondition(@Nonnull WorkflowRun r);
+    @Deprecated
+    public boolean meetsCondition(@Nonnull WorkflowRun r) {
+        if (Util.isOverridden(BuildCondition.class, getClass(), "meetsCondition", WorkflowRun.class, Object.class, Throwable.class)) {
+            return meetsCondition(r, null, null);
+        } else {
+            throw new IllegalStateException(getClass().getName() + " must override meetsCondition(WorkflowRun,Object,Throwable)");
+        }
+    }
 
+    public boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
+        return meetsCondition(r);
+    }
+
+    @Deprecated
     public boolean meetsCondition(@Nonnull Object runWrapperObj) {
+        return meetsCondition(runWrapperObj, null, null);
+    }
+
+    public boolean meetsCondition(@Nonnull Object runWrapperObj, Object context, Throwable error) {
         RunWrapper runWrapper = (RunWrapper)runWrapperObj;
         WorkflowRun run = (WorkflowRun)runWrapper.getRawBuild();
-        return run != null && meetsCondition(run);
+        return run != null && meetsCondition(run, context, error);
     }
 
     @Nonnull


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-52114](https://issues.jenkins-ci.org/browse/JENKINS-52114)
* Description:
    * This changes `success` and `failure` `post` conditions for stages to look at whether there's an explicit error passed to them, rather than just looking at build status. This doesn't apply for top-level `post`, and has some special logic to not fire `success` if the build status is anything but `FAILURE`, and to not fire `failure` if the error is a result of aborting the build.
    * There is one potentially problematic behavior change as a result - if you set `currentBuild.result` to `FAILURE` explicitly within a stage, `success` will still fire, and `failure` will not fire. There's no way to tell that this particular stage explicitly set `currentBuild.result` vs another stage running in parallel having an actual error.
    * Worth mentioning that this doesn't involve any change at all to any other conditions' behaviors - `unstable` still needs [JENKINS-39203](https://issues.jenkins-ci.org/browse/JENKINS-39203), `changed/fixed/regression` all apply to the whole build's status (at least until JENKINS-39203 and friends, at which point we could *theoretically* compare statuses for individual stages across builds, but probably won't), and with `aborted`, we're just treating it as meaning the whole build is aborted.
* Documentation changes:
    * ~~n/a - this just makes `failure` and `success` behave the way people seem to have expected. Shame we can't do anything about `unstable` here, though.~~
    * On second or third thought, yes, we will need to update the documentation to call out that `failure` and `success` on a `stage` are looking at that specific `stage`'s "result" rather than the whole build's status (unlike `unstable` and `aborted`), and that manually setting `currentBuild.result = 'FAILURE'` in a `stage` will no longer result in `failure` for that `stage` firing.
    * PR: https://github.com/jenkins-infra/jenkins.io/pull/1756
* Users/aliases to notify:
    * ...
