### PR TITLE
Allow ModelParser to be run outside of a Jenkins instance

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/AlwaysTrueValidator.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/AlwaysTrueValidator.java
@@ -1,0 +1,232 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTAgent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTAxis;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTAxisContainer;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildCondition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildConditionsContainer;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildParameter;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBuildParameters;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTEnvironment;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTExclude;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTExcludeAxis;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTExcludes;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTInternalFunctionCall;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTLibraries;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMatrix;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTMethodCall;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOption;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTOptions;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTParallel;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostBuild;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPostStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStageBase;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStageInput;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTools;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTrigger;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTTriggers;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTValue;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhen;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenCondition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
+/**
+ * {@link ModelValidator} that will always return true for use in external model parsing.
+ *
+ * @author Andrew Bayer
+ */
+public class AlwaysTrueValidator implements ModelValidator {
+    @Override
+    public boolean validateElement(ModelASTAgent modelASTAgent) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBranch modelASTBranch) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildConditionsContainer modelASTBuildConditionsContainer) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTPostBuild modelASTPostBuild) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTPostStage modelASTPostStage) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildCondition modelASTBuildCondition) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTEnvironment modelASTEnvironment) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTTools modelASTTools) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStep modelASTStep) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTWhen modelASTWhen) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTMethodCall modelASTMethodCall) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTOptions modelASTOptions) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTTriggers modelASTTriggers) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildParameters modelASTBuildParameters) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTOption modelASTOption) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTTrigger modelASTTrigger) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTBuildParameter modelASTBuildParameter) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTPipelineDef modelASTPipelineDef) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStageBase modelASTStageBase) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStage modelASTStage, boolean b) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStages modelASTStages) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTParallel modelASTParallel) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTMatrix modelASTMatrix) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTAxisContainer modelASTAxisContainer) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTAxis modelASTAxis) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTExcludes modelASTExcludes) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTExclude modelASTExclude) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTExcludeAxis modelASTExcludeAxis) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTLibraries modelASTLibraries) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTWhenCondition modelASTWhenCondition) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTInternalFunctionCall modelASTInternalFunctionCall) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTStageInput modelASTStageInput) {
+        return true;
+    }
+
+    @Override
+    public boolean validateElement(ModelASTValue modelASTValue) {
+        return true;
+    }
+}

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParserExternalTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParserExternalTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2020, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser;
+
+import com.cloudbees.groovy.cps.NonCPS;
+import groovy.lang.GroovyClassLoader;
+import net.sf.json.JSONObject;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.control.customizers.ImportCustomizer;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractDeclarativeTest;
+import org.jenkinsci.plugins.pipeline.modeldefinition.DescriptorLookupCache;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ErrorCollector;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.SourceUnitErrorCollector;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.GroovySandbox;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.util.ClassUtils;
+
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.cert.Certificate;
+
+import static groovy.lang.GroovyShell.DEFAULT_CODE_BASE;
+import static org.codehaus.groovy.control.Phases.CONVERSION;
+import static org.junit.Assert.*;
+
+public class ModelParserExternalTest extends AbstractDeclarativeTest {
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void parseOutsideJenkins() throws Exception {
+        String script = pipelineSourceFromResources("simpleParameters");
+
+        ModelASTPipelineDef model = parse(script);
+        assertNotNull(model);
+        assertEquals(1, model.getStages().getStages().size());
+    }
+
+    /**
+     * parse is used to replicate the ModelParser behavior from Converter.groovy outside of Jenkins
+     */
+    private ModelASTPipelineDef parse(String script) throws Exception {
+        CompilerConfiguration cc = GroovySandbox.createBaseCompilerConfiguration();
+
+        ImportCustomizer ic = new ImportCustomizer();
+        ic.addStarImports(NonCPS.class.getPackage().getName());
+        ic.addStarImports("hudson.model","jenkins.model");
+        cc.addCompilationCustomizers(ic);
+
+        CompilationUnit cu = new CompilationUnit(
+                cc,
+                new CodeSource(new URL("file", "", DEFAULT_CODE_BASE), (Certificate[]) null),
+                new GroovyClassLoader(ClassUtils.getDefaultClassLoader()));
+        cu.addSource(Converter.getPIPELINE_SCRIPT_NAME(), script);
+
+        final ModelASTPipelineDef[] model = new ModelASTPipelineDef[1];
+
+        cu.addPhaseOperation(new CompilationUnit.SourceUnitOperation() {
+            @Override
+            public void call(SourceUnit source) throws CompilationFailedException {
+                if (model[0] == null) {
+                    ErrorCollector errorCollector = new SourceUnitErrorCollector(source);
+                    ModelValidator validator = new AlwaysTrueValidator();
+                    model[0] = new ModelParser(source, null, errorCollector, validator, new DescriptorLookupCache()).parse(true);
+                }
+            }
+        }, CONVERSION);
+
+        cu.compile(CONVERSION);
+
+        return model[0];
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * I'm working on tooling for converting Jenkinsfiles to JSON outside of a Jenkins instance, and there are a number of things that break as things stand now. This fixes those, by allowing for providing a `ModelValidator` implementation and a `DescriptorLookupCache` instance to `ModelParser`, and uses a fallback for the zero-arg agent model map if run outside of Jenkins.
* Documentation changes:
    * n/a - this isn't user-facing.
* Users/aliases to notify:
    * @bitwiseman 
