### PR TITLE
[JENKINS-58732] Make docker-workflow dep optional

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -140,6 +140,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>docker-workflow</artifactId>
       <scope>runtime</scope> <!-- TODO unused, just here to encourage upgrades -->
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
As mentioned in https://github.com/jenkinsci/kubernetes-plugin/pull/735, follows up #373 to make this dependency optional so `docker-workflow` could actually be disabled. (Tested that scenario via `hpi:run`.)