### PR TITLE
[JENKINS-34987] - Allow better script splitting in more scenarios

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -1262,7 +1262,7 @@ class RuntimeASTTransformer {
                     }
                 }
 
-                if (declarations.size() != 0) {
+                if (!declarations.isEmpty()) {
                     if (SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES) {
                         result.addAll(pipelineElementHandles)
                         pipelineElementHandles.clear()

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -1268,7 +1268,7 @@ class RuntimeASTTransformer {
                         pipelineElementHandles.clear()
                     } else {
                         throw new IllegalStateException("[JENKINS-34987] SCRIPT_SPLITTING_TRANSFORMATION is an experimental feature of Declarative Pipeline and is incompatible with local variable declarations inside a Jenkinsfile. " +
-                                "Local variable declarations found: " + declarations.join(", ") + ". "
+                                "Local variable declarations found: " + declarations.join(", ") + ". " +
                                  "As a temporary workaround, you can add the '@Field' annotation to these local variable declarations. " +
                                  "However, use of Groovy variables in Declarative pipeline, with or without the '@Field' annotation, is not recommended or supported. " + 
                                  "To use less effective script splitting which allows local variable declarations without changing your pipeline code, set SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES=true .")

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -1268,8 +1268,10 @@ class RuntimeASTTransformer {
                         pipelineElementHandles.clear()
                     } else {
                         throw new IllegalStateException("[JENKINS-34987] SCRIPT_SPLITTING_TRANSFORMATION is an experimental feature of Declarative Pipeline and is incompatible with local variable declarations inside a Jenkinsfile. " +
-                                "Add the '@Field' annotation to local variable declarations: " +
-                                declarations.join(", ") + ". To use less effective script splitting which allows local variable declarations without changing your pipeline code, set SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES=true .")
+                                "Local variable declarations found: " + declarations.join(", ") + ". "
+                                 "As a temporary workaround, you can add the '@Field' annotation to these local variable declarations. " +
+                                 "However, use of Groovy variables in Declarative pipeline, with or without the '@Field' annotation, is not recommended or supported. " + 
+                                 "To use less effective script splitting which allows local variable declarations without changing your pipeline code, set SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES=true .")
                     }
                 }
             }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -1267,9 +1267,9 @@ class RuntimeASTTransformer {
                         result.addAll(pipelineElementHandles)
                         pipelineElementHandles.clear()
                     } else {
-                        throw new IllegalStateException("SCRIPT_SPLITTING_TRANSFORMATION is incompatible with local variable declarations. " +
-                                "Add the the '@Field' annotation to local variable declarations: " +
-                                declarations.join(", ") + ".")
+                        throw new IllegalStateException("[JENKINS-34987] SCRIPT_SPLITTING_TRANSFORMATION is an experimental feature of Declarative Pipeline and is incompatible with local variable declarations inside a Jenkinsfile. " +
+                                "Add the '@Field' annotation to local variable declarations: " +
+                                declarations.join(", ") + ". To use less effective script splitting which allows local variable declarations without changing your pipeline code, set SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES=true .")
                     }
                 }
             }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -71,6 +71,7 @@ import static org.junit.Assert.assertThat;
 public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
 
     private boolean defaultScriptSplitting = RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION;
+    private boolean defaultScriptSplittingAllowLocalVariables = RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES;
 
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
@@ -111,14 +112,18 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
     @Before
     public void setUpFeatureFlags() {
         defaultScriptSplitting = RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION;
+        defaultScriptSplittingAllowLocalVariables = RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES;
 
         // For testing we want to default to exercising splitting
+        // and not allowing local variables
         RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION = true;
+        RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES = true;
     }
 
     @After
     public void cleanupFeatureFlags() {
         RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION = defaultScriptSplitting;
+        RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES = defaultScriptSplittingAllowLocalVariables;
     }
 
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -104,6 +104,16 @@ public class BasicModelDefTest extends AbstractModelDefTest {
             .go();
     }
 
+    @Issue("JENKINS-37984")
+    @Test
+    public void stages100WithOutsideVarAndFuncNotAllowed() throws Exception {
+        RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES = false;
+        expect(Result.FAILURE,"basic/stages100WithOutsideVarAndFunc")
+            .logContains("Add the the '@Field' annotation to local variable declarations")
+            .logNotContains("Method code too large!")
+            .go();
+    }
+
     @Test
     public void failingPipeline() throws Exception {
         expect(Result.FAILURE, "basic/failingPipeline")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -109,7 +109,7 @@ public class BasicModelDefTest extends AbstractModelDefTest {
     public void stages100WithOutsideVarAndFuncNotAllowed() throws Exception {
         RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES = false;
         expect(Result.FAILURE,"basic/stages100WithOutsideVarAndFunc")
-            .logContains("Add the the '@Field' annotation to local variable declarations")
+            .logContains("Add the '@Field' annotation to local variable declarations")
             .logNotContains("Method code too large!")
             .go();
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -109,7 +109,7 @@ public class BasicModelDefTest extends AbstractModelDefTest {
     public void stages100WithOutsideVarAndFuncNotAllowed() throws Exception {
         RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES = false;
         expect(Result.FAILURE,"basic/stages100WithOutsideVarAndFunc")
-            .logContains("Add the '@Field' annotation to local variable declarations")
+            .logContains("add the '@Field' annotation to these local variable declarations")
             .logNotContains("Method code too large!")
             .go();
     }


### PR DESCRIPTION
## JENKINS issue(s):

* [JENKINS-34987](https://issues.jenkins-ci.org/browse/JENKINS-37984)

## Description:

Automatically splitting the pipeline script into multiple smaller parts makes it less likely
for the resulting compiled class throw "Method code too large!" or "Class too large"
exceptions during the class file generation phase of compilation.

Script splitting has two different strategies: method-grouped and closure-only. Closure-only is less effective but method-grouped splitting is not compatible with some groovy structures.  In particular locally declared variables, such as such as `def a = 1`, are incompatible with the more effective method-grouped script splitting.

Before this change, any statements outside the pipeline directive would cause the plugin to switch to using the less effective closure-only script splitting.

This change does three things:
1. It uses the method-grouped script splitting unless it detects locally declared variables such as `def a = 1` outside the `pipeline {}` directive. 
2. If it detects locally declared variables such as `def a = 1`:
a. it defaults to failing the run telling the user to add the `@Field` annotation to the declaration. 
b. If `SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES=true`, it does not report an error, instead falling back to closure-only splitting.  

Script splitting ignores other non-problematic statements such as method/function declarations or method calls.  Note, this is experimental. There may be other structures aside from local variable declaration that are incompatible with script splitting.  More testing is needed.

WARNING: this is a global change. If you install this version an have `SCRIPT_SPLITTING_TRANSFORMATION=true`, any declarative pipeline Jenkinsfile with a local variable declaration outside the pipeline block will fail.  You may switch back to allowing locally declared variables by setting `SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES=true`.  

