### PR TITLE
[JENKINS-56294] pass commandLine to dockerFingerprintFrom for dockerfile agent

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -79,8 +79,9 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
                 def hash = Utils.stringToSHA1("${runWrapper.fullProjectName}\n${script.readFile("${dockerfilePath}")}")
                 def imgName = "${hash}"
                 def additionalBuildArgs = describable.getAdditionalBuildArgs() ? " ${describable.additionalBuildArgs}" : ""
-                script.sh "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
-                script.dockerFingerprintFrom dockerfile: dockerfilePath, image: imgName, toolName: script.env.DOCKER_TOOL_NAME
+                def commandLine = "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
+                script.sh commandLine
+                script.dockerFingerprintFrom dockerfile: dockerfilePath, image: imgName, toolName: script.env.DOCKER_TOOL_NAME, commandLine: commandLine
                 return script.getProperty("docker").image(imgName)
             } catch (FileNotFoundException f) {
                 script.error("No Dockerfile found at ${dockerfilePath} in repository - failing.")


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins-ci.org/browse/JENKINS-56294
* Description:
    * the dockerFingerprintFrom step uses an optional parameter commandLine which it parses for the build args to be passed to docker and in turn requires these arguments in order to correctly determine the from image for dockerfiles where the FROM directive contains a build argument in its expansion. This manifests as an IOException thrown by the dockerFingerprintFrom step when used within a declarative pipeline with a dockerfile whose FROM directive contains a build argument. I believe passing this commandLine argument should resolve that issue and restore parity with the docker workflow plugin.
* Documentation changes:
    * This is a pure bug fix and should not require any new user documentation
* Users/aliases to notify:
    * ...
