### PR TITLE
Support comparator pattern for the changeset directive

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional.java
@@ -25,6 +25,7 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.when.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.scm.ChangeLogSet;
 import hudson.util.ListBoxModel;
@@ -47,6 +48,7 @@ import java.io.IOException;
  *
  * The build must first have collected the changelog via for example <code>checkout scm</code>.
  */
+@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID")
 public class ChangeSetConditional extends DeclarativeStageConditional<ChangeSetConditional> {
 
     @Deprecated

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional.java
@@ -68,7 +68,6 @@ public class ChangeSetConditional extends DeclarativeStageConditional<ChangeSetC
         return glob;
     }
 
-    @Deprecated
     public boolean isCaseSensitive() {
         return caseSensitive;
     }
@@ -104,15 +103,14 @@ public class ChangeSetConditional extends DeclarativeStageConditional<ChangeSetC
     }
 
     @DataBoundSetter
-    @Deprecated
     public void setCaseSensitive(boolean caseSensitive) {
         this.caseSensitive = caseSensitive;
     }
 
-    public boolean changeSetMatches(ChangeLogSet.Entry change, String pattern) {
+    public boolean changeSetMatches(ChangeLogSet.Entry change, String pattern, boolean caseSensitive) {
         Comparator c = Comparator.get(comparator, Comparator.GLOB);
 
-        return change.getAffectedPaths().stream().anyMatch(path -> c.compare(pattern, path));
+        return change.getAffectedPaths().stream().anyMatch(path -> c.compare(pattern, path, caseSensitive));
     }
 
     @Extension

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/utils/Comparator.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/utils/Comparator.java
@@ -45,17 +45,17 @@ public enum Comparator {
      */
     GLOB(Messages._Comparator_GLOB_DisplayName()) {
         @Override
-        public boolean compare(@Nonnull String pattern, String actual, boolean... caseSensitive) {
-            boolean isCaseSensitive = false;
-            if (caseSensitive.length > 0) {
-                isCaseSensitive = caseSensitive[0];
-            }
+        public boolean compare(@Nonnull String pattern, String actual) {
+            return compare(pattern, actual, false);
+        }
+        @Override
+        public boolean compare(@Nonnull String pattern, String actual, boolean caseSensitive) {
             actual = defaultIfBlank(actual, "");
             // replace with the platform specific directory separator before
             // invoking Ant's platform specific path matching.
             String safeCompare = pattern.replace('/', File.separatorChar);
             String safeName = actual.replace('/', File.separatorChar);
-            return SelectorUtils.matchPath(safeCompare, safeName, isCaseSensitive);
+            return SelectorUtils.matchPath(safeCompare, safeName, caseSensitive);
         }
     },
     /**
@@ -63,10 +63,14 @@ public enum Comparator {
      */
     REGEXP(Messages._Comparator_REGEXP_DisplayName()) {
         @Override
-        public boolean compare(@Nonnull String pattern, String actual, boolean... caseSensitive) {
+        public boolean compare(@Nonnull String pattern, String actual) {
             actual = defaultIfBlank(actual, "");
             //TODO validation for pattern compile
             return actual.matches(pattern);
+        }
+        @Override
+        public boolean compare(@Nonnull String pattern, String actual, boolean caseSensitive) {
+            return compare(pattern, actual);
         }
     },
     /**
@@ -74,9 +78,13 @@ public enum Comparator {
      */
     EQUALS(Messages._Comparator_EQUALS_DisplayName()) {
         @Override
-        public boolean compare(@Nonnull String pattern, String actual, boolean... caseSensitive) {
+        public boolean compare(@Nonnull String pattern, String actual) {
             actual = defaultIfBlank(actual, "");
             return actual.equals(pattern);
+        }
+        @Override
+        public boolean compare(@Nonnull String pattern, String actual, boolean caseSensitive) {
+            return compare(pattern, actual);
         }
     };
 
@@ -97,7 +105,15 @@ public enum Comparator {
      * @param caseSensitive whether the comparison will be case-sensitive. Only for the GLOB comparator
      * @return true if matching
      */
-    public abstract boolean compare(String pattern, String actual, boolean... caseSensitive);
+    public abstract boolean compare(String pattern, String actual, boolean caseSensitive);
+
+    /**
+     * Compare the two strings
+     * @param pattern the pattern/value to check for
+     * @param actual the value to check
+     * @return true if matching
+     */
+    public abstract boolean compare(String pattern, String actual);
 
     public static Comparator get(String name, Comparator defaultValue) {
         if (StringUtils.isEmpty(name)) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/utils/Comparator.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/utils/Comparator.java
@@ -45,13 +45,17 @@ public enum Comparator {
      */
     GLOB(Messages._Comparator_GLOB_DisplayName()) {
         @Override
-        public boolean compare(@Nonnull String pattern, String actual) {
+        public boolean compare(@Nonnull String pattern, String actual, boolean... caseSensitive) {
+            boolean isCaseSensitive = false;
+            if (caseSensitive.length > 0) {
+                isCaseSensitive = caseSensitive[0];
+            }
             actual = defaultIfBlank(actual, "");
             // replace with the platform specific directory separator before
             // invoking Ant's platform specific path matching.
             String safeCompare = pattern.replace('/', File.separatorChar);
             String safeName = actual.replace('/', File.separatorChar);
-            return SelectorUtils.matchPath(safeCompare, safeName, false);
+            return SelectorUtils.matchPath(safeCompare, safeName, isCaseSensitive);
         }
     },
     /**
@@ -59,7 +63,7 @@ public enum Comparator {
      */
     REGEXP(Messages._Comparator_REGEXP_DisplayName()) {
         @Override
-        public boolean compare(@Nonnull String pattern, String actual) {
+        public boolean compare(@Nonnull String pattern, String actual, boolean... caseSensitive) {
             actual = defaultIfBlank(actual, "");
             //TODO validation for pattern compile
             return actual.matches(pattern);
@@ -70,7 +74,7 @@ public enum Comparator {
      */
     EQUALS(Messages._Comparator_EQUALS_DisplayName()) {
         @Override
-        public boolean compare(@Nonnull String pattern, String actual) {
+        public boolean compare(@Nonnull String pattern, String actual, boolean... caseSensitive) {
             actual = defaultIfBlank(actual, "");
             return actual.equals(pattern);
         }
@@ -90,9 +94,10 @@ public enum Comparator {
      * Compare the two strings
      * @param pattern the pattern/value to check for
      * @param actual the value to check
+     * @param caseSensitive whether the comparison will be case-sensitive. Only for the GLOB comparator
      * @return true if matching
      */
-    public abstract boolean compare(String pattern, String actual);
+    public abstract boolean compare(String pattern, String actual, boolean... caseSensitive);
 
     public static Comparator get(String name, Comparator defaultValue) {
         if (StringUtils.isEmpty(name)) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/config.jelly
@@ -29,7 +29,7 @@
         <f:textbox/>
     </f:entry>
     <f:entry field="caseSensitive">
-        <f:checkbox title="Case-sensitive path/file matching" checked="false"/>
+        <f:checkbox title="Case-sensitive path/file matching only for the GLOB comparator" checked="false"/>
     </f:entry>
     <f:advanced>
         <f:entry field="comparator" title="Comparator">

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help-caseSensitive.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help-caseSensitive.html
@@ -23,5 +23,5 @@
   -->
 
 <p>
-    If true, the comparison will be case-sensitive. Defaults to false.
+    If true, the comparison will be case-sensitive only for the GLOB comparator. Defaults to false.
 </p>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help-comparator.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help-comparator.html
@@ -1,7 +1,7 @@
 <!--
   ~ The MIT License
   ~
-  ~ Copyright (c) 2017, CloudBees, Inc.
+  ~ Copyright (c) 2019, CloudBees, Inc., Elasticsearch B.V.
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -20,9 +20,17 @@
   ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   ~ THE SOFTWARE.
+  ~
   -->
 
 <p>
-    The string to look for in the list of changed files. Can be a wildcard, using
-    <a href='http://ant.apache.org/manual/Types/fileset.html'>Ant-style globs</a>.
+    What way to compare the pattern specified to the actual value.
+    <!-- TODO Update when new Comparators are added-->
+    Possible values are:
+<ul>
+    <li><strong>EQUALS</strong> - A plain string comparison</li>
+    <li><strong>GLOB</strong> - <a href="https://ant.apache.org/manual/dirtasks.html#patterns">ANT style pattern</a></li>
+    <li><strong>REGEXP</strong> - <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">Regular Expression</a></li>
+</ul>
+If not specified <strong>GLOB</strong> will be used as default.
 </p>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help-pattern.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help-pattern.html
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ The MIT License
   ~
-  ~ Copyright (c) 2018, CloudBees, Inc.
+  ~ Copyright (c) 2017, CloudBees, Inc.
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -23,17 +22,11 @@
   ~ THE SOFTWARE.
   -->
 
-<?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry field="pattern" title="File/path pattern to match against changeset">
-        <f:textbox/>
-    </f:entry>
-    <f:entry field="caseSensitive">
-        <f:checkbox title="Case-sensitive path/file matching" checked="false"/>
-    </f:entry>
-    <f:advanced>
-        <f:entry field="comparator" title="Comparator">
-            <f:select/>
-        </f:entry>
-    </f:advanced>
-</j:jelly>
+<p>
+    The pattern to compare the actual value with.
+</p>
+
+<p>
+    If <code>comparator</code> is not specified it will be evaluated as an <a href="http://ant.apache.org/manual/Types/fileset.html">Ant-style globs</a>.
+    E.g: **/*.java
+</p>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help.html
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditional/help.html
@@ -23,5 +23,5 @@
   -->
 
 <p>
-    Execute the stage if the build's SCM changeset contains one or more files matching the given string or glob.
+    Execute the stage if the build's SCM changeset contains one or more files matching the given pattern.
 </p>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditionalScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditionalScript.groovy
@@ -37,6 +37,6 @@ class ChangeSetConditionalScript extends AbstractChangelogConditionalScript<Chan
 
     @Override
     boolean matches(ChangeLogSet.Entry change) {
-        return describable.changeSetMatches(change, describable.pattern)
+        return describable.changeSetMatches(change, describable.pattern, describable.caseSensitive)
     }
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditionalScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeSetConditionalScript.groovy
@@ -26,7 +26,6 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.when.impl
 
 import hudson.scm.ChangeLogSet
-import org.apache.tools.ant.types.selectors.SelectorUtils
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class ChangeSetConditionalScript extends AbstractChangelogConditionalScript<ChangeSetConditional> {
@@ -37,15 +36,7 @@ class ChangeSetConditionalScript extends AbstractChangelogConditionalScript<Chan
     }
 
     @Override
-    void initializeEval() {
-        glob = describable.glob.replace('\\', '/')
-    }
-
-    @Override
     boolean matches(ChangeLogSet.Entry change) {
-        return change.affectedPaths.any { String path ->
-            path = path.replace('\\', '/')
-            return SelectorUtils.matchPath(glob, path, describable.isCaseSensitive())
-        }
+        return describable.changeSetMatches(change, describable.pattern)
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageMultibranchTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageMultibranchTest.java
@@ -76,7 +76,9 @@ public class WhenStageMultibranchTest extends AbstractModelDefTest {
         assertNotNull(build);
         j.assertLogContains("Hello", build);
         j.assertLogContains("Stage \"Two\" skipped due to when conditional", build);
+        j.assertLogContains("Stage \"Three\" skipped due to when conditional", build);
         j.assertLogNotContains("JS World", build);
+        j.assertLogNotContains("With regexp", build);
 
         controller.addFile("repoX", crNum,
                 "files",
@@ -89,7 +91,9 @@ public class WhenStageMultibranchTest extends AbstractModelDefTest {
 
         j.assertLogContains("Hello", build2);
         j.assertLogContains("JS World", build2);
+        j.assertLogContains("With regexp", build2);
         j.assertLogNotContains("Stage \"Two\" skipped due to when conditional", build2);
+        j.assertLogNotContains("Stage \"Three\" skipped due to when conditional", build2);
         j.assertLogNotContains("Warning, empty changelog", build2);
 
         controller.addFile("repoX", crNum,
@@ -103,8 +107,10 @@ public class WhenStageMultibranchTest extends AbstractModelDefTest {
 
         j.assertLogContains("Hello", build3);
         j.assertLogContains("JS World", build3);
+        j.assertLogContains("With regexp", build3);
         j.assertLogContains("Examining changelog from all builds of this change request", build3);
         j.assertLogNotContains("Stage \"Two\" skipped due to when conditional", build3);
+        j.assertLogNotContains("Stage \"Three\" skipped due to when conditional", build3);
         j.assertLogNotContains("Warning, empty changelog", build3);
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/utils/ComparatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/utils/ComparatorTest.java
@@ -30,6 +30,8 @@ public class ComparatorTest {
     assertFalse(comparator.compare("foo*", null));
     assertFalse(comparator.compare("foo*", ""));
     assertTrue(comparator.compare("foo*", "football"));
+    assertTrue(comparator.compare("foo*", "FOOtball"));
+    assertFalse(comparator.compare("foo*", "Football", true));
   }
 
   @Test

--- a/pipeline-model-definition/src/test/resources/json/when/conditions/changelog/changeset.json
+++ b/pipeline-model-definition/src/test/resources/json/when/conditions/changelog/changeset.json
@@ -38,6 +38,29 @@
           "value": "**/*.js"
         }
       }]}
+    },
+    {
+      "name": "Three",
+      "branches": [      {
+        "name": "default",
+        "steps": [        {
+          "name": "echo",
+          "arguments": [          {
+            "key": "message",
+            "value":             {
+              "isLiteral": true,
+              "value": "With regexp"
+            }
+          }]
+        }]
+      }],
+      "when": {"conditions": [      {
+        "name": "changeset",
+        "arguments":         {
+          "isLiteral": true,
+          "value": ".*\\.js"
+        }
+      }]}
     }
   ],
   "agent":   {

--- a/pipeline-model-definition/src/test/resources/when/conditions/changelog/changeset.groovy
+++ b/pipeline-model-definition/src/test/resources/when/conditions/changelog/changeset.groovy
@@ -41,7 +41,14 @@ pipeline {
                 script {
                     echo "JS World"
                 }
-
+            }
+        }
+        stage("Three") {
+            when {
+                changeset pattern: '.*\\.js', comparator: 'regexp'
+            }
+            steps {
+                echo "With regexp"
             }
         }
     }


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-60217](https://issues.jenkins-ci.org/browse/JENKINS-60217)
* Description:
    * Uses the `comparator` argument as already done with `tag` and `branch`.
* Documentation changes:
    * `help-*.html`.
    * https://github.com/jenkins-infra/jenkins.io/pull/2664
* Users/aliases to notify:

## Questions
- `caseSensitive` might not be relevant anymore as the `(?i)` with the `REGEXP` comparator should be enough. Do you think it might be worth to deprecate it? Or just remove it?



