### PR TITLE
Disable matrix execution

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -818,6 +818,7 @@ class RuntimeASTTransformer {
     @Nonnull
     Expression transformMatrix(@CheckForNull ModelASTMatrix original) {
         if (isGroovyAST(original) && !original?.stages?.stages?.isEmpty() && !original?.axes?.axes?.isEmpty()) {
+            throw new RuntimeException("'matrix' directive is not supported yet. Check the plugin update site or use the experimental update center to get the beta).")
 
             // generate matrix combinations of axes - cartesianProduct
             Set<Map<ModelASTKey, ModelASTValue>> expansion = expandAxes(original.axes.axes)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -72,6 +72,13 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         s.setLabelString("some-label docker");
     }
 
+    @Test
+    public void matrixPipelineDisabled() throws Exception {
+        expect(Result.FAILURE, "matrix/matrixPipeline")
+            .logContains("'matrix' directive is not supported yet.")
+            .go();
+    }
+
     @Issue("JENKINS-47363")
     // Give this a longer timeout
     @Test(timeout=5 * 60 * 1000)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
@@ -86,6 +86,11 @@ public class MatrixTest extends AbstractModelDefTest {
             new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "windows agent")));
     }
 
+    @Before
+    public void matrixDisabled() {
+        Assume.assumeFalse("Disabled matrix tests on this branch.", true);
+    }
+
     @Ignore
     @Issue("JENKINS-41334")
     @Test


### PR DESCRIPTION
* Description:

To get a 1.3.x release out without turning on matrix, I've set it to fail at runtime.
This is simpler than trying to tease apart what's been added in the last few months.

@dwnusbaum @olamy @kshultzCB @joseblas 