### PR TITLE
Change urls for each plugin to point to GitHub

### DIFF
--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -35,7 +35,7 @@
   <packaging>hpi</packaging>
   <name>Pipeline: Model API</name>
   <description>Model API for Declarative Pipeline</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
+  <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
 
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -35,7 +35,7 @@
   <packaging>hpi</packaging>
   <name>Pipeline: Declarative</name>
   <description>An opinionated, declarative Pipeline</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
+  <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
 
   <build>
     <plugins>

--- a/pipeline-model-extensions/pom.xml
+++ b/pipeline-model-extensions/pom.xml
@@ -35,7 +35,7 @@
   <packaging>hpi</packaging>
   <name>Pipeline: Declarative Extension Points API</name>
   <description>APIs for extension points used in Declarative Pipelines</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
+  <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
 
   <build>
     <plugins>

--- a/pipeline-stage-tags-metadata/pom.xml
+++ b/pipeline-stage-tags-metadata/pom.xml
@@ -34,7 +34,7 @@
   <packaging>hpi</packaging>
   <name>Pipeline: Stage Tags Metadata</name>
   <description>Library plugin for Pipeline stage tag metadata</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Model+Definition+Plugin</url>
+  <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
 
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>


### PR DESCRIPTION
* JENKINS issue(s):
    * N/A
* Description:
    * https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/358 only changed the URL for the parent, not each plugin, so pages like https://plugins.jenkins.io/pipeline-model-definition and https://plugins.jenkins.io/pipeline-model-extensions are still sourcing their content from the wiki instead of GitHub (note the lack of badges on those pages, even though the badges are present here on GitHub). 
* Documentation changes:
    * N/A
* Users/aliases to notify:
    * N/A
