### PR TITLE
[FIXED JENKINS-56405] Use Docker registry when only URL is given

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeDockerUtils.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeDockerUtils.java
@@ -40,6 +40,8 @@ import java.io.Serializable;
  * @see org.jenkinsci.plugins.pipeline.modeldefinition.config.DockerLabelProvider
  */
 public class DeclarativeDockerUtils {
+    private static final String DEFAULT_REGISTRY = "https://index.docker.io/v1/";
+
     private static Run<?,?> currentRun() {
         try {
             CpsThread t = CpsThread.current();
@@ -122,7 +124,6 @@ public class DeclarativeDockerUtils {
         }
     }
     public static class DockerRegistry implements Serializable {
-        private final String DEFAULT_REGISTRY = "https://index.docker.io/v1/";
         public String registry;
         public String credential;
 

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeDockerUtils.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeDockerUtils.java
@@ -122,18 +122,23 @@ public class DeclarativeDockerUtils {
         }
     }
     public static class DockerRegistry implements Serializable {
-        public String registry = "https://index.docker.io/v1/";
+        private final String DEFAULT_REGISTRY = "https://index.docker.io/v1/";
+        public String registry;
         public String credential;
 
         public DockerRegistry(String registry, String creds){
-            if( registry != null)
+            if (registry != null) {
                 this.registry = registry;
+            } else {
+                this.registry = DEFAULT_REGISTRY;
+            }
             this.credential = creds;
         }
 
         public boolean hasData(){
-            return credential != null;
+            return credential != null || !registry.equals(DEFAULT_REGISTRY);
         }
+
         public static DockerRegistry build(String dockerHub, String creds){
             return new DockerRegistry( getRegistryUrl(dockerHub), getRegistryCredentialsId(creds));
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -112,6 +112,13 @@ public class AgentTest extends AbstractModelDefTest {
     }
 
     @Test
+    public void agentDockerWithRegistryNoCreds() throws Exception {
+        agentDocker("agentDockerWithRegistryNoCreds",
+                "-v /tmp:/tmp",
+                "Registry is https://index.docker.io/v2/");
+    }
+
+    @Test
     public void agentDockerReuseNode() throws Exception {
         agentDocker("agentDockerReuseNode");
     }

--- a/pipeline-model-definition/src/test/resources/agentDockerWithRegistryNoCreds.groovy
+++ b/pipeline-model-definition/src/test/resources/agentDockerWithRegistryNoCreds.groovy
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        docker {
+            alwaysPull true
+            image "httpd:2.4.12"
+            registryUrl "https://index.docker.io/v2/"
+            args "-v /tmp:/tmp"
+        }
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh 'cat /usr/local/apache2/conf/extra/httpd-userdir.conf'
+                sh 'echo "The answer is 42"'
+                echo "Registry is ${env.DOCKER_REGISTRY_URL}"
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-56405](https://issues.jenkins-ci.org/browse/JENKINS-56405)
* Description:
    * `registryUrl` should be used even if no credentials are supplied.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
