### PR TITLE
[JENKINS-57162] Dockerfile agent hash based on build args

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -65,9 +65,9 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
             def dockerfilePath = describable.getDockerfilePath(script.isUnix())
             try {
                 RunWrapper runWrapper = (RunWrapper)script.getProperty("currentBuild")
-                def hash = Utils.stringToSHA1("${runWrapper.fullProjectName}\n${script.readFile("${dockerfilePath}")}")
-                def imgName = "${hash}"
                 def additionalBuildArgs = describable.getAdditionalBuildArgs() ? " ${describable.additionalBuildArgs}" : ""
+                def hash = Utils.stringToSHA1("${runWrapper.fullProjectName}\n${script.readFile("${dockerfilePath}")}\n${additionalBuildArgs}")
+                def imgName = "${hash}"
                 def commandLine = "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
                 script.sh commandLine
                 script.dockerFingerprintFrom dockerfile: dockerfilePath, image: imgName, toolName: script.env.DOCKER_TOOL_NAME, commandLine: commandLine

--- a/pipeline-model-definition/src/test/resources/agent/additionalDockerBuildArgsParallel.groovy
+++ b/pipeline-model-definition/src/test/resources/agent/additionalDockerBuildArgsParallel.groovy
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage("test") {
+            parallel {
+                stage("foo") {
+                    agent {
+                        dockerfile {
+                            args "-v /tmp:/tmp"
+                            additionalBuildArgs "--build-arg someArg=thisOtherArg"
+                        }
+                    }
+                    steps {
+                        sh 'cat /hi-there'
+                        sh 'echo "The answer is 42"'
+                    }
+                }
+                stage("bar") {
+                    agent {
+                        dockerfile {
+                            args "-v /tmp:/tmp"
+                            additionalBuildArgs "--build-arg someArg=thisDifferentArg"
+                        }
+                    }
+                    steps {
+                        sh 'cat /hi-there'
+                        sh 'echo "The answer is 43"'
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
JENKINS issue(s):
 - [JENKINS-57162](https://issues.jenkins-ci.org/browse/JENKINS-57162)

Description:

This extends the hash used to determine the image tag to include the
build args of the image since those generally result in a distinct image.

I had to do a bit of a hack in the tests to be able to use a fixed project name since that is part of the hash as well.
