### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GroovyShellDecoratorImplTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GroovyShellDecoratorImplTest.java
@@ -24,7 +24,7 @@ public class GroovyShellDecoratorImplTest {
     public void errorInJenkinsfile() throws Exception {
         WorkflowJob job = j.createProject(WorkflowJob.class);
         // still a syntactically valid groovy code but no stage name
-        job.setDefinition(new CpsFlowDefinition("pipeline { stages { stage { sh './test.sh' } } }"));
+        job.setDefinition(new CpsFlowDefinition("pipeline { stages { stage { sh './test.sh' } } }", true));
         WorkflowRun b = j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
 
         j.assertLogContains(Messages.ModelParser_ExpectedStringLiteral(), b);
@@ -40,7 +40,7 @@ public class GroovyShellDecoratorImplTest {
     public void v1() throws Exception {
         WorkflowJob job = j.createProject(WorkflowJob.class);
         // still a syntactically valid groovy code but no stage name
-        job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }"));
+        job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
         j.assertBuildStatusSuccess(job.scheduleBuild2(0));
     }
 }


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the `CpsFlowDefinition`s in the tests don't consistently use the script security sandbox. Using the script security sandbox results in a more realistic environment given that the script security sandbox should always be enabled in production.

In this change, I replaced any usages of the deprecated single-argument constructor for `CpsFlowDefinition` with usages of the non-deprecated two-argument constructor, passing in `true` as the second argument in order to always enable the script security sandbox.