### PR TITLE
Update plugins.jenkins.io GitHub links

### DIFF
--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -37,6 +37,12 @@
   <description>Model API for Declarative Pipeline</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 
+  <scm>
+    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
+  </scm>
+
   <dependencies>
     <!-- JSON schema stuff -->
     <dependency>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -85,6 +85,12 @@
     </plugins>
   </build>
 
+  <scm>
+    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
+  </scm>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-extensions/pom.xml
+++ b/pipeline-model-extensions/pom.xml
@@ -50,6 +50,12 @@
     </plugins>
   </build>
   
+  <scm>
+    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
+  </scm>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-stage-tags-metadata/pom.xml
+++ b/pipeline-stage-tags-metadata/pom.xml
@@ -36,6 +36,12 @@
   <description>Library plugin for Pipeline stage tag metadata</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
 
+  <scm>
+    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
+  </scm>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git://git@github.com/jenkinsci/pipeline-model-definition-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
     <tag>${scmTag}</tag>


### PR DESCRIPTION
# Fix plugins.jenkins.io GitHub links

* JENKINS issue(s):
    * No Jira issue
* Description:
    * Links to GitHub from the plugins.jenkins.io site are broken
* Documentation changes:
    * Documentation updated