### PR TITLE
Update only changed Job Properties

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -691,38 +691,40 @@ class Utils {
     }
 
     /**
-     * Compare lists of {@link ParameterDefinition}
+     * Compare lists of {@link ParameterDefinition}.
      *
-     * @param first  First list of parameter definitions
-     * @param second Second list of parameter definitions
+     * @param first  First list of parameter definitions.
+     * @param second Second list of parameter definitions.
      *
-     * @return {@code true}, if both lists of {@link ParameterDefinition} are contain same elements; {@code false} otherwise
+     * @return {@code true}, if both lists of {@link ParameterDefinition} are contain same elements;
+     * {@code false} otherwise
      */
-    private static boolean isParametersListEquals(List<ParameterDefinition> first, List<ParameterDefinition> second) {
+    private static boolean isParametersListEquals(@Nonnull List<ParameterDefinition> first,
+                                                  @Nonnull List<ParameterDefinition> second) {
         if(first.size() != second.size()){
             return false
         }
         Map<String, ParameterDefinition> firstNameToParameterMap  = first.collectEntries {[(it.name): it]}
         Map<String, ParameterDefinition> secondNameToParameterMap = second.collectEntries {[(it.name): it]}
-        //Check that all parameter's names are equals
+        // Check that all parameter's names are equals.
         if(firstNameToParameterMap.keySet() != secondNameToParameterMap.keySet()){
             return false
         }
-        //Check until first non-equal parameter
+        // Check until first non-equal parameter.
         return !firstNameToParameterMap
                 .values()
                 .any {firstParam -> !isParametersEquals(firstParam, secondNameToParameterMap[firstParam.name])}
     }
 
     /**
-     * Compare {@link ParameterDefinition} objects
+     * Compare {@link ParameterDefinition} objects.
      *
-     * @param first  First parameter definition
-     * @param second Second parameter definition
+     * @param first  First parameter definition.
+     * @param second Second parameter definition.
      *
-     * @return {@code true}, if both {@link ParameterDefinition} objects are equals; {@code false} otherwise
+     * @return {@code true}, if both {@link ParameterDefinition} objects are equals; {@code false} otherwise.
      */
-    private static boolean isParametersEquals(ParameterDefinition first, ParameterDefinition second){
+    private static boolean isParametersEquals(@Nonnull ParameterDefinition first, @Nonnull ParameterDefinition second) {
         if(first.descriptor.id != second.descriptor.id || first.description != second.description){
             return false
         }
@@ -741,7 +743,11 @@ class Utils {
      *
      * @return {@code true} if string representation of objects in XML format are equals; {@code false} otherwise
      */
-    private static boolean isObjectsEqualsXStream(Object first, Object second) {
+    private static boolean isObjectsEqualsXStream(@Nonnull Object first, @Nonnull Object second) {
+        // Same object has same XML representation
+        if(first.is(second)){
+            return true
+        }
         String firstMarshaled  = Items.XSTREAM2.toXML(first)
         String secondMarshaled = Items.XSTREAM2.toXML(second)
         return firstMarshaled == secondMarshaled

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -91,7 +91,7 @@ import java.util.concurrent.TimeUnit
  *
  * @author Andrew Bayer
  */
-@SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
+@SuppressFBWarnings(value = ["SE_NO_SERIALVERSIONID", "LI_LAZY_INIT_STATIC"])
 class Utils {
 
     /**

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -34,7 +34,6 @@ import hudson.ExtensionList
 import hudson.model.*
 import hudson.triggers.Trigger
 import jenkins.model.Jenkins
-import jnr.ffi.annotations.In
 import org.apache.commons.codec.digest.DigestUtils
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.stmt.BlockStatement
@@ -729,11 +728,12 @@ class Utils {
         if(first.descriptor.id != second.descriptor.id || first.description != second.description){
             return false
         }
-        return isObjectsEqualsXStream(first, second)
+        return Objects.equals(first, second) || isObjectsEqualsXStream(first, second)
     }
 
     /**
      * Compare objects' string representations after conversion to XML
+     * Require to use after call equals()
      *
      * Used for objects:
      * - all fields are unknown before comparison
@@ -745,10 +745,6 @@ class Utils {
      * @return {@code true} if string representation of objects in XML format are equals; {@code false} otherwise
      */
     private static boolean isObjectsEqualsXStream(@Nonnull Object first, @Nonnull Object second) {
-        // Same object has same XML representation
-        if(first.is(second)){
-            return true
-        }
         String firstMarshaled  = Items.XSTREAM2.toXML(first)
         String secondMarshaled = Items.XSTREAM2.toXML(second)
         return firstMarshaled == secondMarshaled
@@ -808,7 +804,8 @@ class Utils {
                                                      @Nonnull List<Trigger> existingTriggers) {
         Map<String, Trigger> descriptorsToExistingTriggers = existingTriggers.collectEntries{ [(it.descriptor.id):it] }
         return currentTriggers.findAll{ descriptorsToExistingTriggers[it.descriptor.id] == null ||
-                                        !isObjectsEqualsXStream(it, descriptorsToExistingTriggers[it.descriptor.id])}
+                !(Objects.equals(it, descriptorsToExistingTriggers[it.descriptor.id]) ||
+                        isObjectsEqualsXStream(it, descriptorsToExistingTriggers[it.descriptor.id]))}
     }
 
     /**
@@ -890,7 +887,8 @@ class Utils {
 
         return currentProperties.findAll{ descriptorsToExistingProperties[it.descriptor.id] == null ||
                 countMap[it.descriptor.id] > 1 ||
-                !isObjectsEqualsXStream(it, descriptorsToExistingProperties[it.descriptor.id])}
+                !(Objects.equals(it, descriptorsToExistingProperties[it.descriptor.id]) ||
+                        isObjectsEqualsXStream(it, descriptorsToExistingProperties[it.descriptor.id]))}
     }
 
     /**

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -874,7 +874,7 @@ class Utils {
      * @param currentProperties  Actual triggers for the job.
      * @param existingProperties Any triggers already defined on the job.
      *
-     * @return A list of triggers to add/update. May be empty.
+     * @return A list of properties to add/update. May be empty.
      */
     @Nonnull
     private static List<JobProperty> getPropertiesToUpdate(@CheckForNull List<JobProperty> currentProperties,
@@ -884,20 +884,19 @@ class Utils {
         return currentProperties.findAll{ descriptorsToExistingProperties[it.descriptor.id] == null ||
                 !isObjectsEqualsXStream(it, descriptorsToExistingProperties[it.descriptor.id])}
     }
-
     /**
      * Helper method for getting Triggers, which should be removed from a job.
      *
-     * @param currentTriggers  Actual triggers for the job.
-     * @param existingTriggers Any triggers already defined on the job.
+     * @param currentProperties  Actual triggers for the job.
+     * @param existingProperties Any triggers already defined on the job.
      *
-     * @return A list of triggers to remove. May be empty.
+     * @return A list of properties to remove. May be empty.
      */
     @Nonnull
-    private static List<JobProperty> getPropertiesToRemove(@CheckForNull List<JobProperty> currentTriggers,
-                                                           @Nonnull List<JobProperty> existingTriggers) {
-        Set<String> currentPropertiesDescriptors = currentTriggers.collect{ it.descriptor.id }
-        return existingTriggers.findAll{ !(it.descriptor.id in currentPropertiesDescriptors)}
+    private static List<JobProperty> getPropertiesToRemove(@CheckForNull List<JobProperty> currentProperties,
+                                                           @Nonnull List<JobProperty> existingProperties) {
+        Set<String> currentPropertiesDescriptors = currentProperties.collect{ it.descriptor.id }.toSet()
+        return existingProperties.findAll{ !(it.descriptor.id in currentPropertiesDescriptors)}
     }
 
     /**

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -592,18 +592,12 @@ class Utils {
         List<JobProperty> propsToRemove = getPropertiesToRemove(currentJobProperties, existingJobProperties)
         List<JobProperty> propsToUpdate = getPropertiesToUpdate(currentJobProperties, existingJobProperties)
 
-        List<JobProperty> jobPropertiesToApply = []
-        Set<String> seenClasses = new HashSet<>()
-        if (rawJobProperties != null) {
-            jobPropertiesToApply.addAll(rawJobProperties)
-            seenClasses.addAll(rawJobProperties.collect { it.descriptor.id })
-        }
-
         List<Trigger> currentTriggers  = getTriggersToApply(rawTriggers, existingTriggers, previousTriggers)
         List<Trigger> triggersToRemove = getTriggersToRemove(currentTriggers, existingTriggers)
         List<Trigger> triggersToUpdate = getTriggersToUpdate(currentTriggers, existingTriggers)
 
-        List<ParameterDefinition> parametersToApply = getParametersToApply(rawParameters, existingParameters, previousParameters)
+        List<ParameterDefinition> parametersToApply = getParametersToApply(rawParameters, existingParameters,
+                                                                            previousParameters)
         boolean isParametersChanged = !isParametersListEquals(parametersToApply, existingParameters)
 
         BulkChange bc = new BulkChange(j)

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -733,9 +733,9 @@ class Utils {
      * @return {@code true} if string representation of objects in XML format are equals; {@code false} otherwise
      */
     private static boolean isObjectsEqualsXStream(Object first, Object second) {
-        String firstMarshaled  = Jenkins.get().XSTREAM2.toXML(first)
-        String secondMarshaled = Jenkins.get().XSTREAM2.toXML(second)
-        return first == second
+        String firstMarshaled  = Items.XSTREAM2.toXML(first)
+        String secondMarshaled = Items.XSTREAM2.toXML(second)
+        return firstMarshaled == secondMarshaled
     }
 
     /**

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -635,9 +635,6 @@ class Utils {
             }
 
 
-            // Remove the job properties we defined in previous Jenkinsfiles but don't any more.
-            propsToRemove.each { j.removeProperty(it) }
-
             // If there are any triggers add those properties.
             if(currentTriggers.isEmpty()) {
                 // If there are no any triggers, try to remove PipelineTriggersJobProperty. It may no longer exists.
@@ -761,7 +758,7 @@ class Utils {
         Set<Trigger> toApply = new TreeSet<>(Comparator.comparing({ Trigger t -> t.descriptor.id }))
         toApply.addAll(existingTriggers)
         //Remove all triggers defined in previous Jenkinsfile and may be deprecated
-        toApply.removeAll {it.name in prevDefined}
+        toApply.removeAll {it.descriptor.id in prevDefined}
         //Replace all triggers defined in current Jenkinsfile
         toApply.addAll(newTriggers)
         return toApply.asList()
@@ -779,7 +776,7 @@ class Utils {
     private static List<Trigger> getTriggersToRemove(@CheckForNull List<Trigger> currentTriggers,
                                                      @Nonnull List<Trigger> existingTriggers) {
         Set<String> currentTriggersDescriptors = currentTriggers.collect{ it.descriptor.id }
-        return existingTriggers.findAll{ it.descriptor.id in currentTriggersDescriptors}
+        return existingTriggers.findAll{ !(it.descriptor.id in currentTriggersDescriptors) }
     }
 
     /**
@@ -818,7 +815,7 @@ class Utils {
         Set<ParameterDefinition> toApply = new TreeSet<>(Comparator.comparing({ ParameterDefinition p -> p.name }))
         toApply.addAll(existingParameters)
         //Remove all parameters defined in previous Jenkinsfile and may be deprecated
-        toApply.removeAll {it.name in prevDefined}
+        toApply.removeAll { it.name in prevDefined }
         //Replace all parameters defined in current Jenkinsfile
         toApply.addAll(newParameters)
         return toApply.asList()

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/OptionsTest.java
@@ -525,6 +525,27 @@ public class OptionsTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Test
+    public void sameJobPropertiesNotOverride() throws Exception {
+        WorkflowRun b = getAndStartNonRepoBuild("options/simpleJobProperties");
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+        WorkflowJob job = b.getParent();
+
+        BuildDiscarderProperty bdp = job.getProperty(BuildDiscarderProperty.class);
+        assertNotNull(bdp);
+        BuildDiscarder strategy = bdp.getStrategy();
+
+        WorkflowRun b2 = job.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b2));
+        WorkflowJob job2 = b2.getParent();
+
+        BuildDiscarderProperty bdp2 = job2.getProperty(BuildDiscarderProperty.class);
+        assertNotNull(bdp2);
+        BuildDiscarder strategy2 = bdp.getStrategy();
+
+        assertSame(strategy, strategy2);
+    }
+
 
     private static class DummyPrivateKey extends BaseCredentials implements SSHUserPrivateKey, Serializable {
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParametersTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParametersTest.java
@@ -148,4 +148,24 @@ public class ParametersTest extends AbstractModelDefTest {
         ParameterDefinition paramDef = newProp.getParameterDefinition("DO_NOT_DELETE");
         assertNotNull(paramDef);
     }
+
+    @Test
+    public void sameParametersNotOverride() throws Exception{
+        WorkflowRun b = getAndStartNonRepoBuild("simpleParameters");
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+
+        WorkflowJob job = b.getParent();
+        ParametersDefinitionProperty paramProp = job.getProperty(ParametersDefinitionProperty.class);
+        assertNotNull(paramProp);
+        BooleanParameterDefinition bpd = (BooleanParameterDefinition) paramProp.getParameterDefinitions().get(0);
+
+
+        WorkflowRun b2 = job.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b2));
+        WorkflowJob job2 = b2.getParent();
+        ParametersDefinitionProperty paramProp2 = job2.getProperty(ParametersDefinitionProperty.class);
+        assertNotNull(paramProp2);
+        BooleanParameterDefinition bpd2 = (BooleanParameterDefinition) paramProp2.getParameterDefinitions().get(0);
+        assertSame(bpd, bpd2);
+    }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
@@ -224,6 +224,24 @@ public class TriggersTest extends AbstractModelDefTest {
 
     }
 
+    @Test
+    public void sameTriggersNotOverride() throws Exception {
+        WorkflowRun b = getAndStartNonRepoBuild("simpleTriggers");
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+        WorkflowJob job = b.getParent();
+        PipelineTriggersJobProperty triggersJobProperty = job.getTriggersJobProperty();
+        assertNotNull(triggersJobProperty);
+        Trigger t = triggersJobProperty.getTriggers().get(0);
+
+        WorkflowRun b2 = job.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(j.waitForCompletion(b2));
+        WorkflowJob job2 = b2.getParent();
+        PipelineTriggersJobProperty triggersJobProperty2 = job2.getTriggersJobProperty();
+        assertNotNull(triggersJobProperty2);
+        Trigger t2 = triggersJobProperty2.getTriggers().get(0);
+        assertSame(t, t2);
+    }
+
     @TestExtension("doNotRestartEqualTriggers")
     public static class TestTrigger extends Trigger {
 
@@ -268,9 +286,5 @@ public class TriggersTest extends AbstractModelDefTest {
                 return true;
             }
         }
-
-
     }
-
-
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/TriggersTest.java
@@ -24,9 +24,14 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
+import hudson.Extension;
+import hudson.model.Item;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
 import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -34,13 +39,21 @@ import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty
 import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.recipes.LocalData;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.*;
 
 public class TriggersTest extends AbstractModelDefTest {
+
+    private static CountDownLatch triggerLatch;
+
     @Test
     public void simpleTriggers() throws Exception {
         WorkflowRun b = expect("simpleTriggers")
@@ -66,9 +79,9 @@ public class TriggersTest extends AbstractModelDefTest {
     @Test
     public void simpleTriggersWithOutsideVarAndFunc() throws Exception {
         WorkflowRun b = expect("simpleTriggersWithOutsideVarAndFunc")
-            .logContains("[Pipeline] { (foo)", "hello")
-            .logNotContains("[Pipeline] { (Post Actions)")
-            .go();
+                .logContains("[Pipeline] { (foo)", "hello")
+                .logNotContains("[Pipeline] { (Post Actions)")
+                .go();
 
         WorkflowJob p = b.getParent();
 
@@ -162,4 +175,102 @@ public class TriggersTest extends AbstractModelDefTest {
         expect("actualTriggerCorrectScope")
                 .go();
     }
+
+    @LocalData
+    @Test
+    public void doNotRestartEqualTriggers() throws Exception {
+        // Create countdown latch to monitor how many times
+        // a trigger has been restarted.
+        triggerLatch = new CountDownLatch(2);
+
+        // Create the first build. The DeclarativeJobPropertyTrackerAction action will be created.
+        WorkflowRun b = getAndStartNonRepoBuild("simplePipelineWithTestTrigger");
+        j.assertBuildStatusSuccess(j.waitForCompletion(b));
+
+        System.out.println("after build " + b.getId() + ": " + triggerLatch.getCount());
+
+        // Since the tracker action was not previously available,
+        // the trigger will get restarted and the latch will be decremented
+        assertTrue(triggerLatch.getCount() == 1);
+
+        WorkflowJob job = b.getParent();
+
+        // Build it again.
+        b = j.buildAndAssertSuccess(job);
+        System.out.println("after build " + b.getId() + ": " + triggerLatch.getCount());
+
+        // Since the trigger is the same (the config was not changed between builds),
+        // it will not get restarted,
+        // and the latch will NOT be decremented.
+        assertTrue(triggerLatch.getCount() == 1);
+
+        // Let simulate someone changing the trigger config
+        PipelineTriggersJobProperty triggersJobProperty = job.getProperty(PipelineTriggersJobProperty.class);
+        List<Trigger> newTriggers = new ArrayList<>();
+        TestTrigger myTrigger2 = new TestTrigger();
+        myTrigger2.setName("myTrigger2");
+        newTriggers.add(myTrigger2);
+        job.removeProperty(triggersJobProperty);
+        job.addProperty(new PipelineTriggersJobProperty(newTriggers));
+
+        // Build it again with a new trigger config
+        b = j.buildAndAssertSuccess(job);
+        System.out.println("after build " + b.getId() + ": " + triggerLatch.getCount());
+
+        // Since the trigger is now different (the config WAS changed between builds),
+        // it should get restarted,
+        // and the latch WILL be decremented.
+        assertTrue(triggerLatch.getCount() == 0);
+
+    }
+
+    @TestExtension("doNotRestartEqualTriggers")
+    public static class TestTrigger extends Trigger {
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        @DataBoundSetter
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @DataBoundConstructor
+        public TestTrigger() {
+        }
+
+        @Override
+        public void start(Item project, boolean newInstance) {
+            super.start(project, newInstance);
+            System.out.println("Calling START() for " + name);
+        }
+
+        @Override
+        public void stop() {
+            super.stop();
+            System.out.println("Calling STOP() for " + name);
+            triggerLatch.countDown();
+        }
+
+        @Override
+        public TriggerDescriptor getDescriptor() {
+            return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
+        }
+
+        @Extension
+        @Symbol("testtrigger")
+        public static final class DescriptorImpl extends TriggerDescriptor {
+            @Override
+            public boolean isApplicable(Item item) {
+                return true;
+            }
+        }
+
+
+    }
+
+
 }

--- a/pipeline-model-definition/src/test/resources/simplePipelineWithTestTrigger.groovy
+++ b/pipeline-model-definition/src/test/resources/simplePipelineWithTestTrigger.groovy
@@ -25,7 +25,9 @@
 pipeline {
     agent none
     triggers {
+        cron('@daily')
         testtrigger(name: "myTrigger1")
+        testtriggerb(name: "myTrigger2")
     }
     stages {
         stage("foo") {

--- a/pipeline-model-definition/src/test/resources/simplePipelineWithTestTrigger.groovy
+++ b/pipeline-model-definition/src/test/resources/simplePipelineWithTestTrigger.groovy
@@ -1,0 +1,39 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    triggers {
+        testtrigger(name: "myTrigger1")
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "hello"
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins-ci.org/browse/JENKINS-49500
    * https://issues.jenkins-ci.org/browse/JENKINS-44809
* Description:
    I've found a problem, that concurrent execution of the same pipeline produces a bunch of problems:
     - Jenkins saves job configuration each run, even if the configuration isn't changed. Save to the same file is blocking operation, so all parallel runs stuck for wait IO. In case of installed Job Config History Plugin IO calls multiplied 2 times due to reordering of some JobProperties during marshaling. Also, rewriting all job properties stops not changed triggers (JENKINS-49500)
     - Updating of WorkflowJob object in method `Utils.updateJobProperties()` isn't thread-safe, so it produces undefined behavior. It can't be a root cause of JENKINS-44809. 
     - One more seen issue. One thread deletes parameters, but another save this state to file (BulkChange prevent save to disk before commit only for one thread). The next run hadn't contained parameters. If a job doesn't define parameters in Jenkinsfile, the parameters will not be restored at all.

* Users/aliases to notify:
    * @abayer , @bitwiseman , @scoheb, for your  #review
