### PR TITLE
Remove dependency on obsolete tests jar for workflow-scm-step

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -271,12 +271,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-scm-step</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
         <classifier>tests</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -121,13 +121,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>2.6</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-scm-step</artifactId>
-        <version>2.6</version>
-        <classifier>tests</classifier>
+        <version>2.9</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
* JENKINS issue(s):
    * N/A
* Description:
    * Previously, workflow-scm-step releases included a `-tests` jar with some utilities. Long ago, in https://github.com/jenkinsci/workflow-scm-step-plugin/pull/15 those utilities were moved to other plugins, and in https://github.com/jenkinsci/workflow-scm-step-plugin/pull/17, workflow-scm-step was changed to no longer publish a tests jar. pipeline-model-definition still depends on an older version of workflow-scm-step where the `-tests` jar was present, which causes a compilation failure in the PCT when run against newer versions of workflow-scm-step. Since the utilities were moved to other plugins that are already in use here, I think it should be safe to just remove the dependency, but if the CI build fails I might need to tweak some test imports.
      
* Documentation changes:
    * Only affects testing using the PCT, no doc changes necessary.
* Users/aliases to notify:
    * N/A
