### PR TITLE
Add test for label resolution from parent  env

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -362,6 +362,15 @@ public class AgentTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-43911")
+    @Test
+    public void agentFromParentEnv() throws Exception {
+        expect("agent/agentFromParentEnv")
+                .logContains("WHICH_AGENT=first",
+                        "WHICH_AGENT=second")
+                .go();
+    }
+
     @Ignore("Until JENKINS-46831 is addressed")
     @Issue("JENKINS-46831")
     @Test

--- a/pipeline-model-definition/src/test/resources/agent/agentFromEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/agent/agentFromEnv.groovy
@@ -32,7 +32,13 @@ pipeline {
     stages {
         stage("foo") {
             steps {
-                sh('echo WHICH_AGENT=$WHICH_AGENT')
+                script {
+                    if (isUnix()) {
+                        sh('echo WHICH_AGENT=$WHICH_AGENT')
+                    } else {
+                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                    }
+                }
             }
         }
         stage("bar") {
@@ -43,7 +49,13 @@ pipeline {
                 SECOND_LABEL = "other-docker"
             }
             steps {
-                sh('echo WHICH_AGENT=$WHICH_AGENT')
+                script {
+                    if (isUnix()) {
+                        sh('echo WHICH_AGENT=$WHICH_AGENT')
+                    } else {
+                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                    }
+                }
             }
         }
     }

--- a/pipeline-model-definition/src/test/resources/agent/agentFromEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/agent/agentFromEnv.groovy
@@ -36,7 +36,7 @@ pipeline {
                     if (isUnix()) {
                         sh('echo WHICH_AGENT=$WHICH_AGENT')
                     } else {
-                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                        bat('echo WHICH_AGENT=%WHICH_AGENT%')
                     }
                 }
             }
@@ -53,7 +53,7 @@ pipeline {
                     if (isUnix()) {
                         sh('echo WHICH_AGENT=$WHICH_AGENT')
                     } else {
-                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                        bat('echo WHICH_AGENT=%WHICH_AGENT%')
                     }
                 }
             }

--- a/pipeline-model-definition/src/test/resources/agent/agentFromParentEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/agent/agentFromParentEnv.groovy
@@ -34,9 +34,10 @@ pipeline {
             steps {
                 script {
                     if (isUnix()) {
+
                         sh('echo WHICH_AGENT=$WHICH_AGENT')
                     } else {
-                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                        bat('echo WHICH_AGENT=%WHICH_AGENT%')
                     }
                 }
             }
@@ -50,7 +51,7 @@ pipeline {
                     if (isUnix()) {
                         sh('echo WHICH_AGENT=$WHICH_AGENT')
                     } else {
-                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                        bat('echo WHICH_AGENT=%WHICH_AGENT%')
                     }
                 }
             }

--- a/pipeline-model-definition/src/test/resources/agent/agentFromParentEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/agent/agentFromParentEnv.groovy
@@ -1,0 +1,50 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent {
+        label "docker"
+    }
+    environment {
+        PARENT_LABEL = "other-docker"
+    }
+    stages {
+        stage("foo") {
+            steps {
+                sh('echo WHICH_AGENT=$WHICH_AGENT')
+            }
+        }
+        stage("bar") {
+            agent {
+                label "${PARENT_LABEL}"
+            }
+            steps {
+                sh('echo WHICH_AGENT=$WHICH_AGENT')
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/agent/agentFromParentEnv.groovy
+++ b/pipeline-model-definition/src/test/resources/agent/agentFromParentEnv.groovy
@@ -32,7 +32,13 @@ pipeline {
     stages {
         stage("foo") {
             steps {
-                sh('echo WHICH_AGENT=$WHICH_AGENT')
+                script {
+                    if (isUnix()) {
+                        sh('echo WHICH_AGENT=$WHICH_AGENT')
+                    } else {
+                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                    }
+                }
             }
         }
         stage("bar") {
@@ -40,7 +46,13 @@ pipeline {
                 label "${PARENT_LABEL}"
             }
             steps {
-                sh('echo WHICH_AGENT=$WHICH_AGENT')
+                script {
+                    if (isUnix()) {
+                        sh('echo WHICH_AGENT=$WHICH_AGENT')
+                    } else {
+                        bat('echo WHICH_AGENT=$WHICH_AGENT')
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION


* JENKINS issue(s):
    * JENKINS-43911 (ish) test only
* Description:
    * JENKINS-43911 is still failing because the environment isn't preset when the agent label is evaluated. However, if the stage is inside another stage the label should be able to pick up the environment from the parent. This is not especially interesting but is worth having a test to cover it.
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * @abayer 
