### PR TITLE
Remove dependency on pipeline-model-declarative-agent

### DIFF
--- a/pipeline-model-declarative-agent/README.md
+++ b/pipeline-model-declarative-agent/README.md
@@ -1,0 +1,1 @@
+This plugin is deprecated, please use [Pipeline: Declarative](https://plugins.jenkins.io/pipeline-model-definition/) plugin instead.

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -180,13 +180,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-input-step</artifactId>
     </dependency>
-    <!-- Dependency on tombstoned declarative agent plugin to make sure we don't end up with a
-    bad old version installed -->
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-declarative-agent</artifactId>
-      <version>1.1.1</version>
-    </dependency>
 
     <!-- TEST deps -->
     <dependency>


### PR DESCRIPTION
... and provide simple readme that can be displayed on plugins.jenkins.io for the deprecated plugin (AFAIK it doesn't have its own repo).

Note that <0.5% of declarative-agent users are not using the tombstone release and out of those  most are on old cores: https://stats.jenkins.io/pluginversions/pipeline-model-declarative-agent.html