### PR TITLE
[FIXED JENKINS-53804] Call post conditions as early as possible

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Root.groovy
@@ -59,6 +59,8 @@ class Root implements Serializable {
 
     final String astUUID
 
+    boolean hasPostRun
+
     @Whitelisted
     Root(Agent agent, Stages stages, PostBuild post, Environment environment, Tools tools, Options options,
          Triggers triggers, Parameters parameters, Libraries libraries, String astUUID) {
@@ -105,6 +107,5 @@ class Root implements Serializable {
         } else {
             return false
         }
-
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Stage.groovy
@@ -66,6 +66,8 @@ class Stage implements Serializable {
 
     StageInput input
 
+    boolean hasPostRun = false
+
     @Deprecated
     Stage(String name, StepsBlock steps, Agent agent, PostStage post, StageConditionals when, Tools tools,
           Environment environment, Stages parallel, boolean failFast) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -338,4 +338,12 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-53804")
+    @Test
+    public void credsErrorContextPathErrorInPost() throws Exception {
+        expect(Result.FAILURE, "credsErrorContextPathErrorInPost")
+                .logNotContains("Perhaps you forgot to surround the code with a step that provides this")
+                .logContains("in always")
+                .go();
+    }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -239,4 +239,14 @@ public class PostStageTest extends AbstractModelDefTest {
     protected ExpectationsBuilder expect(Result result, String resource) {
         return super.expect(result, "postStage", resource);
     }
+
+    @Issue("JENKINS-53804")
+    @Test
+    public void credsErrorContextPathErrorInPostStage() throws Exception {
+        expect(Result.FAILURE, "credsErrorContextPathErrorInPostStage")
+                .logNotContains("Perhaps you forgot to surround the code with a step that provides this")
+                .logContains("in always")
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/credsErrorContextPathErrorInPost.groovy
+++ b/pipeline-model-definition/src/test/resources/credsErrorContextPathErrorInPost.groovy
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    environment {
+        FOO = credentials("does not exist")
+    }
+
+    agent any
+
+    stages {
+        stage("foo") {
+            steps {
+                echo "FOO is $FOO"
+            }
+        }
+    }
+    post {
+        always {
+            echo "in always"
+            deleteDir()
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/postStage/credsErrorContextPathErrorInPostStage.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/credsErrorContextPathErrorInPostStage.groovy
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage("foo") {
+            agent any
+
+            environment {
+                FOO = credentials("does not exist")
+            }
+            steps {
+                echo "FOO is $FOO"
+            }
+            post {
+                always {
+                    echo "in always"
+                    deleteDir()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-53804](https://issues.jenkins-ci.org/browse/JENKINS-53804)
* Description:
    * Specifically, try to catch errors from directives and execute the post conditions for the build/stage right afterwards, while we're still inside any enclosing directives - i.e., still in top-level `agent` when a top-level `credentials` explodes.
    * Also reworked post handling in general for stages when I realized that an error in a directive before execution of a stage's steps or nested stages would actually result in `post` for the stage not being run at all, which is not exactly ideal.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
