### PR TITLE
[JENKINS-56402] Set build result to the logical result in post conditions

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -338,4 +338,61 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-56402")
+    @Test
+    public void resultIsFailureInPostAfterStageFailure() throws Exception {
+        expect(Result.FAILURE, "resultIsFailureInPostAfterStageFailure")
+                .logContains("Result in always: FAILURE",
+                        "CurrentResult in always: FAILURE", 
+                        "Result in failure: FAILURE",
+                        "CurrentResult in failure: FAILURE")
+                .go();
+    }
+
+    @Issue("JENKINS-56402")
+    @Test
+    public void resultIsFailureInPostAfterPostFailure() throws Exception {
+        expect(Result.FAILURE, "resultIsFailureInPostAfterPostFailure")
+                .logContains("Result in always: SUCCESS",
+                        "CurrentResult in always: SUCCESS",
+                        "Result in failure: FAILURE",
+                        "CurrentResult in failure: FAILURE",
+                        "Result in cleanup: FAILURE",
+                        "CurrentResult in cleanup: FAILURE")
+                .go();
+    }
+
+    @Issue("JENKINS-56402")
+    @Test
+    public void resultIsFailureInPostAfterResultModified() throws Exception {
+        expect(Result.FAILURE, "resultIsFailureInPostAfterResultModified")
+                .logContains("Result in always: UNSTABLE",
+                        "CurrentResult in always: UNSTABLE",
+                        "Result in cleanup: FAILURE",
+                        "CurrentResult in cleanup: FAILURE")
+                .go();
+    }
+
+    @Issue("JENKINS-56402")
+    @Test
+    public void resultStaysFailureWhenManuallySetInPost() throws Exception {
+        expect(Result.FAILURE, "resultStaysFailureWhenManuallySetInPost")
+                .logContains("Result in always: FAILURE",
+                        "CurrentResult in always: FAILURE",
+                        "Result in cleanup: FAILURE",
+                        "CurrentResult in cleanup: FAILURE")
+                .go();
+    }
+
+    @Issue("JENKINS-56402")
+    @Test
+    public void resultIsSuccessInPost() throws Exception {
+        expect(Result.SUCCESS, "resultIsSuccessInPost")
+                .logContains("Result in always: SUCCESS",
+                        "CurrentResult in always: SUCCESS",
+                        "Result in success: SUCCESS",
+                        "CurrentResult in success: SUCCESS")
+                .go();
+    }
+
 }

--- a/pipeline-model-definition/src/test/resources/resultIsFailureInPostAfterPostFailure.groovy
+++ b/pipeline-model-definition/src/test/resources/resultIsFailureInPostAfterPostFailure.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "bar"
+            }
+        }
+    }
+    post {
+        always {
+            echo "Result in always: ${currentBuild.result}"
+            echo "CurrentResult in always: ${currentBuild.currentResult}"
+            error "oops"
+        }
+        failure {
+            echo "Result in failure: ${currentBuild.result}"
+            echo "CurrentResult in failure: ${currentBuild.currentResult}"
+        }
+        cleanup {
+            echo "Result in cleanup: ${currentBuild.result}"
+            echo "CurrentResult in cleanup: ${currentBuild.currentResult}"
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/resultIsFailureInPostAfterResultModified.groovy
+++ b/pipeline-model-definition/src/test/resources/resultIsFailureInPostAfterResultModified.groovy
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                script {
+                    currentBuild.result = 'unstable'
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo "Result in always: ${currentBuild.result}"
+            echo "CurrentResult in always: ${currentBuild.currentResult}"
+        }
+        unstable {
+            script {
+                currentBuild.result = 'failure'
+            }
+        }
+        cleanup {
+            echo "Result in cleanup: ${currentBuild.result}"
+            echo "CurrentResult in cleanup: ${currentBuild.currentResult}"
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/resultIsFailureInPostAfterStageFailure.groovy
+++ b/pipeline-model-definition/src/test/resources/resultIsFailureInPostAfterStageFailure.groovy
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                error "oops"
+            }
+        }
+    }
+    post {
+        always {
+            echo "Result in always: ${currentBuild.result}"
+            echo "CurrentResult in always: ${currentBuild.currentResult}"
+        }
+        failure {
+            echo "Result in failure: ${currentBuild.result}"
+            echo "CurrentResult in failure: ${currentBuild.currentResult}"
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/resultIsSuccessInPost.groovy
+++ b/pipeline-model-definition/src/test/resources/resultIsSuccessInPost.groovy
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                echo "bar"
+            }
+        }
+    }
+    post {
+        always {
+            echo "Result in always: ${currentBuild.result}"
+            echo "CurrentResult in always: ${currentBuild.currentResult}"
+        }
+        success {
+            echo "Result in success: ${currentBuild.result}"
+            echo "CurrentResult in success: ${currentBuild.currentResult}"
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/resultStaysFailureWhenManuallySetInPost.groovy
+++ b/pipeline-model-definition/src/test/resources/resultStaysFailureWhenManuallySetInPost.groovy
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                script {
+                    error 'oops'
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo "Result in always: ${currentBuild.result}"
+            echo "CurrentResult in always: ${currentBuild.currentResult}"
+        }
+        failure {
+            script {
+                currentBuild.result = 'failure'
+            }
+        }
+        cleanup {
+            echo "Result in cleanup: ${currentBuild.result}"
+            echo "CurrentResult in cleanup: ${currentBuild.currentResult}"
+        }
+    }
+}

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
@@ -84,33 +84,12 @@ public abstract class BuildCondition implements Serializable, ExtensionPoint {
 
     @Nonnull
     protected final Result combineResults(@Nonnull WorkflowRun run, @CheckForNull Throwable error) {
-        Result execResult = getExecutionResult(run);
-        Result prevResult = run.getResult();
-        Result errorResult = Result.SUCCESS;
-        if (prevResult == null) {
-            prevResult = Result.SUCCESS;
-        }
-        if (execResult == null) {
-            execResult = Result.SUCCESS;
-        }
-        if (error != null) {
-            if (error instanceof FlowInterruptedException) {
-                errorResult = ((FlowInterruptedException)error).getResult();
-            } else {
-                errorResult = Result.FAILURE;
-            }
-        }
-        return execResult.combine(prevResult).combine(errorResult);
+        return BuildCondition.getCombinedResult(run, error);
     }
 
     @CheckForNull
     protected Result getExecutionResult(@Nonnull WorkflowRun r) {
-        FlowExecution execution = r.getExecution();
-        if (execution instanceof CpsFlowExecution) {
-            return ((CpsFlowExecution) execution).getResult();
-        } else {
-            return r.getResult();
-        }
+        return BuildCondition.getFlowExecutionResult(r);
     }
 
     public abstract String getDescription();
@@ -154,6 +133,37 @@ public abstract class BuildCondition implements Serializable, ExtensionPoint {
             }
         }
         return conditions;
+    }
+
+    @Nonnull
+    public static Result getCombinedResult(@Nonnull WorkflowRun run, @CheckForNull Throwable error) {
+        Result execResult = getFlowExecutionResult(run);
+        Result prevResult = run.getResult();
+        Result errorResult = Result.SUCCESS;
+        if (prevResult == null) {
+            prevResult = Result.SUCCESS;
+        }
+        if (execResult == null) {
+            execResult = Result.SUCCESS;
+        }
+        if (error != null) {
+            if (error instanceof FlowInterruptedException) {
+                errorResult = ((FlowInterruptedException)error).getResult();
+            } else {
+                errorResult = Result.FAILURE;
+            }
+        }
+        return execResult.combine(prevResult).combine(errorResult);
+    }
+
+    @CheckForNull
+    public static Result getFlowExecutionResult(@Nonnull WorkflowRun r) {
+        FlowExecution execution = r.getExecution();
+        if (execution instanceof CpsFlowExecution) {
+            return ((CpsFlowExecution) execution).getResult();
+        } else {
+            return r.getResult();
+        }
     }
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
* JENKINS issue(s):
    * See [JENKINS-56402](https://issues.jenkins-ci.org/browse/JENKINS-56402)
* Description:
    * Set the build result in post conditions to the logical build result that will be used to determine which post blocks run. The result is unset after the post block so that JENKINS-55459 doesn't regress. If this seems too risky or doesn't seem like it would fix all of the reported issues, then we can go with #320 which just reverts #313 and then re-applies the patch for JENKINS-55475.
* Documentation changes:
    * N/A
* Users/aliases to notify:
    * N/A
