### PR TITLE
[JENKINS-63499] Make password parameters work with the parameters directive in Jenkins 2.236+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(timeout: 120)
+buildPlugin(timeout: 120, useAci: true, platforms: [
+  [ platform: 'linux', jdk: '8'],
+  [ platform: 'windows', jdk: '8'],
+  [ platform: 'linux', jdk: '11', jenkins: '2.236']
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(timeout: 120, useAci: true, platforms: [
+buildPlugin(timeout: 120, useAci: true, configurations: [
   [ platform: 'linux', jdk: '8'],
   [ platform: 'windows', jdk: '8'],
   [ platform: 'linux', jdk: '11', jenkins: '2.236']

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -109,6 +109,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
     </dependency>

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -28,6 +28,7 @@ import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import hudson.model.Describable
 import hudson.model.Descriptor
+import hudson.model.PasswordParameterDefinition
 import hudson.tools.ToolDescriptor
 import hudson.tools.ToolInstallation
 import hudson.util.EditDistance
@@ -454,6 +455,14 @@ class ModelValidatorImpl implements ModelValidator {
                             return
                         }
                         ModelASTKeyValueOrMethodCallPair kvm = (ModelASTKeyValueOrMethodCallPair) a
+
+                        // Special case, see JENKINS-63499.
+                        if (model.type == PasswordParameterDefinition.class && "defaultValue".equals(kvm.key.key)) {
+                            if (!validateParameterType((ModelASTValue) kvm.value, String.class, kvm.key)) {
+                                valid = false
+                            }
+                            return
+                        }
 
                         if (!isValidStepParameter(model, kvm.key.key, kvm.key)) {
                             valid = false

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ParametersDirective.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ParametersDirective.java
@@ -28,14 +28,19 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
 import hudson.model.ParameterDefinition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.jenkinsci.plugins.workflow.cps.Snippetizer;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.PasswordParameterDefinition;
+import hudson.util.Secret;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class ParametersDirective extends AbstractDirective<ParametersDirective> {
@@ -81,11 +86,23 @@ public class ParametersDirective extends AbstractDirective<ParametersDirective> 
         public String toGroovy(@NonNull ParametersDirective directive) {
             StringBuilder result = new StringBuilder("parameters {\n");
             for (ParameterDefinition param : directive.parameters) {
-                result.append(Snippetizer.object2Groovy(UninstantiatedDescribable.from(param)));
+                result.append(Snippetizer.object2Groovy(customUninstantiate(param)));
                 result.append("\n");
             }
             result.append("}\n");
             return result.toString();
+        }
+
+        /**
+         * Compatibility hack for JENKINS-63516.
+         */
+        public UninstantiatedDescribable customUninstantiate(ParameterDefinition param) {
+            UninstantiatedDescribable step = UninstantiatedDescribable.from(param);
+            if (param instanceof PasswordParameterDefinition && DescribableModel.of(PasswordParameterDefinition.class).getParameter("defaultValue") == null) {
+                Map<String, Object> newParamArgs = Utils.copyMapReplacingEntry(step.getArguments(), "defaultValueAsSecret", "defaultValue", Secret.class, Secret::getPlainText);
+                return step.withArguments(newParamArgs);
+            }
+            return step;
         }
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParametersTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParametersTest.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition;
 import hudson.model.BooleanParameterDefinition;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.PasswordParameterDefinition;
 import hudson.model.StringParameterDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -38,7 +39,14 @@ import org.jvnet.hudson.test.Issue;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class ParametersTest extends AbstractModelDefTest {
     @Test
@@ -167,5 +175,22 @@ public class ParametersTest extends AbstractModelDefTest {
         assertNotNull(paramProp2);
         BooleanParameterDefinition bpd2 = (BooleanParameterDefinition) paramProp2.getParameterDefinitions().get(0);
         assertSame(bpd, bpd2);
+    }
+
+    @Issue("JENKINS-63499")
+    @Test
+    public void passwordParameters() throws Exception {
+        WorkflowRun b = expect("passwordParameters")
+                .runFromRepo(false)
+                .logContains("Password is mySecret")
+                .go();
+        WorkflowJob p = b.getParent();
+
+        ParametersDefinitionProperty pdp = p.getProperty(ParametersDefinitionProperty.class);
+        assertThat(pdp.getParameterDefinitions(), hasSize(1));
+        PasswordParameterDefinition param = (PasswordParameterDefinition) pdp.getParameterDefinitions().get(0);
+        assertEquals("myPassword", param.getName());
+        assertEquals("mySecret", param.getDefaultValue());
+        assertEquals("myDescription", param.getDescription());
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -43,6 +43,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -233,6 +233,7 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Ignore("See https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/404#issuecomment-682933947")
     @Issue("JENKINS-52850")
     @Test
     public void sshCredentialsInEnv() throws Exception {

--- a/pipeline-model-definition/src/test/resources/passwordParameters.groovy
+++ b/pipeline-model-definition/src/test/resources/passwordParameters.groovy
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    parameters {
+        password(defaultValue: 'mySecret', description: 'myDescription', name: 'myPassword')
+    }
+    stages {
+        stage("foo") {
+            steps {
+                echo "Password is ${params.myPassword}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### JENKINS issue(s):

See [JENKINS-63499](https://issues.jenkins-ci.org/browse/JENKINS-63499).

### Description:

https://github.com/jenkinsci/jenkins/pull/4630 modified the `@DataBoundConstructor` for `PasswordParameterDefinition` in a way that broke backwards compatibility for structs-based data binding. `PasswordParameterDefinition` is used by Declarative for the parameters directive, so this PR adds a special case so that old Pipelines that configure `password` parameters as described in [the documentation](https://www.jenkins.io/doc/book/pipeline/syntax/#parameters) continue to work.

The directive generator is also affected by the original core change, here is the output when you try to generate a `parameters` directive with a password parameter:

```
parameters {
  password defaultValueAsSecret: <object of type hudson.util.Secret>, description: 'test', name: 'test'
}
```

TODO: Decide if the directive generator should also be fixed as part of this PR.

### Documentation changes:

Usage is the same as before.
