### PR TITLE
[JENKINS-51792] Change ModelParser to error only once when there are multiple steps blocks

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -550,8 +550,12 @@ class ModelParser implements Parser {
                                     }
                                     stage.failFast = parallel.failFast
                                 } else {
-                                    // otherwise it's a single line of execution
-                                    stage.branches.add(parseBranch("default", block))
+                                    if (stage.getBranches().isEmpty()) {
+                                        // Only add a 'default' branch here if we don't already have one.
+                                        stage.branches.add(parseBranch("default", block))
+                                    } else {
+                                        break
+                                    }
                                 }
                             } else {
                                 // otherwise it's a single line of execution

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -811,6 +811,14 @@ public class ValidatorTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue ("JENKINS-51792")
+    @Test
+    public void multipleStepsSectionsInStage() throws Exception {
+        expectError("multipleStepsSectionsInStage")
+                .logContains(Messages.Parser_MultipleOfSection("steps"))
+                .go();
+    }
+
     @Test
     public void nonBlockStages() throws Exception {
         expectError("nonBlockStages")

--- a/pipeline-model-definition/src/test/resources/errors/multipleStepsSectionsInStage.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/multipleStepsSectionsInStage.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent any
+    stages {
+        stage('Should only be one steps block here') {
+            steps {
+                echo "Should not see me"
+            }
+            steps {
+                echo "Should not see me either"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-51792](https://issues.jenkins-ci.org/browse/JENKINS-51792)
* Description:
    * Given a malformed Pipeline, where there was more than one `steps` section inside of a `stage`, we were reporting a `Duplicate parallel branch name: "default"`. This was a bit confusing if the user's Pipeline had no branch named `default` in it at all. This change checks to make sure that the stage is empty before adding a `default` branch.
* Documentation changes:
    * No documentation changes should be necessary. This is just cleanup of some unnecessary error messages, which a user would only see if they had a mistake in their Pipeline anyway.
* Users/aliases to notify:
    * N/A
