### PR TITLE
Remove deprecated dockerFingerprintFrom

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/DockerPipelineFromDockerfileScript.groovy
@@ -70,7 +70,6 @@ class DockerPipelineFromDockerfileScript extends AbstractDockerPipelineScript<Do
                 def imgName = "${hash}"
                 def commandLine = "docker build -t ${imgName}${additionalBuildArgs} -f \"${dockerfilePath}\" \"${describable.getActualDir()}\""
                 script.sh commandLine
-                script.dockerFingerprintFrom dockerfile: dockerfilePath, image: imgName, toolName: script.env.DOCKER_TOOL_NAME, commandLine: commandLine
                 return script.getProperty("docker").image(imgName)
             } catch (FileNotFoundException f) {
                 script.error("No Dockerfile found at ${dockerfilePath} in repository - failing.")


### PR DESCRIPTION
See here for reference: https://github.com/jenkinsci/docker-workflow-plugin/pull/180

`dockerFingerprintFrom` has problems with multi-stage docker builds. The maintainers of the `docker-workflow-plugin` have decided to deprecate these steps, because the actual fingerprints are not anywhere in use.
