### PR TITLE
Store full pipeline definition in ExecutionModelAction and add abstract ModelValidator class

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/ModelASTPipelineDef.java
@@ -118,7 +118,7 @@ public final class ModelASTPipelineDef extends ModelASTElement {
     @Override
     public void removeSourceLocation() {
         super.removeSourceLocation();
-        removeSourceLocationsFrom(stages, libraries, postBuild, environment, tools, options, parameters, triggers);
+        removeSourceLocationsFrom(agent, stages, libraries, postBuild, environment, tools, options, parameters, triggers);
     }
 
     private static String indent(int count) {

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/AbstractModelValidator.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/AbstractModelValidator.java
@@ -1,0 +1,233 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.validator;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTAxis;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTAxisContainer;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildCondition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildConditionsContainer;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildParameter;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildParameters;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTEnvironment;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTExclude;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTExcludeAxis;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTExcludes;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTInternalFunctionCall;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTLibraries;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMatrix;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTParallel;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostBuild;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStageBase;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStageInput;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTools;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTrigger;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTriggers;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhen;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenCondition;
+
+/**
+ * Abstract implementation of {@link ModelValidator}.
+ *
+ * Use this class as a generic AST visitor instead of {@link ModelValidator} to prevent binary compatibility issues
+ * in cases where it is fine to ignore any AST elements that were added to Declarative after you extended this class.
+ */
+public class AbstractModelValidator implements ModelValidator {
+
+    @Override
+    public boolean validateElement(ModelASTAgent agent) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBranch branch) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildConditionsContainer container) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTPostBuild postBuild) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTPostStage post) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildCondition buildCondition) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTEnvironment environment) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTTools tools) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStep step) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTWhen when) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTMethodCall methodCall) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTOptions properties) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTTriggers triggers) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildParameters buildParameters) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTOption jobProperty) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTTrigger trigger) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildParameter buildParameter) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTPipelineDef pipelineDef) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStageBase stage) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStage stage, boolean isWithinParallel) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStages stages) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTParallel parallel) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTMatrix matrix) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTAxisContainer axes) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTAxis axis) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTExcludes excludes) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTExclude exclude) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTExcludeAxis axis) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTLibraries libraries) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTWhenCondition condition) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTInternalFunctionCall call) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStageInput input) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTValue value) {
+        return true;
+    }
+}

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidator.java
@@ -28,6 +28,16 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.validator;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.*;
 
 
+/**
+ * A visitor interface that can be used to traverse the AST of a Declarative Pipeline.
+ *
+ * Warning: Do not implement this interface directly in non-Declarative plugins, because this interface is unstable and
+ * may receive backwards-incompatible changes. Instead, use {@link AbstractModelValidator}, which will retain backwards
+ * compatibility.
+ *
+ * @see AbstractModelValidator
+ * @see ModelASTPipelineDef#validate
+ */
 public interface ModelValidator {
     boolean validateElement(ModelASTAgent agent);
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -82,7 +82,7 @@ class RuntimeASTTransformer {
     }
 
     /**
-     * Given a run, transform a {@link ModelASTPipelineDef}, attach the {@link ModelASTStages} for that {@link ModelASTPipelineDef} to the
+     * Given a run, transform a {@link ModelASTPipelineDef}, attach the {@link ModelASTPipelineDef} to the
      * run, and return an {@link ArgumentListExpression} containing a closure that returns the {@Root} we just created.
      */
     @Nonnull
@@ -90,13 +90,12 @@ class RuntimeASTTransformer {
         wrapper = new Wrapper(sourceUnit, pipelineDef)
         Expression root = transformRoot(pipelineDef)
         if (run != null) {
-            ModelASTStages stages = pipelineDef.stages
-            stages.removeSourceLocation()
+            pipelineDef.removeSourceLocation()
             ExecutionModelAction action = run.getAction(ExecutionModelAction.class)
             if (action == null) {
-                run.addAction(new ExecutionModelAction(stages))
+                run.addAction(new ExecutionModelAction(pipelineDef))
             } else {
-                action.addStages(stages)
+                action.addPipelineDef(pipelineDef)
                 run.save()
             }
         }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/ExecutionModelAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/ExecutionModelAction.java
@@ -25,42 +25,85 @@
 package org.jenkinsci.plugins.pipeline.modeldefinition.actions;
 
 import hudson.model.InvisibleAction;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.CheckForNull;
 
 public class ExecutionModelAction extends InvisibleAction {
-    private ModelASTStages stages;
     private String stagesUUID;
-    private List<ModelASTStages> stagesList = new ArrayList<>();
+    private List<ModelASTPipelineDef> pipelineDefs = new ArrayList<>();
 
-    public ExecutionModelAction(ModelASTStages s) {
-        this.stagesList.add(s);
-        this.stages = null;
+    /**
+     * Only present for backwards compatibility during deserialization, null in all other cases.
+     */
+    @Deprecated
+    private @CheckForNull ModelASTStages stages;
+    /**
+     * Only present for backwards compatibility during deserialization, null in all other cases.
+     */
+    @Deprecated
+    private @CheckForNull List<ModelASTStages> stagesList;
+
+    public ExecutionModelAction(ModelASTPipelineDef pipeline) {
+        this.pipelineDefs.add(pipeline);
     }
 
-    public ExecutionModelAction(List<ModelASTStages> s) {
-        this.stagesList.addAll(s);
-        this.stages = null;
+    /**
+     * @deprecated Use {@link #ExecutionModelAction(ModelASTPipelineDef)} instead.
+     */
+    @Deprecated
+    public ExecutionModelAction(ModelASTStages s) {
+        this(createDummyPipelineDef(s));
+    }
+
+    /**
+     * @deprecated Use {@link #ExecutionModelAction(ModelASTPipelineDef)} and {@link #addPipelineDef} instead.
+     */
+    @Deprecated
+    public ExecutionModelAction(List<ModelASTStages> stages) {
+        for (ModelASTStages s : stages) {
+            pipelineDefs.add(createDummyPipelineDef(s));
+        }
     }
 
     protected Object readResolve() throws IOException {
-        if (this.stages != null) {
-            if (this.stagesList == null) {
-                this.stagesList = new ArrayList<>();
+        // Originally, `stages` was the only field in this class. `stagesList` was added to support Pipelines that use
+        // Declarative more than once. If `stages` is non-null, `stagesList` is null, and vice-versa. For instances
+        // created after `pipelinedefs` was added, both `stagesList` and `stages` will be null.
+        if (pipelineDefs == null) {
+            pipelineDefs = new ArrayList<>();
+        }
+        if (stages != null) {
+            pipelineDefs.add(createDummyPipelineDef(stages));
+            stages = null;
+        } else if (stagesList != null) {
+            for (ModelASTStages s : stagesList) {
+                pipelineDefs.add(createDummyPipelineDef(s));
             }
-            this.stagesList.add(stages);
-            
-            this.stages = null;
+            stagesList = null;
         }
         return this;
     }
 
+    /**
+     * Create an {@link ModelASTPipelineDef} from a {@link ModelASTStages} object.
+     *
+     * Only used for backwards compatibility in cases where we do not have the full {@link ModelASTPipelineDef}.
+     */
+    private static ModelASTPipelineDef createDummyPipelineDef(ModelASTStages s) {
+        ModelASTPipelineDef dummyDef = new ModelASTPipelineDef(null);
+        dummyDef.setStages(s);
+        return dummyDef;
+    }
+
     public ModelASTStages getStages() {
-        for (ModelASTStages s : stagesList) {
+        for (ModelASTPipelineDef p : pipelineDefs) {
+            ModelASTStages s = p.getStages();
             if (s.getUuid().toString().equals(stagesUUID)) {
                 return s;
             }
@@ -77,10 +120,49 @@ public class ExecutionModelAction extends InvisibleAction {
     }
 
     public List<ModelASTStages> getStagesList() {
-        return Collections.unmodifiableList(stagesList);
+        List<ModelASTStages> stages = new ArrayList<>();
+        for (ModelASTPipelineDef p : pipelineDefs) {
+            stages.add(p.getStages());
+        }
+        return Collections.unmodifiableList(stages);
     }
 
+    /**
+     * @deprecated Use {@link #addPipeline} instead.
+     */
+    @Deprecated
     public void addStages(ModelASTStages s) {
-        this.stagesList.add(s);
+        ModelASTPipelineDef dummyDefForBackwardsCompat = new ModelASTPipelineDef(null);
+        dummyDefForBackwardsCompat.setStages(s);
+        this.pipelineDefs.add(dummyDefForBackwardsCompat);
+    }
+
+    /**
+     * Get the main {@link ModelASTPipelineDef} for the build, returning {@code null} if there isn't one or it
+     * can't be found.
+     *
+     * @see #getPipelineDefs
+     */
+    public ModelASTPipelineDef getPipelineDef() {
+        for (ModelASTPipelineDef p : pipelineDefs) {
+            if (p.getStages().getUuid().toString().equals(stagesUUID)) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return an unmodifiable list of all instances of {@link ModelASTPipelineDef} attached to the build, including
+     * those from shared libraries.
+     *
+     * @see #getPipelineDef
+     */
+    public List<ModelASTPipelineDef> getPipelineDefs() {
+        return Collections.unmodifiableList(pipelineDefs);
+    }
+
+    public void addPipelineDef(ModelASTPipelineDef p) {
+        this.pipelineDefs.add(p);
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/ExecutionModelAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/ExecutionModelAction.java
@@ -128,7 +128,7 @@ public class ExecutionModelAction extends InvisibleAction {
     }
 
     /**
-     * @deprecated Use {@link #addPipeline} instead.
+     * @deprecated Use {@link #addPipelineDef} instead.
      */
     @Deprecated
     public void addStages(ModelASTStages s) {

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -166,14 +166,44 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         ExecutionModelAction action = b.getAction(ExecutionModelAction.class);
         assertNotNull(action);
         ModelASTStages stages = action.getStages();
-        assertNull(stages.getSourceLocation());
+        assertExecutionModelActionStageContents(b, stages);
+    }
+
+    @Test
+    public void executionModelActionFullPipeline() throws Exception {
+        WorkflowRun b = expect("executionModelAction").go();
+
+        ExecutionModelAction action = b.getAction(ExecutionModelAction.class);
+        assertNotNull(action);
+        ModelASTPipelineDef pipeline = action.getPipelineDef();
+        assertNull(pipeline.getSourceLocation());
+
+        ModelASTAgent agent = pipeline.getAgent();
+        assertNotNull(agent);
+        assertEquals("none", agent.getAgentType().getKey());
+
+        ModelASTEnvironment env = pipeline.getEnvironment();
+        assertNotNull(env);
+        ModelASTKey var = new ModelASTKey(null);
+        var.setKey("VAR");
+        ModelASTValue val = (ModelASTValue) env.getVariables().get(var);
+        assertNotNull(val);
+        assertTrue(val.isLiteral());
+        assertEquals("VALUE", val.getValue());
+
+        ModelASTStages stages = pipeline.getStages();
+        assertExecutionModelActionStageContents(b, stages);
+    }
+
+    private void assertExecutionModelActionStageContents(WorkflowRun b, ModelASTStages stages) throws Exception {
         assertNotNull(stages);
+        assertNull(stages.getSourceLocation());
 
         assertEquals(1, stages.getStages().size());
 
         ModelASTStage stage = stages.getStages().get(0);
-        assertNull(stage.getSourceLocation());
         assertNotNull(stage);
+        assertNull(stage.getSourceLocation());
 
         assertEquals(2, stage.getBranches().size());
 

--- a/pipeline-model-definition/src/test/resources/executionModelAction.groovy
+++ b/pipeline-model-definition/src/test/resources/executionModelAction.groovy
@@ -24,6 +24,9 @@
 
 pipeline {
     agent none
+    environment {
+        VAR = "VALUE"
+    }
     stages {
         stage("foo") {
             steps {


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-60531](https://issues.jenkins-ci.org/browse/JENKINS-60531)
* Description:
    * Developer-only change. Right now, there are two issues that make it difficult to use the Declarative AST from another plugin to statically analyze a Declarative Pipeline:
      * `ExecutionModelAction` does not contain the full Pipeline, only the stages, so there is no way to analyze the top-level agent, options, environment, etc. My proposed fix for this issue is to make `ExecutionModelAction` store the full Pipeline going forward, along with implementing a bit of compatibility code for old builds where only the stages were stored.
      * I think the best way to walk/analyze the AST of a Declarative Pipeline is to use `ModelValidator` from `pipeline-model-api`, however, that interface recently got some incompatible changes (new methods were added) in relation to the matrix feature. If any other plugins were using that interface, it would have broken binary compatibility. 

        I'm not sure about the best way to prevent this kind of issue going forward, so this PR just adds a new `AbstractModelValidator` class that implements the `ModelValidator` interface and does nothing in all methods. Whenever `ModelValidator` gets incompatible changes (methods added), the idea would be to change the implementation of `AbstractModelValidator` to preserve binary compatibility. A different approach could be to add some notes to `ModelValidator` explaining that any new methods that are added need to be a `default` method to avoid issues with binary compatibility, and that methods cannot be removed/renamed.
* Documentation changes:
    * None? (I don't think anything extensive is needed for developer-only changes, but not sure what is normally done for this kind of thing).

