### PR TITLE
Remove call to System.err.println in ModelInterprer.groovy

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -680,7 +680,6 @@ class ModelInterpreter implements Serializable {
         Throwable stageError = null
         try {
             catchRequiredContextForNode(thisStage.agent ?: parentAgent) {
-                System.err.println("GOT CONTEXT FOR ${thisStage.name}")
                 delegateAndExecute(thisStage.steps.closure)
             }
         } catch (Throwable e) {


### PR DESCRIPTION
* JENKINS issue(s):
    * N/A
* Description:
    * Looks like this was unintentionally committed as part of https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/330, noticed it while running some stuff locally.
* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * N/A
