### PR TITLE
[FIXED JENKINS-46354] Make sure firstError is null on retries

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -77,6 +77,9 @@ class ModelInterpreter implements Serializable {
                     withCredentialsBlock(root.environment) {
                         withEnvBlock(root.getEnvVars(script)) {
                             inWrappers(root.options?.wrappers) {
+                                // Wipe out the error, since if we get here and it's not null, that means we're retrying
+                                // the whole pipeline and don't want firstError to be set.
+                                firstError = null
                                 toolsBlock(root.tools, root.agent, null) {
                                     firstError = evaluateSequentialStages(root, root.stages, firstError, null, restartedStage, null).call()
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -479,6 +479,22 @@ public class OptionsTest extends AbstractModelDefTest {
         inQueue.cancel(true);
     }
 
+    @Issue("JENKINS-46354")
+    @Test
+    public void topLevelRetryExecutesAllStages() throws Exception {
+        expect("topLevelRetryExecutesAllStages")
+                .logContains("Actually executing stage Bar")
+                .go();
+    }
+
+    @Issue("JENKINS-46354")
+    @Test
+    public void parentStageRetryExecutesAllChildStages() throws Exception {
+        expect("parentStageRetryExecutesAllChildStages")
+                .logContains("Actually executing stage Bar", "Actually executing stage Baz")
+                .go();
+    }
+
     private static class DummyPrivateKey extends BaseCredentials implements SSHUserPrivateKey, Serializable {
 
         private final String id;

--- a/pipeline-model-definition/src/test/resources/parentStageRetryExecutesAllChildStages.groovy
+++ b/pipeline-model-definition/src/test/resources/parentStageRetryExecutesAllChildStages.groovy
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Keeping the run count
+int runCount = 0
+
+// Main pipeline
+pipeline {
+    agent none
+
+    stages {
+        stage("Parent") {
+            options {
+                retry(3)
+            }
+            stages {
+                stage('Init') {
+                    steps {
+                        echo "Init stage"
+
+                        script {
+                            // Increment the run count
+                            runCount++
+                        }
+
+                        echo "runCount is ${runCount}"
+                    }
+                }
+
+                stage("Foo") {
+
+                    steps {
+
+                        echo "Stage Foo executing"
+
+                        script {
+                            if (runCount < 2) {
+                                error "Failing - retry me!"
+                            } else {
+                                echo "Stage Foo will not fail..."
+                            }
+                        }
+                    }
+                }
+                stage("Bar") {
+                    steps {
+                        echo "Actually executing stage Bar"
+                    }
+                }
+            }
+        }
+        stage("Baz") {
+            steps {
+                echo "Actually executing stage Baz"
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/topLevelRetryExecutesAllStages.groovy
+++ b/pipeline-model-definition/src/test/resources/topLevelRetryExecutesAllStages.groovy
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Keeping the run count
+int runCount = 0
+
+// Main pipeline
+pipeline {
+    agent none
+
+    options {
+        retry(3)
+    }
+
+    stages {
+
+        stage('Init') {
+            steps {
+                echo "Init stage"
+
+                script {
+                    // Increment the run count
+                    runCount++
+                }
+
+                echo "runCount is ${runCount}"
+            }
+        }
+
+        stage("Foo") {
+
+            steps {
+
+                echo "Stage Foo executing"
+
+                script {
+                    if (runCount < 2) {
+                        error "Failing - retry me!"
+                    } else {
+                        echo "Stage Foo will not fail..."
+                    }
+                }
+            }
+        }
+
+        stage("Bar") {
+            steps {
+                echo "Actually executing stage Bar"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-46354](https://issues.jenkins-ci.org/browse/JENKINS-46354)
* Description:
    * When we retry the whole pipeline, we need to be sure that `firstError` is null before we try running everything again - otherwise, all stages get skipped due to an earlier failure.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
