### PR TITLE
[FIXED JENKINS-54919] Process agent configuration on the fly

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -160,4 +160,6 @@ class Agent extends MappedClosure<Object,Agent> implements Serializable {
         DeclarativeAgent a = getDeclarativeAgent(null, null)
         return a != null && !None.class.isInstance(a)
     }
+
+    private static final long serialVersionUID = -9134086848416921688L
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -49,10 +49,17 @@ import javax.annotation.CheckForNull
 @ToString
 @EqualsAndHashCode
 @SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
-class Agent implements Serializable {
+class Agent extends MappedClosure<Object,Agent> implements Serializable {
 
     final Closure rawClosure
-    Map<String,Object> asMap = [:]
+
+    /*
+     * We're still extending MappedClosure, but just to preserve compatibility of running builds on upgrade.
+     */
+    @Deprecated
+    Agent(Map<String,Object> m) {
+        this.resultMap = m
+    }
 
     @Whitelisted
     Agent(Closure rawClosure) {
@@ -60,7 +67,7 @@ class Agent implements Serializable {
     }
 
     void populateMap(Map<String,Object> m) {
-        this.asMap = m
+        this.resultMap = m
     }
 
     @Deprecated
@@ -77,7 +84,7 @@ class Agent implements Serializable {
         String foundSymbol = findSymbol()
         if (foundSymbol != null) {
             DeclarativeAgentDescriptor foundDescriptor = DeclarativeAgentDescriptor.byName(foundSymbol)
-            def val = asMap.get(foundSymbol)
+            def val = getMap().get(foundSymbol)
             def argMap = [:]
             if (val instanceof Map) {
                 argMap.putAll(val)
@@ -140,7 +147,7 @@ class Agent implements Serializable {
         String sym = null
         DeclarativeAgentDescriptor.allSorted().each { d ->
             SymbolLookup.getSymbolValue(d)?.each { s ->
-                if (asMap.containsKey(s) && sym == null) {
+                if (getMap().containsKey(s) && sym == null) {
                     sym = s
                 }
             }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -49,11 +49,18 @@ import javax.annotation.CheckForNull
 @ToString
 @EqualsAndHashCode
 @SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
-class Agent extends MappedClosure<Object,Agent> implements Serializable {
+class Agent implements Serializable {
+
+    final Closure rawClosure
+    Map<String,Object> asMap = [:]
 
     @Whitelisted
-    Agent(Map<String,Object> inMap) {
-        resultMap = inMap
+    Agent(Closure rawClosure) {
+        this.rawClosure = rawClosure
+    }
+
+    void populateMap(Map<String,Object> m) {
+        this.asMap = m
     }
 
     @Deprecated
@@ -70,7 +77,7 @@ class Agent extends MappedClosure<Object,Agent> implements Serializable {
         String foundSymbol = findSymbol()
         if (foundSymbol != null) {
             DeclarativeAgentDescriptor foundDescriptor = DeclarativeAgentDescriptor.byName(foundSymbol)
-            def val = getMap().get(foundSymbol)
+            def val = asMap.get(foundSymbol)
             def argMap = [:]
             if (val instanceof Map) {
                 argMap.putAll(val)
@@ -133,7 +140,7 @@ class Agent extends MappedClosure<Object,Agent> implements Serializable {
         String sym = null
         DeclarativeAgentDescriptor.allSorted().each { d ->
             SymbolLookup.getSymbolValue(d)?.each { s ->
-                if (getMap().containsKey(s) && sym == null) {
+                if (asMap.containsKey(s) && sym == null) {
                     sym = s
                 }
             }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
@@ -371,7 +371,7 @@ class ASTParserUtils {
      * @return A {@link MapExpression}, or null if the original expression was null.
      */
     @CheckForNull
-    static Expression recurseAndTransformMappedClosure(@CheckForNull ClosureExpression original) {
+    static MapExpression recurseAndTransformMappedClosure(@CheckForNull ClosureExpression original) {
         if (original != null) {
             MapExpression mappedClosure = new MapExpression()
             eachStatement(original.code) { s ->

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -126,24 +126,24 @@ class RuntimeASTTransformer {
      */
     Expression transformAgent(@CheckForNull ModelASTAgent original) {
         if (isGroovyAST(original) && original.agentType != null) {
-            ArgumentListExpression argList = new ArgumentListExpression()
+            MapExpression m
             if (original.variables == null ||
                 (original.variables instanceof ModelASTClosureMap &&
                     ((ModelASTClosureMap)original.variables).variables.isEmpty())) {
                 // Zero-arg agent type
                 MapExpression zeroArg = new MapExpression()
                 zeroArg.addMapEntryExpression(constX(original.agentType.key), constX(true))
-                argList.addExpression(zeroArg)
+                m = zeroArg
             } else {
                 BlockStatementMatch match =
                     matchBlockStatement((Statement) original.sourceLocation)
                 if (match != null) {
-                    argList.addExpression(recurseAndTransformMappedClosure(match.body))
+                    m = recurseAndTransformMappedClosure(match.body)
                 } else {
                     throw new IllegalArgumentException("Expected a BlockStatement for agent but got an instance of ${original.sourceLocation.class}")
                 }
             }
-            return ctorX(ClassHelper.make(Agent.class), argList)
+            return ctorX(ClassHelper.make(Agent.class), args(closureX(block(returnS(m)))))
         }
 
         return constX(null)

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -591,6 +591,9 @@ class ModelInterpreter implements Serializable {
      * @return The return of the resulting executed closure
      */
     def inDeclarativeAgent(Object context, Root root, Agent agent, Closure body) {
+        if (agent != null) {
+            agent.populateMap((Map<String,Object>)instanceFromClosure(agent.rawClosure, Map.class))
+        }
         if (agent == null
             && root.agent.getDeclarativeAgent(root, root) instanceof AbstractDockerAgent
             && root.options?.options?.get("newContainerPerStage") != null) {
@@ -733,6 +736,19 @@ class ModelInterpreter implements Serializable {
 
         return instanceList
     }
+
+    private <Z> Z instanceFromClosure(Closure rawClosure, Class<Z> instanceType) {
+        rawClosure.delegate = script
+        rawClosure.resolveStrategy = Closure.DELEGATE_FIRST
+
+        def inst = rawClosure.call()
+        if (instanceType.isInstance(inst)) {
+            return instanceType.cast(inst)
+        }
+
+        return null
+    }
+
     /**
      * Executes the post build actions for this build
      * @param root The root context we're executing in

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -341,6 +341,14 @@ public class AgentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-54919")
+    @Test
+    public void paramInAgentLabel() throws Exception {
+        expect("paramInAgentLabel")
+                .logContains("[Pipeline] { (foo)", "ONAGENT=true")
+                .go();
+    }
+
     private void agentDocker(final String jenkinsfile, String... additionalLogContains) throws Exception {
         assumeDocker();
 

--- a/pipeline-model-definition/src/test/resources/paramInAgentLabel.groovy
+++ b/pipeline-model-definition/src/test/resources/paramInAgentLabel.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    parameters {
+        string(defaultValue: "some-label", description: '', name: 'JENKINS_LABEL')
+    }
+    stages {
+        stage("foo") {
+            agent {
+                label params.JENKINS_LABEL
+            }
+            steps {
+                script {
+                    if (isUnix()) {
+                        sh('echo ONAGENT=$ONAGENT')
+                    } else {
+                        bat('echo ONAGENT=%ONAGENT%')
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-54919](https://issues.jenkins-ci.org/browse/JENKINS-54919)
* Description:
    * This lets us reference environment variables (well, sorta - you can reference an environment variable defined at the parent level in a stage agent, but not an environment variable defined at the same level) and more immediately, this will allow referencing parameters that have just been added to the Pipeline in this build (well, as long as they have default values set).
    * Basically, this makes Agent work more like StageConditionals by wrapping the map that defines the agent in a closure, and evaluating that closure at the time we actually need to use it, rather than baking the values in when we instantiate the runtime model.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
