### PR TITLE
[JENKINS-63123] Exclude transitive guava dependency from json-schema-validator

### DIFF
--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -57,6 +57,13 @@
     <dependency>
       <groupId>com.github.fge</groupId>
       <artifactId>json-schema-validator</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Conflicts with the version from Jenkins core in downstream plugins. -->
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
* JENKINS issue(s):
    * See [JENKINS-63123](https://issues.jenkins-ci.org/browse/JENKINS-63123)
* Description:
    * Apparently, in some cases downstream plugins were getting upper bounds issues because `pipeline-model-api`  depends on `json-schema-validator` 2.0.4 which depends on `json-schema-core` 1.0.4 which depends on `guava` 13.0.1, which is newer than the version of Guava bundled in Jenkins core (11.0.1). From what I can tell 11.0.1 is what `pipeline-model-api` itself it using, and it is not bundling a newer version or anything, so I think this only affects downstream plugins, and even then maybe only under specific circumstances.
* Documentation changes:
    * N/A
* Users/aliases to notify:
    * @oleg-nenashev If you have an easy way to check whether this fixes the issue you were seeing, could you please do so? (Or let me know where you were seeing it and I can check there)
