### PR TITLE
[JENKINS-58732] Remove docker-workflow dependency (refiled)

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -44,7 +44,7 @@
         <artifactId>maven-hpi-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
-          <compatibleSinceVersion>1.2-beta-4</compatibleSinceVersion>
+          <compatibleSinceVersion>1.6.0</compatibleSinceVersion>
         </configuration>
       </plugin>
       <plugin>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -219,7 +219,7 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
         result.add(new Object[]{"perStageConfigMissingSteps", Messages.JSONParser_MissingRequiredProperties("'steps'")});
         result.add(new Object[]{"perStageConfigUnknownSection", "additional properties are not allowed"});
 
-        result.add(new Object[]{"unknownAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", "[any, docker, dockerfile, label, none, otherField]")});
+        result.add(new Object[]{"unknownAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", "[any, label, none, otherField]")});
 
         // Not using the full message here due to issues with the test extension in MultipleUnnamedParametersTest bleeding over in some situations.
         // That resulted in multiArgCtorProp sometimes showing up in the list of valid options, but not always. We still have the full test in


### PR DESCRIPTION
Just the first commit from #391; whatever the purpose of the subsequent commits, they may have been made obsolete by changes in `master` since then.

Follows up #373 & #383.

Admins using `agent docker` / `agent dockerfile` should have updated to at least https://github.com/jenkinsci/docker-workflow-plugin/releases/tag/docker-workflow-1.22 first.