### PR TITLE
JENKINS-60994 Fixing timeout tests

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ProvisioningTimeoutModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ProvisioningTimeoutModelDefTest.java
@@ -25,12 +25,12 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 
 import hudson.model.Result;
 import hudson.model.Slave;
-import hudson.slaves.RetentionStrategy;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 
 /**
@@ -38,21 +38,15 @@ import org.jvnet.hudson.test.Issue;
  *
  * The goal of this test is check the nuances between top level and stage level agents regarding timeouts (options)
  *  Top Level Agents: timeout is only for the build itself, therefore won't fail.
- *  Stage Level Agents: timeout includes provisioning, in this example is +200ms
+ *  Stage Level Agents: timeout includes provisioning, in this example is +600ms
  *
  * Jira Ticket JENKINS-60994 to describe this problem.
  */
 @RunWith(Parameterized.class)
 public class ProvisioningTimeoutModelDefTest extends AbstractModelDefTest {
 
-    private static Slave s;
-
-    @BeforeClass
-    public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setNumExecutors(1);
-        s.setLabelString("some-label docker");
-    }
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
 
     @Parameterized.Parameters
     public static Object[][] data() {

--- a/pipeline-model-definition/src/test/resources/options/stageLevelAgentFailsWithTimeout.groovy
+++ b/pipeline-model-definition/src/test/resources/options/stageLevelAgentFailsWithTimeout.groovy
@@ -32,7 +32,6 @@ pipeline {
                 timeout(time: 1200, unit: "MILLISECONDS")
             }
             steps {
-                echo "hello"
                 sleep 1
             }
         }

--- a/pipeline-model-definition/src/test/resources/options/topLevelAgentSuccessWithTimeout.groovy
+++ b/pipeline-model-definition/src/test/resources/options/topLevelAgentSuccessWithTimeout.groovy
@@ -25,12 +25,11 @@
 pipeline {
     agent any
     options {
-        timeout(time: 1200, unit: "MILLISECONDS")
+        timeout(time: 1600, unit: "MILLISECONDS")
     }
     stages {
         stage("foo") {
                 steps {
-                echo "hello"
                 sleep 1
             }
         }


### PR DESCRIPTION
This PR is for amending [#376](https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/376)
 regarding https://issues.jenkins-ci.org/browse/JENKINS-60994

Documentation changes:
jenkins-infra/jenkins.io#2853