### PR TITLE
JENKINS-60115: Make toGroovy() and toJSON() @Nonnull

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/AbstractModelASTCodeBlock.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/AbstractModelASTCodeBlock.java
@@ -25,6 +25,8 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
@@ -43,6 +45,7 @@ public abstract class AbstractModelASTCodeBlock extends ModelASTStep {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder(getName()).append(" {\n");
         result.append(codeBlockAsString());

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAgent.java
@@ -22,6 +22,7 @@ public final class ModelASTAgent extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         final JSONObject j = new JSONObject();
 
@@ -71,6 +72,7 @@ public final class ModelASTAgent extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder argStr = new StringBuilder();
         if (variables == null ||

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAxis.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAxis.java
@@ -26,6 +26,7 @@ public class ModelASTAxis extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("name", toJSON(name))
@@ -38,6 +39,7 @@ public class ModelASTAxis extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder argStr = new StringBuilder()
             .append("name '").append(toGroovy(name) + "'\n")

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAxisContainer.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTAxisContainer.java
@@ -22,6 +22,7 @@ public class ModelASTAxisContainer extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(axes);
     }
@@ -33,6 +34,7 @@ public class ModelASTAxisContainer extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("axes", axes);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBranch.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBranch.java
@@ -24,6 +24,7 @@ public final class ModelASTBranch extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("name", name)
@@ -37,6 +38,7 @@ public final class ModelASTBranch extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovy(steps);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildCondition.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildCondition.java
@@ -20,6 +20,7 @@ public final class ModelASTBuildCondition extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("condition", condition)
@@ -33,6 +34,7 @@ public final class ModelASTBuildCondition extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock(condition, branch);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildConditionsContainer.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildConditionsContainer.java
@@ -26,6 +26,7 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
     public abstract String getName();
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return toJSONObject("conditions", conditions);
     }
@@ -38,6 +39,7 @@ public abstract class ModelASTBuildConditionsContainer extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock(getName(), conditions);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildParameters.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTBuildParameters.java
@@ -20,6 +20,7 @@ public final class ModelASTBuildParameters extends ModelASTElement implements Mo
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return toJSONObject("parameters", parameters);
     }
@@ -31,6 +32,7 @@ public final class ModelASTBuildParameters extends ModelASTElement implements Mo
     }
 
     @Override
+    @Nonnull
     public String toGroovy() { return toGroovyBlock("parameters", parameters); }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTClosureMap.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTClosureMap.java
@@ -44,6 +44,7 @@ public final class ModelASTClosureMap extends ModelASTElement implements ModelAS
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(variables);
     }
@@ -55,6 +56,7 @@ public final class ModelASTClosureMap extends ModelASTElement implements ModelAS
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock(null, variables, " ");
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTElement.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTElement.java
@@ -58,6 +58,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      * @return Generally a {@link JSONObject} or {@link JSONArray} but for some leaf nodes, may be a {@link String} or
      *     other simple class.
      */
+    @Nonnull
     public abstract Object toJSON();
 
     @CheckForNull
@@ -110,6 +111,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     public abstract String toGroovy();
 
 
@@ -118,6 +120,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static String toGroovy(@CheckForNull ModelASTMarkerInterface item) {
         return item != null ? item.toGroovy() : "";
     }
@@ -127,6 +130,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static String toGroovyCheckEmpty(@CheckForNull ModelASTElementContainer item) {
         return item != null && !item.isEmpty() ? item.toGroovy() : "";
     }
@@ -136,6 +140,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static <T extends ModelASTMarkerInterface> String toGroovy(List<T> list) {
         StringBuilder result = new StringBuilder();
         for (T item: list) {
@@ -149,6 +154,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static <T extends ModelASTMarkerInterface> String toGroovyArgList(Collection<T> list) {
         StringBuilder result = new StringBuilder();
         boolean first = true;
@@ -168,6 +174,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static <K extends ModelASTMarkerInterface, V extends  ModelASTMarkerInterface>  String toGroovyArgList(Map<K, V> map, String separator) {
         StringBuilder result = new StringBuilder();
         boolean first = true;
@@ -188,6 +195,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static String toGroovyBlock(String name, ModelASTMarkerInterface item) {
         StringBuilder result = new StringBuilder();
         if (name != null) {
@@ -204,6 +212,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static <T extends ModelASTMarkerInterface> String toGroovyBlock(String name, List<T> list) {
         StringBuilder result = new StringBuilder();
         if (name != null) {
@@ -220,6 +229,7 @@ public abstract class ModelASTElement implements ModelASTMarkerInterface {
      *
      * @return A simple {@link String} of Groovy code for this element and its children.
      */
+    @Nonnull
     protected static <K extends ModelASTMarkerInterface, V extends  ModelASTMarkerInterface> String toGroovyBlock(String name, Map<K, V> map, String separator) {
         StringBuilder result = new StringBuilder();
         if (name != null) {

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTEnvironment.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTEnvironment.java
@@ -20,6 +20,7 @@ public final class ModelASTEnvironment extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(variables);
     }
@@ -31,6 +32,7 @@ public final class ModelASTEnvironment extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("environment", variables, " = ");
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTExclude.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTExclude.java
@@ -22,6 +22,7 @@ public class ModelASTExclude extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(axes);
     }
@@ -33,6 +34,7 @@ public class ModelASTExclude extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("exclude", axes);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTExcludeAxis.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTExcludeAxis.java
@@ -22,6 +22,7 @@ public class ModelASTExcludeAxis extends ModelASTAxis {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return super.toJSON()
             .elementOpt("inverse", inverse);
@@ -34,6 +35,7 @@ public class ModelASTExcludeAxis extends ModelASTAxis {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder argStr = new StringBuilder()
             .append("name '").append(toGroovy(getName()) + "'\n");

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTExcludes.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTExcludes.java
@@ -22,6 +22,7 @@ public class ModelASTExcludes extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(excludes);
     }
@@ -33,6 +34,7 @@ public class ModelASTExcludes extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("excludes", excludes);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTInternalFunctionCall.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTInternalFunctionCall.java
@@ -46,6 +46,7 @@ public class ModelASTInternalFunctionCall extends ModelASTElement implements Mod
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("name", name)
@@ -59,6 +60,7 @@ public class ModelASTInternalFunctionCall extends ModelASTElement implements Mod
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder(name);
         result.append('(');

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTKey.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTKey.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
 
+import javax.annotation.Nonnull;
+
 /**
  * Represents the key in a key/value pair, as used in {@link ModelASTEnvironment}, {@link ModelASTNamedArgumentList} and elsewhere.
  *
@@ -13,11 +15,13 @@ public class ModelASTKey extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public Object toJSON() {
         return key;
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return key;
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTKeyValueOrMethodCallPair.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTKeyValueOrMethodCallPair.java
@@ -19,6 +19,7 @@ public final class ModelASTKeyValueOrMethodCallPair extends ModelASTElement impl
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("key", toJSON(key))
@@ -31,6 +32,7 @@ public final class ModelASTKeyValueOrMethodCallPair extends ModelASTElement impl
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return key.toGroovy() + ": " + value.toGroovy();
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTLibraries.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTLibraries.java
@@ -44,6 +44,7 @@ public final class ModelASTLibraries extends ModelASTElement implements ModelAST
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return toJSONObject("libraries", libs);
     }
@@ -55,6 +56,7 @@ public final class ModelASTLibraries extends ModelASTElement implements ModelAST
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder("libraries {\n");
         for (ModelASTValue v : libs) {

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMarkerInterface.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMarkerInterface.java
@@ -33,8 +33,10 @@ import javax.annotation.Nonnull;
  * @author Andrew Bayer
  */
 public interface ModelASTMarkerInterface {
+    @Nonnull
     String toGroovy();
 
+    @Nonnull
     Object toJSON();
 
     void validate(@Nonnull ModelValidator validator);

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMatrix.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMatrix.java
@@ -24,6 +24,7 @@ public final class ModelASTMatrix extends ModelASTStageBase {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         JSONObject o = super.toJSON()
                 .elementOpt("axes", toJSON(axes))
@@ -45,6 +46,7 @@ public final class ModelASTMatrix extends ModelASTStageBase {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder children = new StringBuilder()
             .append(toGroovy(axes))

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMethodCall.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTMethodCall.java
@@ -43,6 +43,7 @@ public class ModelASTMethodCall extends ModelASTElement implements ModelASTMetho
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("name", name)
@@ -56,6 +57,7 @@ public class ModelASTMethodCall extends ModelASTElement implements ModelASTMetho
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder(name);
         result.append('(');

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTNamedArgumentList.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTNamedArgumentList.java
@@ -23,6 +23,7 @@ public final class ModelASTNamedArgumentList extends ModelASTArgumentList {
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(arguments);
     }
@@ -63,6 +64,7 @@ public final class ModelASTNamedArgumentList extends ModelASTArgumentList {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyArgList(arguments, ": ");
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTOptions.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTOptions.java
@@ -21,6 +21,7 @@ public final class ModelASTOptions extends ModelASTElement implements ModelASTEl
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return toJSONObject("options", options);
     }
@@ -32,6 +33,7 @@ public final class ModelASTOptions extends ModelASTElement implements ModelASTEl
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("options", options);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTParallel.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTParallel.java
@@ -28,6 +28,7 @@ public class ModelASTParallel extends ModelASTStages {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("parallel", getStages());
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
@@ -28,6 +28,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         JSONObject a = new JSONObject()
                 .elementOpt("stages", toJSON(stages))
@@ -50,6 +51,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder()
             .append("pipeline {\n")

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPositionalArgumentList.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPositionalArgumentList.java
@@ -24,6 +24,7 @@ public final class ModelASTPositionalArgumentList extends ModelASTArgumentList {
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(arguments);
     }
@@ -35,6 +36,7 @@ public final class ModelASTPositionalArgumentList extends ModelASTArgumentList {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder();
         boolean first = true;

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTSingleArgument.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTSingleArgument.java
@@ -21,6 +21,7 @@ public final class ModelASTSingleArgument extends ModelASTArgumentList {
     }
 
     @Override
+    @Nonnull
     public Object toJSON() {
         return toJSON(value);
     }
@@ -32,6 +33,7 @@ public final class ModelASTSingleArgument extends ModelASTArgumentList {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return value.toGroovy();
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTSingleArgument.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTSingleArgument.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public final class ModelASTSingleArgument extends ModelASTArgumentList {
 
     /**
-     * While not @Nonnull, if this field is null parsing or validation errors will occur before
+     * While not {@link Nonnull}, if this field is null then parsing/validation errors will occur before
      * {@link NullPointerException} would be thrown by {@link #toGroovy()} or {@link #toJSON()}.
      */
     private ModelASTValue value;

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTSingleArgument.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTSingleArgument.java
@@ -14,6 +14,11 @@ import java.util.Map;
  * @author Andrew Bayer
  */
 public final class ModelASTSingleArgument extends ModelASTArgumentList {
+
+    /**
+     * While not @Nonnull, if this field is null parsing or validation errors will occur before
+     * {@link NullPointerException} would be thrown by {@link #toGroovy()} or {@link #toJSON()}.
+     */
     private ModelASTValue value;
 
     public ModelASTSingleArgument(Object sourceLocation) {
@@ -23,7 +28,7 @@ public final class ModelASTSingleArgument extends ModelASTArgumentList {
     @Override
     @Nonnull
     public Object toJSON() {
-        return toJSON(value);
+        return value.toJSON();
     }
 
     @Override

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStage.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStage.java
@@ -45,6 +45,7 @@ public class ModelASTStage extends ModelASTStageBase {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
 
         JSONObject o = super.toJSON()
@@ -73,6 +74,7 @@ public class ModelASTStage extends ModelASTStageBase {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder()
             // TODO decide if we need to support multiline names

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStageBase.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStageBase.java
@@ -31,6 +31,7 @@ public abstract class ModelASTStageBase extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         JSONObject o = new JSONObject()
             .elementOpt("agent", toJSON(agent))
@@ -51,6 +52,7 @@ public abstract class ModelASTStageBase extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder()
             .append(toGroovy(agent))

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStageInput.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStageInput.java
@@ -49,6 +49,7 @@ public final class ModelASTStageInput extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         final JSONObject o = new JSONObject()
             .accumulate("message", toJSON(message))
@@ -71,6 +72,7 @@ public final class ModelASTStageInput extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder("input {\n");
         result.append("message ").append(message.toGroovy()).append("\n");

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStages.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStages.java
@@ -23,6 +23,7 @@ public class ModelASTStages extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public Object toJSON() {
         return toJSONArray(stages);
     }
@@ -40,6 +41,7 @@ public class ModelASTStages extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("stages", stages);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTStep.java
@@ -55,6 +55,7 @@ public class ModelASTStep extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("name", name)
@@ -68,6 +69,7 @@ public class ModelASTStep extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         // Default to using whatever the original args structure is.
         ModelASTArgumentList argList = args;

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTools.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTools.java
@@ -21,6 +21,7 @@ public final class ModelASTTools extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public JSONArray toJSON() {
         return toJSONArray(tools);
     }
@@ -32,6 +33,7 @@ public final class ModelASTTools extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("tools", tools, " ");
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTreeStep.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTreeStep.java
@@ -21,6 +21,7 @@ public class ModelASTTreeStep extends ModelASTStep {
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return super.toJSON().accumulate("children", toJSONArray(children));
     }
@@ -32,6 +33,7 @@ public class ModelASTTreeStep extends ModelASTStep {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock(super.toGroovy(), children);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTriggers.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTTriggers.java
@@ -20,6 +20,7 @@ public final class ModelASTTriggers extends ModelASTElement implements ModelASTE
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return toJSONObject("triggers", triggers);
     }
@@ -31,6 +32,7 @@ public final class ModelASTTriggers extends ModelASTElement implements ModelASTE
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         return toGroovyBlock("triggers", triggers);
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
@@ -147,7 +147,7 @@ public abstract class ModelASTValue extends ModelASTElement implements ModelASTM
             } else if (getValue() != null) {
                 return getValue().toString();
             } else {
-                return null;
+                return "null";
             }
         }
     }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTValue.java
@@ -75,6 +75,7 @@ public abstract class ModelASTValue extends ModelASTElement implements ModelASTM
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
             .accumulate("isLiteral", isLiteral())
@@ -133,6 +134,7 @@ public abstract class ModelASTValue extends ModelASTElement implements ModelASTM
         }
 
         @Override
+        @Nonnull
         public String toGroovy() {
             if (getValue() instanceof String) {
                 String str = (String) getValue();
@@ -161,6 +163,7 @@ public abstract class ModelASTValue extends ModelASTElement implements ModelASTM
         }
 
         @Override
+        @Nonnull
         public String toGroovy() {
             String gstring = (String)getValue();
             if (gstring.startsWith("${") && gstring.endsWith("}")) {

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTWhen.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTWhen.java
@@ -82,6 +82,7 @@ public class ModelASTWhen extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public Object toJSON() {
         return new JSONObject()
                 .accumulate("conditions", toJSONArray(conditions))
@@ -91,6 +92,7 @@ public class ModelASTWhen extends ModelASTElement {
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
         StringBuilder result = new StringBuilder("when {\n");
         if (beforeAgent != null && beforeAgent) {

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTWhenCondition.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTWhenCondition.java
@@ -46,6 +46,7 @@ public class ModelASTWhenCondition extends ModelASTElement implements ModelASTWh
     }
 
     @Override
+    @Nonnull
     public JSONObject toJSON() {
         return new JSONObject()
                 .accumulate("name", name)
@@ -60,6 +61,7 @@ public class ModelASTWhenCondition extends ModelASTElement implements ModelASTWh
     }
 
     @Override
+    @Nonnull
     public String toGroovy() {
 
         StringBuilder result = new StringBuilder();

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -261,7 +261,7 @@ class ModelParser implements Parser {
 
         // Lazily evaluate r.toJSON() - i.e., only if AST_DEBUG_LOGGING is true.
         astDebugLog {
-            "Model as JSON:\\n${r.toJSON().toString(2)}"
+            "Model as JSON:\n${r.toJSON().toString(2)}"
         }
         // Only transform the pipeline {} to pipeline({ return root }) if this is being called in the compiler and there
         // are no errors.
@@ -274,7 +274,7 @@ class ModelParser implements Parser {
 
             // Lazily evaluate prettyPrint(...) - i.e., only if AST_DEBUG_LOGGING is true.
             astDebugLog {
-                "Transformed runtime AST: ${ -> prettyPrint(pipelineBlock.whole.arguments)}"
+                "Transformed runtime AST:\n${ -> prettyPrint(pipelineBlock.whole.arguments)}"
             }
         }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -132,6 +132,7 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
             "agent/agentAny",
             "agent/agentLabel",
             "agent/agentNoneWithNode",
+            "basic/singleArgumentNullValue",
             "steps/metaStepSyntax",
             "environment/simpleEnvironment",
             "simpleScript",

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -565,6 +565,16 @@ public class BasicModelDefTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Issue("JENKINS-60115")
+    @Test
+    public void singleArgumentNullValue() throws Exception {
+        expect("basic/singleArgumentNullValue")
+            .logContains("[Pipeline] { (foo)",
+                "Trying to pass milestone 0",
+                "Null is no problem")
+            .go();
+    }
+
     @Issue("JENKINS-51962")
     @Test
     public void failureInFirstOfSequential() throws Exception {

--- a/pipeline-model-definition/src/test/resources/basic/singleArgumentNullValue.groovy
+++ b/pipeline-model-definition/src/test/resources/basic/singleArgumentNullValue.groovy
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("foo") {
+            steps {
+                milestone null
+                echo "Null is no problem"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-definition/src/test/resources/json/basic/singleArgumentNullValue.json
+++ b/pipeline-model-definition/src/test/resources/json/basic/singleArgumentNullValue.json
@@ -1,0 +1,31 @@
+{"pipeline": {
+  "stages": [  {
+    "name": "foo",
+    "branches": [    {
+      "name": "default",
+      "steps":       [
+        {
+          "name": "milestone",
+          "arguments": [          {
+            "key": "ordinal",
+            "value":             {
+              "isLiteral": true,
+              "value": null
+            }
+          }]
+        },
+        {
+          "name": "echo",
+          "arguments": [          {
+            "key": "message",
+            "value":             {
+              "isLiteral": true,
+              "value": "Null is no problem"
+            }
+          }]
+        }
+      ]
+    }]
+  }],
+  "agent": {"type": "none"}
+}}


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins-ci.org/browse/JENKINS-60115
* Description:
    * It not really a surprise that there is a code path that produces `null` from some AST element `toGroovy()`, but it really shouldn't be possible.
* Documentation changes:
    *  NA
* Users/aliases to notify:
    * None yet. 