### PR TITLE
Clarify "cannot be used as a value directly" to mean "add quotes"

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/Messages.properties
@@ -30,7 +30,7 @@ Parser.MultipleOfSection=Multiple occurrences of the {0} section
 Parser.Triggers=Triggers
 Parser.UndefinedSection=Undefined section "{0}"
 
-ModelParser.BareDollarCurly={0} cannot be used as a value directly. Did you mean "{0}"?
+ModelParser.BareDollarCurly={0} cannot be used as a value directly. Did you mean "{0}"? (add quotes)
 ModelParser.BigIntegerValue=BigIntegers cannot be used as constants in Declarative. The maximum value for an integer is 9,223,372,036,854,775,807 and the minimum value for an integer is -9,223,372,036,854,775,808.
 ModelParser.CannotHaveBlocks={0} definitions cannot have blocks
 ModelParser.DuplicateEnvVar=Duplicate environment variable name: "{0}"


### PR DESCRIPTION
Just saw this message in an error and I couldn't figure it out, and searched for the error message and arrived at this code, I think clarifying this error message to include human language describing the change needed would be a better developer experience. 
>${param.slack_channel} cannot be used as a value directly. Did you mean "${param.slack_channel}"
