### PR TITLE
[JENKINS-62988] Do not use 3rd-party dependencies in ModelInterpreter.groovy

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition
 import com.cloudbees.groovy.cps.NonCPS
 import com.cloudbees.groovy.cps.impl.CpsClosure
 import hudson.FilePath
+import hudson.Functions
 import hudson.Launcher
 import hudson.model.Result
 import org.jenkinsci.plugins.pipeline.StageStatus
@@ -39,13 +40,12 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun
 import org.jenkinsci.plugins.workflow.steps.MissingContextVariableException
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
-import javax.annotation.CheckForNull
-import javax.annotation.Nonnull
-
-import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace
-
 /**
  * CPS-transformed code for actually performing the build.
+ *
+ * WARNING: Avoid using 3rd-party non-Jenkins dependencies (including annotations)
+ * in this code, because even they work in tests, they may not be available at
+ * runtime due to class loading differences.
  *
  * @author Andrew Bayer
  */
@@ -452,7 +452,7 @@ class ModelInterpreter implements Serializable {
      * @param body The closure to execute
      * @return The return of the resulting executed closure
      */
-    def withCredentialsBlock(@CheckForNull Environment environment, Closure body) {
+    def withCredentialsBlock(Environment environment, Closure body) {
         Map<String,CredentialWrapper> creds = new HashMap<>()
 
         if (environment != null) {
@@ -490,7 +490,7 @@ class ModelInterpreter implements Serializable {
      */
     @NonCPS
     private List<Map<String, Object>> createWithCredentialsParameters(
-            @Nonnull Map<String, CredentialWrapper> credentials) {
+            Map<String, CredentialWrapper> credentials) {
         List<Map<String, Object>> parameters = []
         credentials.each { k, v ->
             v.addParameters(k, parameters)
@@ -761,7 +761,7 @@ class ModelInterpreter implements Serializable {
                     Utils.markStageFailedAndContinued(stageName)
                 }
                 Utils.logToTaskListener("Error when executing ${conditionName} post condition:")
-                Utils.logToTaskListener(getFullStackTrace(e))
+                Utils.logToTaskListener(Functions.printThrowable(e))
                 if (stageError == null) {
                     stageError = e
                 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -44,7 +44,7 @@ import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
  * CPS-transformed code for actually performing the build.
  *
  * WARNING: Avoid using 3rd-party non-Jenkins dependencies (including annotations)
- * in this code, because even they work in tests, they may not be available at
+ * in this code, because even if they work in tests, they may not be available at
  * runtime due to class loading differences.
  *
  * @author Andrew Bayer


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-62988](https://issues.jenkins-ci.org/browse/JENKINS-62988)
* Description:
    * The classes `ModelInterpreter.groovy` has available to it at runtime depend on the versions of Jenkins and `workflow-cps` (among other plugins) being used, so we should minimize usage of any transitive dependencies that may be removed or modified, particularly annotations.
    * TODO:
        * [x] Check that tests pass
        * [ ] Check the behavior of this PR in a real Jenkins instance (since tests have a different class loading setup)
        * [ ] Verify that switching from `ExceptionUtils.getFullStackTrace` to `Functions.printThrowable` doesn't break things
* Documentation changes:
    * N/A
* Users/aliases to notify:
    * N/A
