### PR TITLE
Fix description of "Unstable"

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Messages.properties
@@ -28,7 +28,7 @@ Changed.Description=Run if the current build\'s status is different than the pre
 Failure.Description=Run if the build status is "Failure"
 NotBuilt.Description=Run if the build status is "Not Built"
 Success.Description=Run if the build status is "Success" or hasn\'t been set yet
-Unstable.Description=Run if the build status is "Unstable"Fixed.Description=Run if the current build is "Success" and the previous build is "Failure" or "Unstable"
+Unstable.Description=Run if the build status is "Unstable"
 Regression.Description=Run if the current build\'s status is worse than the previous build\'s status
 Cleanup.Description=Always run after all other conditions, regardless of build status
-Fixed.Description=Run if the previous build was not successful and the current build's status is "Success"
+Fixed.Description=Run if the previous build was not successful and the current build\'s status is "Success"


### PR DESCRIPTION
Seen in "Declarative Directive Generator": ![grafik](https://user-images.githubusercontent.com/145182/48604179-3d168200-e979-11e8-8582-85e7178660c7.png)

1. Remove old (?) description for "Fixed" that accidentally was appended to "Unstable"
2. Since the two descriptions for "Fixed" vary, which one is actually the correct one? I guess/hope for the latter/current, as "Fixed" is hopefully also run when the previous build was e.g. "Aborted"?
    - Run if the current build is "Success" and the previous build is "Failure" or "Unstable"
    - Run if the previous build was not successful and the current build's status is "Success"