### PR TITLE
Bumb version of jackson-api-plugin to 2.9.8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-json-org</artifactId>
-        <version>2.8.11</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.github.fge</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>jackson2-api</artifactId>
-        <version>2.8.11.2</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
2.8 versions contain a broken JSON library that fails warnings-ng tests:
https://travis-ci.org/jenkinsci/warnings-ng-plugin/jobs/498444524#L7229
