### PR TITLE
[JENKINS-51865] Introduce beforeOptions in 'when'

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTWhen.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTWhen.java
@@ -43,6 +43,8 @@ public class ModelASTWhen extends ModelASTElement {
 
     private Boolean beforeInput;
 
+    private Boolean beforeOptions;
+
     public ModelASTWhen(Object sourceLocation) {
         super(sourceLocation);
     }
@@ -71,12 +73,21 @@ public class ModelASTWhen extends ModelASTElement {
         this.beforeInput = beforeInput;
     }
 
+    public Boolean getBeforeOptions() {
+        return beforeOptions;
+    }
+
+    public void setBeforeOptions(Boolean beforeOptions) {
+        this.beforeOptions = beforeOptions;
+    }
+
     @Override
     public Object toJSON() {
         return new JSONObject()
                 .accumulate("conditions", toJSONArray(conditions))
                 .elementOpt("beforeAgent", beforeAgent)
-                .elementOpt("beforeInput", beforeInput);
+                .elementOpt("beforeInput", beforeInput)
+                .elementOpt("beforeOptions", beforeOptions);
     }
 
     @Override
@@ -87,6 +98,9 @@ public class ModelASTWhen extends ModelASTElement {
         }
         if (beforeInput != null && beforeInput) {
             result.append("beforeInput true\n");
+        }
+        if (beforeOptions != null && beforeOptions) {
+            result.append("beforeOptions true\n");
         }
         result.append(toGroovy(conditions));
         result.append("}\n");
@@ -105,6 +119,7 @@ public class ModelASTWhen extends ModelASTElement {
                 "conditions=" + conditions +
                 ", beforeAgent=" + beforeAgent +
                 ", beforeInput=" + beforeInput +
+                ", beforeOptions=" + beforeOptions +
                 "}";
     }
 

--- a/pipeline-model-api/src/main/resources/ast-schema.json
+++ b/pipeline-model-api/src/main/resources/ast-schema.json
@@ -418,6 +418,9 @@
         "beforeInput": {
           "type": "boolean"
         },
+        "beforeOptions": {
+          "type": "boolean"
+        },
         "conditions": {
           "type": "array",
           "minItems": 1,

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/StageConditionals.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/StageConditionals.groovy
@@ -60,17 +60,19 @@ class StageConditionals implements Serializable {
     final Closure rawClosure
     final Boolean beforeAgent
     final Boolean beforeInput
+    final Boolean beforeOptions
 
     @Deprecated
     @Whitelisted
     StageConditionals(Closure rawClosure) {
-        this(rawClosure, null, null)
+        this(rawClosure, null, null, null)
     }
 
     @Whitelisted
-    StageConditionals(Closure rawClosure, Boolean beforeAgent, Boolean beforeInput) {
+    StageConditionals(Closure rawClosure, Boolean beforeAgent, Boolean beforeInput, Boolean beforeOptions) {
         this.rawClosure = rawClosure
         this.beforeAgent = beforeAgent
         this.beforeInput = beforeInput
+        this.beforeOptions = beforeOptions
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/JSONParser.groovy
@@ -357,6 +357,10 @@ class JSONParser implements Parser {
             when.beforeInput = j.node.get("beforeInput")?.asBoolean()
         }
 
+        if (j.node.has("beforeOptions")) {
+            when.beforeOptions = j.node.get("beforeOptions")?.asBoolean()
+        }
+
         JsonTree conditionsTree = j.append(JsonPointer.of("conditions"))
         conditionsTree.node.eachWithIndex { JsonNode entry, int i ->
             JsonTree condTree = conditionsTree.append(JsonPointer.of(i))

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -905,6 +905,8 @@ class ModelParser implements Parser {
                     w.beforeAgent = parseBooleanMethod(mc)
                 } else if (name == "beforeInput") {
                     w.beforeInput = parseBooleanMethod(mc)
+                } else if (name == "beforeOptions") {
+                    w.beforeOptions = parseBooleanMethod(mc)
                 } else {
                     w.conditions.add(parseWhenContent(s))
                 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -727,7 +727,8 @@ class RuntimeASTTransformer {
             return ctorX(ClassHelper.make(StageConditionals.class),
                 args(closureX(block(returnS(closList))),
                     constX(original.beforeAgent != null ? original.beforeAgent : false),
-                    constX(original.beforeInput != null ? original.beforeInput : false)
+                    constX(original.beforeInput != null ? original.beforeInput : false),
+                    constX(original.beforeOptions != null ? original.beforeOptions : false)
                 ))
         }
         return constX(null)

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective.java
@@ -43,11 +43,15 @@ import java.util.Map;
 public class WhenDirective extends AbstractDirective<WhenDirective> {
     private DeclarativeStageConditional conditional;
     private boolean beforeAgent;
+    private boolean beforeInput;
+    private boolean beforeOptions;
 
     @DataBoundConstructor
-    public WhenDirective(DeclarativeStageConditional conditional, boolean beforeAgent) {
+    public WhenDirective(DeclarativeStageConditional conditional, boolean beforeAgent, boolean beforeInput, boolean beforeOptions) {
         this.conditional = conditional;
         this.beforeAgent = beforeAgent;
+        this.beforeInput = beforeInput;
+        this.beforeOptions = beforeOptions;
     }
 
     public DeclarativeStageConditional getConditional() {
@@ -56,6 +60,14 @@ public class WhenDirective extends AbstractDirective<WhenDirective> {
 
     public boolean isBeforeAgent() {
         return beforeAgent;
+    }
+
+    public boolean isBeforeInput() {
+        return beforeInput;
+    }
+
+    public boolean isBeforeOptions() {
+        return beforeOptions;
     }
 
     @Extension
@@ -107,6 +119,12 @@ public class WhenDirective extends AbstractDirective<WhenDirective> {
                         result.append("// ERROR TRANSLATING CONDITIONAL: ").append(e).append("\n");
                     }
 
+                    if (directive.isBeforeOptions()) {
+                        result.append("beforeOptions true\n");
+                    }
+                    if (directive.isBeforeInput()) {
+                        result.append("beforeInput true\n");
+                    }
                     if (directive.isBeforeAgent()) {
                         result.append("beforeAgent true\n");
                     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective/config.jelly
@@ -40,6 +40,12 @@
             </f:dropdownListBlock>
         </j:forEach>
     </f:dropdownList>
+    <f:entry field="beforeOptions">
+        <f:checkbox title="${%Evaluate Before Options}"/>
+    </f:entry>
+    <f:entry field="beforeInput">
+        <f:checkbox title="${%Evaluate Before Input}"/>
+    </f:entry>
     <f:entry field="beforeAgent">
         <f:checkbox title="${%Evaluate Before Agent}"/>
     </f:entry>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective/help-beforeInput.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective/help-beforeInput.html
@@ -22,6 +22,6 @@
   ~ THE SOFTWARE.
   -->
 <div>
-    Evaluate the <code>when</code> condition before entering this stage's <code>agent</code>, if any.
-    This setting is ignored if <code>beforeOptions</code> or <code>beforeInput</code> is active.
+    Evaluate the <code>when</code> condition before entering this stage's <code>input</code>, if any.
+    This setting is ignored if <code>beforeOptions</code> is active.
 </div>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective/help-beforeOptions.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/WhenDirective/help-beforeOptions.html
@@ -22,6 +22,5 @@
   ~ THE SOFTWARE.
   -->
 <div>
-    Evaluate the <code>when</code> condition before entering this stage's <code>agent</code>, if any.
-    This setting is ignored if <code>beforeOptions</code> or <code>beforeInput</code> is active.
+    Evaluate the <code>when</code> condition before entering this stage's <code>options</code>, if any.
 </div>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
@@ -449,6 +449,26 @@ public class WhenStageTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-51865")
+    @Test
+    public void whenBeforeOptionsTrue() throws Exception {
+        expect("when/whenBeforeOptionsTrue")
+                .logContains("Stage One here")
+                .logNotContains("Stage Two here")
+                .logNotContains("Timeout set to expire")
+                .go();
+    }
+
+    @Issue("JENKINS-51865")
+    @Test
+    public void whenBeforeOptionsFalse() throws Exception {
+        expect("when/whenBeforeOptionsFalse")
+                .logContains("Stage One here")
+                .logNotContains("Stage Two here")
+                .logContains("Timeout set to expire")
+                .go();
+    }
+
     @Issue("JENKINS-49226")
     @Test
     public void whenEquals() throws Exception {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
@@ -218,7 +218,7 @@ public class DirectiveGeneratorTest {
 
     @Test
     public void whenBranch() throws Exception {
-        WhenDirective when = new WhenDirective(new BranchConditional("some-pattern"), true);
+        WhenDirective when = new WhenDirective(new BranchConditional("some-pattern"), true, false, false);
 
         assertGenerateDirective(when, "when {\n" +
                 "  branch 'some-pattern'\n" +
@@ -227,8 +227,28 @@ public class DirectiveGeneratorTest {
     }
 
     @Test
+    public void whenBranchBeforeInput() throws Exception {
+        WhenDirective when = new WhenDirective(new BranchConditional("some-pattern"), false, true, false);
+
+        assertGenerateDirective(when, "when {\n" +
+                "  branch 'some-pattern'\n" +
+                "  beforeInput true\n" +
+                "}");
+    }
+
+    @Test
+    public void whenBranchBeforeOptions() throws Exception {
+        WhenDirective when = new WhenDirective(new BranchConditional("some-pattern"), false, false, true);
+
+        assertGenerateDirective(when, "when {\n" +
+                "  branch 'some-pattern'\n" +
+                "  beforeOptions true\n" +
+                "}");
+    }
+
+    @Test
     public void whenEnvironment() throws Exception {
-        WhenDirective when = new WhenDirective(new EnvironmentConditional("SOME_VAR", "some value"), false);
+        WhenDirective when = new WhenDirective(new EnvironmentConditional("SOME_VAR", "some value"), false, false, false);
 
         assertGenerateDirective(when, "when {\n" +
                 "  environment name: 'SOME_VAR', value: 'some value'\n" +
@@ -237,7 +257,7 @@ public class DirectiveGeneratorTest {
 
     @Test
     public void whenChangelog() throws Exception {
-        WhenDirective when = new WhenDirective(new ChangeLogConditional("some-pattern"), false);
+        WhenDirective when = new WhenDirective(new ChangeLogConditional("some-pattern"), false, false, false);
         assertGenerateDirective(when, "when {\n" +
                 "  changelog 'some-pattern'\n" +
                 "}");
@@ -245,7 +265,7 @@ public class DirectiveGeneratorTest {
 
     @Test
     public void whenChangeset() throws Exception {
-        WhenDirective when = new WhenDirective(new ChangeSetConditional("some/file/in/changeset"), false);
+        WhenDirective when = new WhenDirective(new ChangeSetConditional("some/file/in/changeset"), false, false, false);
 
         assertGenerateDirective(when, "when {\n" +
                 "  changeset 'some/file/in/changeset'\n" +
@@ -254,7 +274,7 @@ public class DirectiveGeneratorTest {
 
     @Test
     public void whenNot() throws Exception {
-        WhenDirective when = new WhenDirective(new NotConditional(new BranchConditional("some-bad-branch")), false);
+        WhenDirective when = new WhenDirective(new NotConditional(new BranchConditional("some-bad-branch")), false, false, false);
 
         assertGenerateDirective(when, "when {\n" +
                 "  not {\n" +
@@ -268,7 +288,7 @@ public class DirectiveGeneratorTest {
         List<DeclarativeStageConditional<?>> nested = new ArrayList<>();
         nested.add(new BranchConditional("that-branch"));
         nested.add(new BranchConditional("this-branch"));
-        WhenDirective when = new WhenDirective(new AnyOfConditional(nested), true);
+        WhenDirective when = new WhenDirective(new AnyOfConditional(nested), true, false, false);
 
         assertGenerateDirective(when, "when {\n" +
                 "  anyOf {\n" +
@@ -284,7 +304,7 @@ public class DirectiveGeneratorTest {
         List<DeclarativeStageConditional<?>> nested = new ArrayList<>();
         nested.add(new BranchConditional("that-branch"));
         nested.add(new BranchConditional("this-branch"));
-        WhenDirective when = new WhenDirective(new AllOfConditional(nested), false);
+        WhenDirective when = new WhenDirective(new AllOfConditional(nested), false, false, false);
 
         assertGenerateDirective(when, "when {\n" +
                 "  allOf {\n" +
@@ -296,7 +316,7 @@ public class DirectiveGeneratorTest {
     
     @Test
     public void whenAllOfEmpty() throws Exception {
-        WhenDirective when = new WhenDirective(new AllOfConditional(null), false);
+        WhenDirective when = new WhenDirective(new AllOfConditional(null), false, false, false);
 
         assertGenerateDirective(when, "when {\n" +
                 "  allOf {\n" +
@@ -317,7 +337,7 @@ public class DirectiveGeneratorTest {
 
         nested.add(new AnyOfConditional(veryNested));
 
-        WhenDirective whenDirective = new WhenDirective(new AllOfConditional(nested), false);
+        WhenDirective whenDirective = new WhenDirective(new AllOfConditional(nested), false, false, false);
 
         assertGenerateDirective(whenDirective, "when {\n" +
                 "  allOf {\n" +
@@ -502,7 +522,7 @@ public class DirectiveGeneratorTest {
         List<DeclarativeStageConditional<?>> nested = new ArrayList<>();
         nested.add(new BranchConditional("that-branch"));
         nested.add(new BranchConditional("this-branch"));
-        WhenDirective when = new WhenDirective(new AllOfConditional(nested), false);
+        WhenDirective when = new WhenDirective(new AllOfConditional(nested), false, false, false);
         AgentDirective agent = new AgentDirective(new DockerPipeline("some-image"));
 
         StageDirective stage = new StageDirective(Arrays.asList(agent, when, env, tools, post), "bob", StageDirective.StageContentType.STEPS);
@@ -541,7 +561,7 @@ public class DirectiveGeneratorTest {
     @Issue("JENKINS-51932")
     @Test
     public void whenIsRestartedRun() throws Exception {
-        WhenDirective when = new WhenDirective(new IsRestartedRunConditional(), false);
+        WhenDirective when = new WhenDirective(new IsRestartedRunConditional(), false, false, false);
         assertGenerateDirective(when, "when {\n" +
                 "  isRestartedRun()\n" +
                 "}");

--- a/pipeline-model-definition/src/test/resources/when/whenBeforeOptionsFalse.groovy
+++ b/pipeline-model-definition/src/test/resources/when/whenBeforeOptionsFalse.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage("One") {
+            steps {
+                echo "Stage One here"
+            }
+        }
+        stage("Two") {
+            when {
+                beforeOptions false
+                expression {
+                    return false
+                }
+            }
+            options {
+                timeout(time: 10, unit: 'SECONDS')
+            }
+            steps {
+                echo "Stage Two here"
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/resources/when/whenBeforeOptionsTrue.groovy
+++ b/pipeline-model-definition/src/test/resources/when/whenBeforeOptionsTrue.groovy
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+
+    stages {
+        stage("One") {
+            steps {
+                echo "Stage One here"
+            }
+        }
+        stage("Two") {
+            when {
+                beforeOptions true
+                expression {
+                    return false
+                }
+            }
+            options {
+                timeout(time: 10, unit: 'SECONDS')
+            }
+            steps {
+                echo "Stage Two here"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins-ci.org/browse/JENKINS-51865
* Description:
    * Introduces `beforeOptions` in `when` to be able to skip any (costly and pointless) `options` like `lock` (https://github.com/jenkinsci/lockable-resources-plugin).
* Documentation changes:
    * https://github.com/jenkins-infra/jenkins.io/pull/2569
* Users/aliases to notify:
    * @abayer
    * @bitwiseman

Some remarks:
- A single `before` attribute with possible values `'options'` XOR `'input'` XOR `'agent'` would be more concise but `beforeAgent` and `beforeInput` are already out there "in the wild".
- Strangely, `beforeInput` was missing from the generator (I fixed that).
- Also strangely, `beforeInput` and `beforeAgent` are _not_ evaluated when using `parallel` (but the new `beforeOptions` _is_ evaluated because I did not see why it shouldn't).
- I tried to give all user facing aspects a logical order (options, input, agent) but for the rest I oriented myself to `beforeInput` which was introduced after `beforeAgent`.
- I did not touch the matrix based tests because I wouldn't really know what I was doing...
