### PR TITLE
Gmavenplus Part 2

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -48,6 +48,10 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>codenarc-maven-plugin</artifactId>
         <version>0.22-1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,24 @@
   </dependencyManagement>
 
   <build>
+    <!-- gmaven is inherited from the parent-pom.  Set it to never run. -->
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.gmaven</groupId>
+          <artifactId>gmaven-plugin</artifactId>
+          <executions>
+            <execution>
+              <phase>none</phase>
+            </execution>
+            <execution>
+              <id>test-in-groovy</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -329,27 +329,27 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>1.7.1</version>
+          <configuration>
+            <providerSelection>1.8</providerSelection>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>generateStubs</goal>
+                <goal>compile</goal>
+                <goal>generateTestStubs</goal>
+                <goal>compileTests</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.gmavenplus</groupId>
-        <artifactId>gmavenplus-plugin</artifactId>
-        <version>1.7.1</version>
-        <configuration>
-          <providerSelection>1.8</providerSelection>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generateStubs</goal>
-              <goal>compile</goal>
-              <goal>generateTestStubs</goal>
-              <goal>compileTests</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.3</version>


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * Looking that the build logs I noticed that gmaven was still running in some cases.  Also, noticed that gmavenplus runs on all the child projects, but is only needed by pipeline-model-definition.  Fixed both issues. 
* Users/aliases to notify:
    * @abayer 
