### PR TITLE
gmavenplus uses the groovy version in the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,9 +328,6 @@
           <groupId>org.codehaus.gmavenplus</groupId>
           <artifactId>gmavenplus-plugin</artifactId>
           <version>1.7.1</version>
-          <configuration>
-            <providerSelection>1.8</providerSelection>
-          </configuration>
           <executions>
             <execution>
               <goals>


### PR DESCRIPTION
Unlike gmaven, gmavenplus does not use providers.