### PR TITLE
[JENKINS-56544] Don't set build result when a stage with an agent fails

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Aborted.groovy
@@ -47,12 +47,7 @@ class Aborted extends BuildCondition {
 
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
-        Result execResult = getExecutionResult(r)
-        Result errorResult = null
-        if (error != null) {
-            errorResult = Utils.getResultFromException(error)
-        }
-        return execResult == Result.ABORTED || r.getResult() == Result.ABORTED || errorResult == Result.ABORTED
+        return combineResults(r, error) == Result.ABORTED
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Failure.groovy
@@ -48,16 +48,7 @@ class Failure extends BuildCondition {
 
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
-        Result execResult = getExecutionResult(r)
-        if (context instanceof Stage && execResult != Result.ABORTED && r.getResult() != Result.ABORTED) {
-            return error != null
-        }
-        Result errorResult = null
-        if (error != null) {
-            errorResult = Utils.getResultFromException(error)
-        }
-        return execResult != Result.ABORTED &&
-            (execResult == Result.FAILURE || r.getResult() == Result.FAILURE || errorResult == Result.FAILURE)
+        return combineResults(r, error) == Result.FAILURE
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/NotBuilt.groovy
@@ -47,12 +47,7 @@ class NotBuilt extends BuildCondition {
 
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
-        Result execResult = getExecutionResult(r)
-        Result errorResult = null
-        if (error != null) {
-            errorResult = Utils.getResultFromException(error)
-        }
-        return execResult == Result.NOT_BUILT || r.getResult() == Result.NOT_BUILT || errorResult == Result.NOT_BUILT
+        return combineResults(r, error) == Result.NOT_BUILT
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Success.groovy
@@ -48,17 +48,7 @@ class Success extends BuildCondition {
 
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
-        Result execResult = getExecutionResult(r)
-        if (context instanceof Stage && (execResult == Result.FAILURE || r.getResult() == Result.FAILURE)) {
-            return error == null
-        }
-        Result errorResult = null
-        if (error != null) {
-            errorResult = Utils.getResultFromException(error)
-        }
-        return (execResult == null || execResult.isBetterOrEqualTo(Result.SUCCESS)) &&
-                (r.getResult() == null || r.getResult().isBetterOrEqualTo(Result.SUCCESS)) &&
-                (errorResult == null || errorResult.isBetterOrEqualTo(Result.SUCCESS))
+        return combineResults(r, error) == Result.SUCCESS
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unstable.groovy
@@ -47,12 +47,7 @@ class Unstable extends BuildCondition {
 
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
-        Result execResult = getExecutionResult(r)
-        Result errorResult = null
-        if (error != null) {
-            errorResult = Utils.getResultFromException(error)
-        }
-        return execResult == Result.UNSTABLE || r.getResult() == Result.UNSTABLE || errorResult == Result.UNSTABLE
+        return combineResults(r, error) == Result.UNSTABLE
     }
 
     @Override

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unsuccessful.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/conditions/Unsuccessful.groovy
@@ -47,14 +47,7 @@ class Unsuccessful extends BuildCondition {
 
     @Override
     boolean meetsCondition(@Nonnull WorkflowRun r, Object context, Throwable error) {
-        Result execResult = getExecutionResult(r)
-        Result errorResult = null
-        if (error != null) {
-            errorResult = Utils.getResultFromException(error)
-        }
-        return (execResult != null && execResult != Result.SUCCESS) ||
-                (r.getResult() != null && r.getResult() != Result.SUCCESS) ||
-                (errorResult != null && errorResult != Result.SUCCESS)
+        return combineResults(r, error) != Result.SUCCESS
     }
 
     @Override

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -45,28 +45,17 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
                     try {
                         img = buildImage().call()
                     } catch (Exception e) {
-                        script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                         Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
                         throw e
                     }
                 }
             } else {
-                try {
-                    img = buildImage().call()
-                } catch (Exception e) {
-                    script.getProperty("currentBuild").result = Utils.getResultFromException(e)
-                    throw e
-                }
+                img = buildImage().call()
             }
             if (img != null) {
-                try {
-                    img.inside(describable.args, {
-                        body.call()
-                    })
-                } catch (Exception e) {
-                    script.getProperty("currentBuild").result = Utils.getResultFromException(e)
-                    throw e
-                }
+                img.inside(describable.args, {
+                    body.call()
+                })
             }
         }
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineScript.groovy
@@ -44,23 +44,17 @@ class DockerPipelineScript extends AbstractDockerPipelineScript<DockerPipeline> 
                     try {
                         script.getProperty("docker").image(describable.image).pull()
                     } catch (Exception e) {
-                        script.getProperty("currentBuild").result = Utils.getResultFromException(e)
                         Utils.markStageFailedAndContinued(SyntheticStageNames.agentSetup())
                         throw e
                     }
                 }
             }
-            try {
-                if (Utils.withinAStage() && describable.alwaysPull) {
-                    script.getProperty("docker").image(describable.image).pull()
-                }
-                script.getProperty("docker").image(describable.image).inside(describable.args, {
-                    body.call()
-                })
-            } catch (Exception e) {
-                script.getProperty("currentBuild").result = Utils.getResultFromException(e)
-                throw e
+            if (Utils.withinAStage() && describable.alwaysPull) {
+                script.getProperty("docker").image(describable.image).pull()
             }
+            script.getProperty("docker").image(describable.image).inside(describable.args, {
+                body.call()
+            })
         }
     }
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -39,13 +39,8 @@ class LabelScript extends DeclarativeAgentScript<Label> {
     @Override
     Closure run(Closure body) {
         return {
-            try {
-                script.node(describable?.label) {
-                    CheckoutScript.doCheckout(script, describable, describable.customWorkspace, body).call()
-                }
-            } catch (Exception e) {
-                script.getProperty("currentBuild").result = Utils.getResultFromException(e)
-                throw e
+            script.node(describable?.label) {
+                CheckoutScript.doCheckout(script, describable, describable.customWorkspace, body).call()
             }
         }
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -1390,8 +1390,11 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                         "[Pipeline] { (first)",
                         "{ (Branch: second)",
                         "[Pipeline] { (second)",
-                        "SECOND STAGE FAILED")
-                .logNotContains("Second branch")
+                        "FIRST STAGE FAILURE",
+                        "SECOND STAGE ABORTED")
+                .logNotContains("Second branch",
+                        "FIRST STAGE ABORTED",
+                        "SECOND STAGE FAILURE")
                 .hasFailureCase()
                 .go();
     }
@@ -1405,13 +1408,33 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                         "[Pipeline] { (first)",
                         "{ (Branch: second)",
                         "[Pipeline] { (second)",
-                        "SECOND STAGE FAILED")
-                .logNotContains("Second branch")
+                        "FIRST STAGE FAILURE",
+                        "SECOND STAGE ABORTED")
+                .logNotContains("Second branch",
+                        "FIRST STAGE ABORTED",
+                        "SECOND STAGE FAILURE")
                 .hasFailureCase()
                 .go();
 
     }
 
+    @Issue(value = {"JENKINS-55459", "JENKINS-56544"})
+    @Test
+    public void parallelStagesFailFastWithAgent() throws Exception {
+        expect(Result.FAILURE, "parallelStagesFailFastWithAgent")
+                .logContains("[Pipeline] { (foo)",
+                        "{ (Branch: first)",
+                        "[Pipeline] { (first)",
+                        "{ (Branch: second)",
+                        "[Pipeline] { (second)",
+                        "FIRST STAGE FAILURE",
+                        "SECOND STAGE ABORTED")
+                .logNotContains("Second branch",
+                        "FIRST STAGE ABORTED",
+                        "SECOND STAGE FAILURE")
+                .hasFailureCase()
+                .go();
+    }
 
     @Issue("JENKINS-47783")
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BuildConditionResponderTest.java
@@ -82,6 +82,13 @@ public class BuildConditionResponderTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Test
+    public void postFailureAfterManualResultChange() throws Exception {
+        expect(Result.FAILURE, "postFailureAfterManualResultChange")
+                .logContains("MANUALLY CHANGED RESULT TO FAILURE", "FAILURE CONDITION RAN")
+                .go();
+    }
+
     @Issue("JENKINS-50645")
     @Test
     public void postFailureAfterUnstable() throws Exception {

--- a/pipeline-model-definition/src/test/resources/json/parallelStagesFailFast.json
+++ b/pipeline-model-definition/src/test/resources/json/parallelStagesFailFast.json
@@ -16,7 +16,38 @@
               }
             }]
           }]
-        }]
+        }],
+        "post": {"conditions": [        {
+          "condition": "aborted",
+          "branch":           {
+            "name": "default",
+            "steps": [            {
+              "name": "echo",
+              "arguments": [              {
+                "key": "message",
+                "value":                 {
+                  "isLiteral": true,
+                  "value": "FIRST STAGE ABORTED"
+                }
+              }]
+            }]
+          }
+        }, {
+          "condition": "failure",
+          "branch":           {
+            "name": "default",
+            "steps": [            {
+              "name": "echo",
+              "arguments": [              {
+                "key": "message",
+                "value":                 {
+                  "isLiteral": true,
+                  "value": "FIRST STAGE FAILURE"
+                }
+              }]
+            }]
+          }
+        }]}
       },
       {
         "name": "second",
@@ -46,6 +77,21 @@
           ]
         }],
         "post": {"conditions": [        {
+          "condition": "aborted",
+          "branch":           {
+            "name": "default",
+            "steps": [            {
+              "name": "echo",
+              "arguments": [              {
+                "key": "message",
+                "value":                 {
+                  "isLiteral": true,
+                  "value": "SECOND STAGE ABORTED"
+                }
+              }]
+            }]
+          }
+        }, {
           "condition": "failure",
           "branch":           {
             "name": "default",
@@ -55,7 +101,7 @@
                 "key": "message",
                 "value":                 {
                   "isLiteral": true,
-                  "value": "SECOND STAGE FAILED"
+                  "value": "SECOND STAGE FAILURE"
                 }
               }]
             }]

--- a/pipeline-model-definition/src/test/resources/json/parallelStagesFailFastWithOption.json
+++ b/pipeline-model-definition/src/test/resources/json/parallelStagesFailFastWithOption.json
@@ -16,11 +16,23 @@
               }
             }]
           }]
-        }]
-      },
-      {
-        "name": "second",
+        }],
         "post": {"conditions": [        {
+          "condition": "aborted",
+          "branch":           {
+            "name": "default",
+            "steps": [            {
+              "name": "echo",
+              "arguments": [              {
+                "key": "message",
+                "value":                 {
+                  "isLiteral": true,
+                  "value": "FIRST STAGE ABORTED"
+                }
+              }]
+            }]
+          }
+        }, {
           "condition": "failure",
           "branch":           {
             "name": "default",
@@ -30,7 +42,41 @@
                 "key": "message",
                 "value":                 {
                   "isLiteral": true,
-                  "value": "SECOND STAGE FAILED"
+                  "value": "FIRST STAGE FAILURE"
+                }
+              }]
+            }]
+          }
+        }]}
+      },
+      {
+        "name": "second",
+        "post": {"conditions": [        {
+          "condition": "aborted",
+          "branch":           {
+            "name": "default",
+            "steps": [            {
+              "name": "echo",
+              "arguments": [              {
+                "key": "message",
+                "value":                 {
+                  "isLiteral": true,
+                  "value": "SECOND STAGE ABORTED"
+                }
+              }]
+            }]
+          }
+        }, {
+          "condition": "failure",
+          "branch":           {
+            "name": "default",
+            "steps": [            {
+              "name": "echo",
+              "arguments": [              {
+                "key": "message",
+                "value":                 {
+                  "isLiteral": true,
+                  "value": "SECOND STAGE FAILURE"
                 }
               }]
             }]

--- a/pipeline-model-definition/src/test/resources/parallelStagesFailFast.groovy
+++ b/pipeline-model-definition/src/test/resources/parallelStagesFailFast.groovy
@@ -32,6 +32,14 @@ pipeline {
                     steps {
                         error "First branch"
                     }
+                    post {
+                        aborted {
+                            echo "FIRST STAGE ABORTED"
+                        }
+                        failure {
+                            echo "FIRST STAGE FAILURE"
+                        }
+                    }
                 }
                 stage("second") {
                     steps {
@@ -39,8 +47,11 @@ pipeline {
                         echo "Second branch"
                     }
                     post {
+                        aborted {
+                            echo "SECOND STAGE ABORTED"
+                        }
                         failure {
-                            echo "SECOND STAGE FAILED"
+                            echo "SECOND STAGE FAILURE"
                         }
                     }
                 }

--- a/pipeline-model-definition/src/test/resources/parallelStagesFailFastWithAgent.groovy
+++ b/pipeline-model-definition/src/test/resources/parallelStagesFailFastWithAgent.groovy
@@ -24,12 +24,9 @@
 
 pipeline {
     agent none
-    options {
-        parallelsAlwaysFailFast()
-    }
     stages {
         stage("foo") {
-            //failFast true
+            failFast true
             parallel {
                 stage("first") {
                     steps {
@@ -45,6 +42,10 @@ pipeline {
                     }
                 }
                 stage("second") {
+                    agent any
+                    options {
+                        skipDefaultCheckout()
+                    }
                     steps {
                         sleep 10
                         echo "Second branch"
@@ -62,7 +63,3 @@ pipeline {
         }
     }
 }
-
-
-
-

--- a/pipeline-model-definition/src/test/resources/postFailureAfterManualResultChange.groovy
+++ b/pipeline-model-definition/src/test/resources/postFailureAfterManualResultChange.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2018, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                script {
+                    currentBuild.result = 'FAILURE'
+                }
+                echo "MANUALLY CHANGED RESULT TO ${currentBuild.result}"
+            }
+            post {
+                failure {
+                    echo "FAILURE CONDITION RAN"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-56544]()
* Description:
    * Failure inside of a stage with an agent previously modified the build result. Now, the build result is left unmodified. 
    * The trigger for the failure post condition has been modified so that it is not executed along with the aborted post condition in some cases.
    * All post condition triggers for a specific build result now have identical implementations apart from the result they check for.
    * TODO: Add a JSON file for the newly added test?
    * TODO: Add some tests with Docker agents and failFast?
* Documentation changes:
    * TODO: Does the limitation mentioned under [the failure post condition in the documentation](https://jenkins.io/doc/book/pipeline/syntax/#post-conditions) still apply?
        > Note that if you manually set currentBuild.result = 'FAILURE' in a stage and have a failure post condition on that stage, the failure will not fire for that stage.
* Users/aliases to notify:
    * N/A
