### PR TITLE
Trying to de-flake two tests

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -296,7 +296,11 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         Thread.sleep(1000);
         run1.doStop();
 
-        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run1));
+        j.waitForCompletion(run1);
+        // This sometimes flakes out for reasons I can't identify, so I'm seeing if a sleep will help.
+        Thread.sleep(2000);
+
+        j.assertBuildStatus(Result.ABORTED, run1);
 
         j.assertLogContains("I AM ABORTED", run1);
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -297,10 +297,6 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
         run1.doStop();
 
         j.waitForCompletion(run1);
-        // This sometimes flakes out for reasons I can't identify, so I'm seeing if a sleep will help.
-        Thread.sleep(2000);
-
-        j.assertBuildStatus(Result.ABORTED, run1);
 
         j.assertLogContains("I AM ABORTED", run1);
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -220,7 +220,11 @@ public class PostStageTest extends AbstractModelDefTest {
         Thread.sleep(1000);
         run1.doStop();
 
-        j.assertBuildStatus(Result.ABORTED, j.waitForCompletion(run1));
+        j.waitForCompletion(run1);
+        // This sometimes flakes out for reasons I can't identify, so I'm seeing if a sleep will help.
+        Thread.sleep(2000);
+
+        j.assertBuildStatus(Result.ABORTED, run1);
 
         j.assertLogContains("I AM ABORTED", run1);
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -221,10 +221,6 @@ public class PostStageTest extends AbstractModelDefTest {
         run1.doStop();
 
         j.waitForCompletion(run1);
-        // This sometimes flakes out for reasons I can't identify, so I'm seeing if a sleep will help.
-        Thread.sleep(2000);
-
-        j.assertBuildStatus(Result.ABORTED, run1);
 
         j.assertLogContains("I AM ABORTED", run1);
 


### PR DESCRIPTION
These suckers are flaky for reasons I just don't understand - the
build result check will come up as failure, even though the build is
definitely aborted. I'm suspecting a timing issue, so am trying a sleep.
