### PR TITLE
[JENKINS-55459] Make parallel stages that fail fast result in build failure

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
@@ -47,7 +48,11 @@ class Aborted extends BuildCondition {
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
-        return execResult == Result.ABORTED || r.getResult() == Result.ABORTED
+        Result errorResult = Result.SUCCESS;
+        if (error != null) {
+            errorResult = Utils.getResultFromException(error)
+        }
+        return execResult == Result.ABORTED || r.getResult() == Result.ABORTED || errorResult == Result.ABORTED
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -48,7 +48,7 @@ class Aborted extends BuildCondition {
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
-        Result errorResult = Result.SUCCESS;
+        Result errorResult = null
         if (error != null) {
             errorResult = Utils.getResultFromException(error)
         }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Changed.groovy
@@ -51,7 +51,7 @@ class Changed extends BuildCondition {
 
         // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
         // SUCCESS.
-        Result runResult = combineResults(r)
+        Result runResult = combineResults(r, error)
 
         // If there's no previous build, we're inherently changed.
         if (prev == null) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
@@ -51,8 +52,12 @@ class Failure extends BuildCondition {
         if (context instanceof Stage && execResult != Result.ABORTED && r.getResult() != Result.ABORTED) {
             return error != null
         }
+        Result errorResult = null
+        if (error != null) {
+            errorResult = Utils.getResultFromException(error)
+        }
         return execResult != Result.ABORTED &&
-            (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)
+            (execResult == Result.FAILURE || r.getResult() == Result.FAILURE || errorResult == Result.FAILURE)
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Fixed.groovy
@@ -51,7 +51,7 @@ class Fixed extends BuildCondition {
 
         // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
         // SUCCESS.
-        Result runResult = combineResults(r)
+        Result runResult = combineResults(r, error)
 
         // If there's no previous build, we can't exactly be fixed, can we?
         if (prev == null) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
@@ -47,7 +48,11 @@ class NotBuilt extends BuildCondition {
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
-        return execResult == Result.NOT_BUILT || r.getResult() == Result.NOT_BUILT
+        Result errorResult = null
+        if (error != null) {
+            errorResult = Utils.getResultFromException(error)
+        }
+        return execResult == Result.NOT_BUILT || r.getResult() == Result.NOT_BUILT || errorResult == Result.NOT_BUILT
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Regression.groovy
@@ -51,7 +51,7 @@ class Regression extends BuildCondition {
 
         // Get the *worst* result of either the execution or the run. If the run's result is null, that's effectively
         // SUCCESS.
-        Result runResult = combineResults(r)
+        Result runResult = combineResults(r, error)
 
         // If there's no previous build, we can't exactly be regressing, can we?
         if (prev == null) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
@@ -51,8 +52,13 @@ class Success extends BuildCondition {
         if (context instanceof Stage && (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)) {
             return error == null
         }
+        Result errorResult = null
+        if (error != null) {
+            errorResult = Utils.getResultFromException(error)
+        }
         return (execResult == null || execResult.isBetterOrEqualTo(Result.SUCCESS)) &&
-                (r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS))
+                (r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS)) &&
+                (errorResult == null || errorResult.isBetterOrEqualTo(Result.SUCCESS))
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
@@ -47,7 +48,11 @@ class Unstable extends BuildCondition {
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
         Result execResult = getExecutionResult(r)
-        return execResult == Result.UNSTABLE || r.getResult() == Result.UNSTABLE
+        Result errorResult = null
+        if (error != null) {
+            errorResult = Utils.getResultFromException(error)
+        }
+        return execResult == Result.UNSTABLE || r.getResult() == Result.UNSTABLE || errorResult == Result.UNSTABLE
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unsuccessful.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unsuccessful.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.model.conditions
 import hudson.Extension
 import hudson.model.Result
 import org.jenkinsci.Symbol
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.BuildCondition
 import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
@@ -46,16 +47,14 @@ class Unsuccessful extends BuildCondition {
 
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
-        return isNotNull(r) || ! is(r, Result.SUCCESS)
-    }
-
-    private boolean isNotNull(WorkflowRun r){
-        return r.getResult() != null && getExecutionResult(r) != null
-    }
-
-    private boolean is(WorkflowRun r, Result res){
         Result execResult = getExecutionResult(r)
-        return execResult == res || r.getResult() == res
+        Result errorResult = null
+        if (error != null) {
+            errorResult = Utils.getResultFromException(error)
+        }
+        return (execResult != null && execResult != Result.SUCCESS) ||
+                (r.getResult() != null && r.getResult() != Result.SUCCESS) ||
+                (errorResult != null && errorResult != Result.SUCCESS)
     }
 
     @Override

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -168,7 +168,6 @@ class ModelInterpreter implements Serializable {
                     try {
                         evaluateStage(root, thisStage.agent ?: root.agent, thisStage, firstError, parent, skippedReason).call()
                     } catch (Throwable e) {
-                        script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                         Utils.markStageFailedAndContinued(thisStage.name)
                         if (firstError == null) {
                             firstError = e
@@ -684,7 +683,6 @@ class ModelInterpreter implements Serializable {
                 delegateAndExecute(thisStage.steps.closure)
             }
         } catch (Throwable e) {
-            script.getProperty("currentBuild").result = Utils.getResultFromException(e)
             Utils.markStageFailedAndContinued(thisStage.name)
             if (stageError == null) {
                 stageError = e

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -788,7 +788,6 @@ class ModelInterpreter implements Serializable {
                     }
                 }
             } catch (Throwable e) {
-                script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                 if (stageName != null) {
                     Utils.markStageFailedAndContinued(stageName)
                 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -485,7 +485,35 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
             } else {
                 run = run.getParent().scheduleBuild2(0).waitForStart();
             }
-            j.assertBuildStatus(result, j.waitForCompletion(run));
+            try {
+                j.assertBuildStatus(result, j.waitForCompletion(run));
+            } catch (AssertionError e) {
+                // It appears that in some cases where the build result is set explictly, WorkflowRun.isBuilding()
+                // returns false too soon. Perhaps the reason is that we end up catching the Run in the middle of shutdown,
+                // so CpsFlowExecution.isComplete (and thus WorkflowRun.isInProgress() and WorkflowRun.isBuilding()) is false,
+                // but the WorkflowRun has not yet had its result set to whatever the result of the FlowEndNode is, so
+                // we see the manually-set result for a short amount of time.
+                // Here is an extract of logs where this happened while running BuildConditionResponderTest.postFailureAfterUnstable(),
+                // note that WorkflowRun#finish was called _after_ the build result was checked for the first time!
+                /*
+                  14.530 [test0 #1] [Pipeline] echo
+                  14.531 [test0 #1] I FAILED
+                  14.531 [test0 #1] [Pipeline] }
+                Build result did not initially match FAILURE
+                  14.583 [test0 #1] [Pipeline] // stage
+                  14.583 [test0 #1] [Pipeline] End of Pipeline
+                  14.589 [id=52]    INFO    o.j.p.workflow.job.WorkflowRun#finish: test0 #1 completed: FAILURE
+                  14.609 [test0 #1] ERROR: I AM FAILING NOW
+                  14.609 [test0 #1] Finished: FAILURE
+                But after 1s build result _did_ match FAILURE
+                  15.712 [id=15]    INFO    jenkins.model.Jenkins#cleanUp: Stopping Jenkins
+                  15.723 [id=52]    WARNING h.u.ExceptionCatchingThreadFactory#uncaughtException: Thread Computer.threadPoolForRemoting [#1] terminated unexpectedly
+                */
+                System.out.println("Build result did not initially match " + result);
+                Thread.sleep(1000);
+                j.assertBuildStatus(result, run);
+                System.out.println("But after 1s build result _did_ match " + result);
+            }
             // To deal with some erratic failures due to error logs not showing up until after "completion"
             Thread.sleep(100);
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -1384,13 +1384,13 @@ public class BasicModelDefTest extends AbstractModelDefTest {
     @Issue("JENKINS-47109")
     @Test
     public void parallelStagesFailFast() throws Exception {
-        expect(Result.ABORTED, "parallelStagesFailFast")
+        expect(Result.FAILURE, "parallelStagesFailFast")
                 .logContains("[Pipeline] { (foo)",
                         "{ (Branch: first)",
                         "[Pipeline] { (first)",
                         "{ (Branch: second)",
                         "[Pipeline] { (second)",
-                        "SECOND STAGE ABORTED")
+                        "SECOND STAGE FAILED")
                 .logNotContains("Second branch")
                 .hasFailureCase()
                 .go();
@@ -1399,13 +1399,13 @@ public class BasicModelDefTest extends AbstractModelDefTest {
     @Issue("JENKINS-53558")
     @Test
     public void parallelStagesFailFastWithOption() throws Exception {
-        expect(Result.ABORTED,"parallelStagesFailFastWithOption")
+        expect(Result.FAILURE,"parallelStagesFailFastWithOption")
                 .logContains("[Pipeline] { (foo)",
                         "{ (Branch: first)",
                         "[Pipeline] { (first)",
                         "{ (Branch: second)",
                         "[Pipeline] { (second)",
-                        "SECOND STAGE ABORTED")
+                        "SECOND STAGE FAILED")
                 .logNotContains("Second branch")
                 .hasFailureCase()
                 .go();

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -1381,7 +1381,7 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
-    @Issue("JENKINS-47109")
+    @Issue(value = {"JENKINS-47109", "JENKINS-55459"})
     @Test
     public void parallelStagesFailFast() throws Exception {
         expect(Result.FAILURE, "parallelStagesFailFast")
@@ -1396,7 +1396,7 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
-    @Issue("JENKINS-53558")
+    @Issue(value = {"JENKINS-53558", "JENKINS-55459"})
     @Test
     public void parallelStagesFailFastWithOption() throws Exception {
         expect(Result.FAILURE,"parallelStagesFailFastWithOption")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -98,11 +98,13 @@ public class PostStageTest extends AbstractModelDefTest {
 
     }
 
+    @Issue("JENKINS-55476")
     @Test
     public void withAllLocalUnsuccessfulWithSuccess() throws Exception {
         env(s).put("MAKE_RESULT", Result.SUCCESS.toString()).set();
         expect(Result.SUCCESS, "unsuccessful")
                 .logContains("I LOVE YOU VIRGINIA")
+                .logNotContains("I FAILED YOU, SORRY")
                 .go();
 
     }
@@ -111,6 +113,7 @@ public class PostStageTest extends AbstractModelDefTest {
         env(s).put("MAKE_RESULT", Result.NOT_BUILT.toString()).set();
         expect(Result.NOT_BUILT, "unsuccessful")
                 .logContains("I LOVE YOU VIRGINIA")
+                .logContains("I FAILED YOU, SORRY")
                 .go();
 
     }

--- a/pipeline-model-definition/src/test/resources/json/parallelStagesFailFast.json
+++ b/pipeline-model-definition/src/test/resources/json/parallelStagesFailFast.json
@@ -46,7 +46,7 @@
           ]
         }],
         "post": {"conditions": [        {
-          "condition": "aborted",
+          "condition": "failure",
           "branch":           {
             "name": "default",
             "steps": [            {
@@ -55,7 +55,7 @@
                 "key": "message",
                 "value":                 {
                   "isLiteral": true,
-                  "value": "SECOND STAGE ABORTED"
+                  "value": "SECOND STAGE FAILED"
                 }
               }]
             }]

--- a/pipeline-model-definition/src/test/resources/json/parallelStagesFailFastWithOption.json
+++ b/pipeline-model-definition/src/test/resources/json/parallelStagesFailFastWithOption.json
@@ -21,7 +21,7 @@
       {
         "name": "second",
         "post": {"conditions": [        {
-          "condition": "aborted",
+          "condition": "failure",
           "branch":           {
             "name": "default",
             "steps": [            {
@@ -30,7 +30,7 @@
                 "key": "message",
                 "value":                 {
                   "isLiteral": true,
-                  "value": "SECOND STAGE ABORTED"
+                  "value": "SECOND STAGE FAILED"
                 }
               }]
             }]

--- a/pipeline-model-definition/src/test/resources/parallelStagesFailFast.groovy
+++ b/pipeline-model-definition/src/test/resources/parallelStagesFailFast.groovy
@@ -39,8 +39,8 @@ pipeline {
                         echo "Second branch"
                     }
                     post {
-                        aborted {
-                            echo "SECOND STAGE ABORTED"
+                        failure {
+                            echo "SECOND STAGE FAILED"
                         }
                     }
                 }

--- a/pipeline-model-definition/src/test/resources/parallelStagesFailFastWithOption.groovy
+++ b/pipeline-model-definition/src/test/resources/parallelStagesFailFastWithOption.groovy
@@ -42,8 +42,8 @@ pipeline {
                         echo "Second branch"
                     }
                     post {
-                        aborted {
-                            echo "SECOND STAGE ABORTED"
+                        failure {
+                            echo "SECOND STAGE FAILED"
                         }
                     }
                 }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-55459](https://issues.jenkins-ci.org/browse/JENKINS-55459)
    * [JENKINS-55476](https://issues.jenkins-ci.org/browse/JENKINS-55476)
* Description:
    * This changes the behavior of Declarative Pipeline to mimic Scripted Pipeline when a parallel stage configured to fail fast, fails fast. Previously, the overall build result would be set to ABORTED, whereas in Scripted Pipeline (and Declarative after this change), the overall build result would be set to FAILURE.
    * This PR also fixes a bug causing the `unsuccessful` condition to always be executed in post blocks (JENKINS-55476).
    * Open questions:
      * How does this affect Blue Ocean/Stage View visualizations?
      * Does removing the setting of build results in `ModelInterpreter.groovy` break post conditions in some cases?
      * Does the trick in `Aborted.groovy` (which fixes regressions in tests due to the above changes) have side effects that are undesirable? Should similar behavior be added to any of the other build conditions?
      * The build result is still set explicitly in `ModelInterpreter#runPostConditions` and `ModelInterpreter#evaluateStage`, and removing that code caused many test failures, so I left them, but will their existence break this fix in some cases?
* Documentation changes:
    * Not sure if the current behavior is documented anywhere, would need to be investigated.
* Users/aliases to notify:
    * @nofarb
