### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -622,10 +622,10 @@ class Utils {
             if (quietPeriod != null) {
                 j.setQuietPeriod(quietPeriod.quietPeriod)
             } else {
-                String quietPeriodName = Jenkins.getActiveInstance().getDescriptorByType(QuietPeriod.DescriptorImpl.class)?.getName()
+                String quietPeriodName = Jenkins.get().getDescriptorByType(QuietPeriod.DescriptorImpl.class)?.getName()
                 // If the quiet period was set by the previous build, wipe it out.
                 if (quietPeriodName != null && previousOptions.contains(quietPeriodName)) {
-                    j.setQuietPeriod(Jenkins.getActiveInstance().getQuietPeriod())
+                    j.setQuietPeriod(Jenkins.get().getQuietPeriod())
                 }
             }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -1013,7 +1013,7 @@ class ModelParser implements Parser {
 
 
     private ModelASTArgumentList populateStepArgumentList(final ModelASTStep step, final ModelASTArgumentList origArgs) {
-        if (Jenkins.getInstance() != null && origArgs instanceof ModelASTSingleArgument) {
+        if (Jenkins.getInstanceOrNull() != null && origArgs instanceof ModelASTSingleArgument) {
             ModelASTValue singleArgValue = ((ModelASTSingleArgument)origArgs).value
             ModelASTNamedArgumentList namedArgs = new ModelASTNamedArgumentList(origArgs.sourceLocation)
             Descriptor<? extends Describable> desc = lookup.lookupStepFirstThenFunction(step.name)

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -137,7 +137,7 @@ class ModelValidatorImpl implements ModelValidator {
 
         // Only do the symbol lookup if we have a Jenkins instance and condition/branch aren't null. That only happens
         // when there's a failure at parse-time.
-        if (Jenkins.getInstance() != null && buildCondition.condition != null && buildCondition.branch != null) {
+        if (Jenkins.getInstanceOrNull() != null && buildCondition.condition != null && buildCondition.branch != null) {
             if (SymbolLookup.get().find(BuildCondition.class, buildCondition.condition) == null) {
                 errorCollector.error(buildCondition,
                     Messages.ModelValidatorImpl_InvalidBuildCondition(buildCondition.condition, BuildCondition.getOrderedConditionNames()))
@@ -187,7 +187,7 @@ class ModelValidatorImpl implements ModelValidator {
 
                 // Can't do tools validation without a Jenkins instance, so move on if that's not available, or if the tool value is a
                 // non-literal - we allow users to shoot themselves there.
-                if (Jenkins.getInstance() != null && v.isLiteral()) {
+                if (Jenkins.getInstanceOrNull() != null && v.isLiteral()) {
                     // Not bothering with a null check here since we could only get this far if the ToolDescriptor's available in the first place.
                     ToolDescriptor desc = ToolInstallation.all().find { it.getId() == Tools.typeForKey(k.key) }
                     def installer = desc.getInstallations().find { it.name == (String) v.value }
@@ -408,7 +408,7 @@ class ModelValidatorImpl implements ModelValidator {
 
         // We can't do step validation without a Jenkins instance, so move on.
         // Also, special casing of parallel due to it not having a DataBoundConstructor.
-        if (Jenkins.getInstance() != null && step.name != "parallel") {
+        if (Jenkins.getInstanceOrNull() != null && step.name != "parallel") {
             Descriptor desc = lookup.lookupStepFirstThenFunction(step.name)
             DescribableModel<? extends Describable> model = lookup.modelForStepFirstThenFunction(step.name)
 
@@ -423,7 +423,7 @@ class ModelValidatorImpl implements ModelValidator {
     boolean validateElement(@Nonnull ModelASTMethodCall meth) {
         boolean valid = true
 
-        if (Jenkins.getInstance() != null) {
+        if (Jenkins.getInstanceOrNull() != null) {
             DescribableModel<? extends Describable> model
 
             List<Class<? extends Describable>> parentDescribables = Utils.parentsForMethodCall(meth)

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
@@ -171,7 +171,7 @@ public class RestartDeclarativePipelineAction implements Action {
     }
 
     public String getCheckUrl() {
-        return Jenkins.getInstance().getRootUrl() + run.getUrl() + getUrlName() + "/" + "checkStageName";
+        return Jenkins.get().getRootUrl() + run.getUrl() + getUrlName() + "/" + "checkStageName";
     }
 
     public FormValidation doCheckStageName(@QueryParameter String value) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/cli/DeclarativeLinterCommand.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/cli/DeclarativeLinterCommand.java
@@ -44,7 +44,7 @@ public class DeclarativeLinterCommand extends CLICommand {
     }
 
     protected int run() throws Exception {
-        Jenkins.getInstance().checkPermission(READ);
+        Jenkins.get().checkPermission(READ);
         int retVal = 0;
         List<String> output = new ArrayList<>();
 

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ModelConverterAction.java
@@ -83,7 +83,7 @@ public class ModelConverterAction implements RootAction {
     @SuppressWarnings("unused")
     @RequirePOST
     public HttpResponse doToJenkinsfile(StaplerRequest req) {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
 
         JSONObject result = new JSONObject();
 
@@ -123,7 +123,7 @@ public class ModelConverterAction implements RootAction {
     @SuppressWarnings("unused")
     @RequirePOST
     public HttpResponse doToJson(StaplerRequest req) {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
 
         JSONObject result = new JSONObject();
 
@@ -151,7 +151,7 @@ public class ModelConverterAction implements RootAction {
     @SuppressWarnings("unused")
     @RequirePOST
     public HttpResponse doStepsToJson(StaplerRequest req) {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
 
         JSONObject result = new JSONObject();
 
@@ -179,7 +179,7 @@ public class ModelConverterAction implements RootAction {
     @SuppressWarnings("unused")
     @RequirePOST
     public HttpResponse doStepsToJenkinsfile(StaplerRequest req) {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
 
         JSONObject result = new JSONObject();
 
@@ -235,7 +235,7 @@ public class ModelConverterAction implements RootAction {
     @SuppressWarnings("unused")
     @RequirePOST
     public HttpResponse doValidateJenkinsfile(StaplerRequest req) {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
 
         JSONObject result = new JSONObject();
 
@@ -263,7 +263,7 @@ public class ModelConverterAction implements RootAction {
     @SuppressWarnings("unused")
     @RequirePOST
     public HttpResponse doValidateJson(StaplerRequest req) {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
 
         JSONObject result = new JSONObject();
 
@@ -305,7 +305,7 @@ public class ModelConverterAction implements RootAction {
     @SuppressWarnings("unused")
     @RequirePOST
     public HttpResponse doValidate(StaplerRequest req) {
-        Jenkins.getInstance().checkPermission(Jenkins.READ);
+        Jenkins.get().checkPermission(Jenkins.READ);
 
         List<String> output = new ArrayList<>();
 

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator.java
@@ -76,7 +76,7 @@ public class DirectiveGenerator extends Snippetizer {
     public HttpResponse doGenerateDirective(StaplerRequest req, @QueryParameter String json) throws Exception {
         // TODO is there not an easier way to do this? Maybe Descriptor.newInstancesFromHeteroList on a one-element JSONArray?
         JSONObject jsonO = JSONObject.fromObject(json);
-        Jenkins j = Jenkins.getActiveInstance();
+        Jenkins j = Jenkins.get();
         Class<?> c = j.getPluginManager().uberClassLoader.loadClass(jsonO.getString("stapler-class"));
         DirectiveDescriptor descriptor = (DirectiveDescriptor)j.getDescriptor(c.asSubclass(AbstractDirective.class));
         if (descriptor == null) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/StageDirective.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/StageDirective.java
@@ -104,13 +104,13 @@ public class StageDirective extends AbstractDirective<StageDirective> {
         @Nonnull
         public List<Descriptor> getDescriptors() {
             List<Descriptor> descriptors = new ArrayList<>();
-            descriptors.add(Jenkins.getActiveInstance().getDescriptorByType(AgentDirective.DescriptorImpl.class));
-            descriptors.add(Jenkins.getActiveInstance().getDescriptorByType(InputDirective.DescriptorImpl.class));
-            descriptors.add(Jenkins.getActiveInstance().getDescriptorByType(EnvironmentDirective.DescriptorImpl.class));
-            descriptors.add(Jenkins.getActiveInstance().getDescriptorByType(OptionsDirective.DescriptorImpl.class));
-            descriptors.add(Jenkins.getActiveInstance().getDescriptorByType(WhenDirective.DescriptorImpl.class));
-            descriptors.add(Jenkins.getActiveInstance().getDescriptorByType(ToolsDirective.DescriptorImpl.class));
-            descriptors.add(Jenkins.getActiveInstance().getDescriptorByType(PostDirective.DescriptorImpl.class));
+            descriptors.add(Jenkins.get().getDescriptorByType(AgentDirective.DescriptorImpl.class));
+            descriptors.add(Jenkins.get().getDescriptorByType(InputDirective.DescriptorImpl.class));
+            descriptors.add(Jenkins.get().getDescriptorByType(EnvironmentDirective.DescriptorImpl.class));
+            descriptors.add(Jenkins.get().getDescriptorByType(OptionsDirective.DescriptorImpl.class));
+            descriptors.add(Jenkins.get().getDescriptorByType(WhenDirective.DescriptorImpl.class));
+            descriptors.add(Jenkins.get().getDescriptorByType(ToolsDirective.DescriptorImpl.class));
+            descriptors.add(Jenkins.get().getDescriptorByType(PostDirective.DescriptorImpl.class));
 
             return descriptors;
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineActionTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineActionTest.java
@@ -140,7 +140,7 @@ public class RestartDeclarativePipelineActionTest extends AbstractModelDefTest {
 
     private static boolean canRestart(WorkflowRun b, String user) {
         final RestartDeclarativePipelineAction a = b.getAction(RestartDeclarativePipelineAction.class);
-        return ACL.impersonate(User.get(user).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
+        return ACL.impersonate(User.getById(user, true).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
             @Override public Boolean call() throws RuntimeException {
                 return a.isRestartEnabled();
             }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineActionTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineActionTest.java
@@ -36,6 +36,7 @@ import com.github.fge.jsonschema.util.JsonLoader;
 import hudson.model.*;
 import hudson.scm.ChangeLogSet;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.security.AuthorizationStrategy;
 import hudson.security.SecurityRealm;
 import hudson.security.csrf.CrumbIssuer;
@@ -140,11 +141,9 @@ public class RestartDeclarativePipelineActionTest extends AbstractModelDefTest {
 
     private static boolean canRestart(WorkflowRun b, String user) {
         final RestartDeclarativePipelineAction a = b.getAction(RestartDeclarativePipelineAction.class);
-        return ACL.impersonate(User.getById(user, true).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
-            @Override public Boolean call() throws RuntimeException {
-                return a.isRestartEnabled();
-            }
-        });
+        try (ACLContext context = ACL.as(User.getById(user, true))) {
+            return a.isRestartEnabled();
+        }
     }
 
     @Issue("JENKINS-45455")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/cli/DeclarativeLinterCommandTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/cli/DeclarativeLinterCommandTest.java
@@ -99,7 +99,7 @@ public class DeclarativeLinterCommandTest extends AbstractModelDefTest {
         assertThat(result, not(succeeded()));
         assertThat(result.stderr(), containsString("ERROR: anonymous is missing the Overall/Read permission"));
 
-        declarativeLinterCommand.setTransportAuth(User.get("alice").impersonate());
+        declarativeLinterCommand.setTransportAuth(User.getById("alice", true).impersonate());
         final CLICommandInvoker.Result result2 = command.withStdin(FileUtils.openInputStream(testPath)).invoke();
 
         assertThat(result2, succeeded());


### PR DESCRIPTION
While perusing the source tree, I noticed a number of deprecated methods:

- The documentation for [`ACL.impersonate(org.acegisecurity.Authentication, java.lang.Runnable)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#impersonate-org.acegisecurity.Authentication-java.lang.Runnable-) states: "use try with resources and [`as(Authentication)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#as-org.acegisecurity.Authentication-)".
- The documentation for [`User.get(java.lang.String)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#get-java.lang.String-) states: "This method is deprecated, because it causes unexpected `User` creation by API usage code and causes performance degradation of used to retrieve users by ID. Use [`getById(java.lang.String, boolean)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#getById-java.lang.String-boolean-) when you know you have an ID."
- The documentation for [`Jenkins.getActiveInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getActiveInstance--) states: "This is a verbose historical alias for [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--)."
- The documentation for [`Jenkins.getInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstance--) states: "This is a historical alias for [`getInstanceOrNull()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstanceOrNull--) but with ambiguous nullability. Use [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--) in typical cases."

Accordingly, I replaced any calls to `User.get(java.lang.String` with calls to `User.getById(java.lang.String, boolean`, I replaced any usages of `ACL.impersonate` with usages of try-with-resources and `ACL.as`, and I replaced any calls to `Jenkins.getActiveInstance()` with calls to `Jenkins.get()`.

Most calls to `Jenkins.getInstance()` were doing null checking on the result, so I replaced those with calls to `Jenkins.getInstanceOrNull()`. Some calls to `Jenkins.getInstance()` were not doing null checking on the result. In those cases, `Jenkins.get()` is more appropriate to use rather than `Jenkins.getInstanceOrNull()`, so I changed the code to use `Jenkins.get()`.