### PR TITLE
[JENKINS-61007] Do not use @SuppressFBWarnings in src/main/resources/**/*.groovy

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -25,8 +25,6 @@ package org.jenkinsci.plugins.pipeline.modeldefinition
 
 import com.cloudbees.groovy.cps.NonCPS
 import com.cloudbees.groovy.cps.impl.CpsClosure
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import hudson.FilePath
 import hudson.Launcher
 import hudson.model.Result
@@ -812,7 +810,6 @@ class ModelInterpreter implements Serializable {
      *
      * @author Falko Modler
      */
-    @SuppressFBWarnings(value="SE_NO_SERIALVERSIONID")
     private class WhenEvaluator implements Serializable {
 
         final StageConditionals when


### PR DESCRIPTION
[JENKINS-61007](https://issues.jenkins-ci.org/browse/JENKINS-61007)

Apparently the annotation introduced in #356 cannot be resolved in this context. Groovy may have different rules for lax resolution of annotations than Java. I do not know how to reproduce inside a functional test due to the different class loading environment. Anyway, I can confirm that this patch fixes the problem for me locally.