### PR TITLE
Remove content that is dynamically generated on plugins.jenkins.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,6 @@
 
 The Pipeline Model Definition Plugin provides a config-like syntax for defining Pipelines - thus Declarative Pipeline.
 
-This plugin requires Jenkins 2.121.1 or later
-
-**WARNING**:
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
--   [Script Security sandbox
-    bypass](https://jenkins.io/security/advisory/2019-01-08/#SECURITY-1266)
-
 ## Documentation
 
 * [User guide and syntax reference](https://jenkins.io/doc/book/pipeline/)


### PR DESCRIPTION
The minimum Jenkins version was out of date, and the right version is automatically added to the plugin site, here is a screenshot:

<img width="274" alt="Screen Shot 2020-01-30 at 13 49 07" src="https://user-images.githubusercontent.com/1068968/73480182-6a293780-4367-11ea-94fe-dac40d8f8385.png">

Similarly, the security warnings are automatically added to the sidebar on the right-hand side of the page:

<img width="417" alt="Screen Shot 2020-01-30 at 13 49 12" src="https://user-images.githubusercontent.com/1068968/73480215-7b724400-4367-11ea-9051-7280ae1be0c7.png">


