### PR TITLE
[JENKINS-54322] enable markStageSkippedForConditional within the scripted

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -386,6 +386,7 @@ class Utils {
         markStageWithTag(stageName, getStageStatusMetadata().tagName, getStageStatusMetadata().skippedForFailure)
     }
 
+    @Whitelisted
     @Restricted(NoExternalUse.class)
     static void markStageSkippedForConditional(String stageName) {
         markStageWithTag(stageName, getStageStatusMetadata().tagName, getStageStatusMetadata().skippedForConditional)


### PR DESCRIPTION
* JENKINS issue(s):
    * See [JENKINS-54322](https://issues.jenkins-ci.org/browse/JENKINS-54322)
* Description:
    * Since this class can be used within the scripted pipeline, I'd like to expose the option to mark a staged as skipped programmatically.
    * Not sure whether it might be interesting to expose the other `mark*` methods
* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * @abayer as you worked on https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/210