### PR TITLE
[JENKINS-64508] Add extension point for globally defined when conditions

### DIFF
--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleGlobalWhenCondition.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleGlobalWhenCondition.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
+/**
+ * Special case of a {@link ModelASTWhenCondition} generated for a globally defined when condition.
+ */
+public class InvisibleGlobalWhenCondition extends ModelASTWhenCondition {
+    private final String stageName;
+    private final ModelASTStageBase stage;
+
+    /**
+     * Used to create invisible when conditions without base stage information, used for the "allOf" conditional
+     * generated when a stage already has when conditions.
+     */
+    public InvisibleGlobalWhenCondition() {
+        this(null, null);
+    }
+
+    /**
+     * Used to create invisible when conditions with a base stage for comparison and querying.
+     *
+     * @param stageName The name of the stage this condition belongs to. Explicitly specified due to auto-generated stage 
+     *                  names with matrices.
+     * @param stage The {@link ModelASTStageBase} for the stage this condition belongs to, for inspection.
+     */
+    public InvisibleGlobalWhenCondition(String stageName, ModelASTStageBase stage) {
+        super(null);
+        this.stageName = stageName;
+        this.stage = stage;
+    }
+
+    public String getStageName() {
+        return stageName;
+    }
+
+    public ModelASTStageBase getStage() {
+        return stage;
+    }
+
+    @Override
+    @NonNull
+    public JSONObject toJSON() {
+        return new JSONObject();
+    }
+
+    @Override
+    @NonNull
+    public String toGroovy() {
+        return "";
+    }
+
+    @Override
+    public void validate(@NonNull ModelValidator validator) {
+    }
+
+    @Override
+    public void removeSourceLocation() {
+        super.removeSourceLocation();
+        removeSourceLocationsFrom(stage);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        InvisibleGlobalWhenCondition that = (InvisibleGlobalWhenCondition) o;
+
+        if (getStageName() != null ? !getStageName().equals(that.getStageName()) : that.getStageName() != null) {
+            return false;
+        }
+        return getStage() != null ? getStage().equals(that.getStage()) : that.getStage() == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getStageName() != null ? getStageName().hashCode() : 0);
+        result = 31 * result + (getStage() != null ? getStage().hashCode() : 0);
+        return result;
+    }
+}

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleGlobalWhenCondition.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleGlobalWhenCondition.java
@@ -28,6 +28,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
 
+import java.util.Objects;
+
 /**
  * Special case of a {@link ModelASTWhenCondition} generated for a globally defined when condition.
  */
@@ -110,8 +112,8 @@ public class InvisibleGlobalWhenCondition extends ModelASTWhenCondition {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (getStageName() != null ? getStageName().hashCode() : 0);
-        result = 31 * result + (getStage() != null ? getStage().hashCode() : 0);
+        result = 31 * result + Objects.hashCode(getStage());
+        result = 31 * result + Objects.hashCode(getStageName());
         return result;
     }
 }

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleWhen.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleWhen.java
@@ -29,9 +29,10 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
 
 /**
- * When container generated when adding invisible global when conditions to a stage, containing the new conditions and
- * any explicitly defined ones. When created with existing conditions, the existing when container is stored for use as
- * well. This is used as a marker to avoid validation, JSON/Groovy generation, etc for the generated container.
+ * {@code when} container generated when adding invisible global {@code when} conditions to a stage, containing the new
+ * invisible conditions and any explicitly defined ones. When created with existing conditions, the existing {@code when}
+ * container is stored for use as well. This is used as a marker to avoid validation, JSON/Groovy generation, etc for
+ * the generated container.
  */
 public class InvisibleWhen extends ModelASTWhen {
     /**

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleWhen.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ast/InvisibleWhen.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.ast;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.ModelValidator;
+
+/**
+ * When container generated when adding invisible global when conditions to a stage, containing the new conditions and
+ * any explicitly defined ones. When created with existing conditions, the existing when container is stored for use as
+ * well. This is used as a marker to avoid validation, JSON/Groovy generation, etc for the generated container.
+ */
+public class InvisibleWhen extends ModelASTWhen {
+    /**
+     * The optional original when container on the stage, used for delegation.
+     */
+    private ModelASTWhen originalWhen;
+
+    public InvisibleWhen() {
+        super(null);
+    }
+
+    public void setOriginalWhen(ModelASTWhen originalWhen) {
+        this.originalWhen = originalWhen;
+    }
+
+    @Override
+    public Object getSourceLocation() {
+        return originalWhen != null ? originalWhen.getSourceLocation() : null;
+    }
+
+    @Override
+    public Boolean getBeforeAgent() {
+        return originalWhen != null && originalWhen.getBeforeAgent() != null ? originalWhen.getBeforeAgent() : false;
+    }
+
+    @Override
+    public Boolean getBeforeInput() {
+        return originalWhen != null && originalWhen.getBeforeInput() != null ? originalWhen.getBeforeInput() : false;
+    }
+
+    @Override
+    public Boolean getBeforeOptions() {
+        return originalWhen != null && originalWhen.getBeforeOptions() != null ? originalWhen.getBeforeOptions() : false;
+    }
+
+    @NonNull
+    @Override
+    public Object toJSON() {
+        return originalWhen != null ? originalWhen.toJSON() : new JSONObject();
+    }
+
+    @NonNull
+    @Override
+    public String toGroovy() {
+        return originalWhen != null ? originalWhen.toGroovy() : "";
+    }
+
+    @Override
+    public void removeSourceLocation() {
+        if (originalWhen != null) {
+            originalWhen.removeSourceLocation();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return originalWhen != null ? originalWhen.toString() : super.toString();
+    }
+
+    @Override
+    public void validate(@NonNull ModelValidator validator) {
+        if (originalWhen != null) {
+            originalWhen.validate(validator);
+        }
+    }
+}

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -452,31 +452,6 @@ class Utils {
         return knownTypes
     }
 
-    @Whitelisted
-    @Restricted(NoExternalUse.class)
-    static <T> T instantiateDescribable(Class<T> c, Map<String, ?> args) {
-        DescribableModel<T> model = new DescribableModel<>(c)
-        // Special case for JENKINS-63499.
-        if (model != null && model.type == PasswordParameterDefinition.class && model.getParameter("defaultValueAsSecret") != null) {
-            args = copyMapReplacingEntry(args, "defaultValue", "defaultValueAsSecret", String.class, { s -> Secret.fromString(s) })
-        }
-        return model?.instantiate(args)
-    }
-
-    /**
-     * Copy a map, replacing the entry with the specified key if it matches the specified type.
-     */
-    public static <T> Map<String, Object> copyMapReplacingEntry(Map<String, ?> map, String oldKey, String newKey, Class<T> requiredValueType, Function<T, Object> replacer) {
-        Map<String, Object> newMap = new TreeMap<>()
-        for (Map.Entry<String, ?> entry : map.entrySet()) {
-            if (entry.getKey().equals(oldKey) && requiredValueType.isInstance(entry.getValue())) {
-                newMap.put(newKey, replacer.apply(requiredValueType.cast(entry.getValue())))
-            } else {
-                newMap.put(entry.getKey(), entry.getValue())
-            }
-        }
-        newMap
-    }
 
     /**
      * @param c The closure to wrap.

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -24,6 +24,10 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.github.fge.jsonschema.tree.JsonTree
+import com.github.fge.jsonschema.tree.SimpleJsonTree
+import com.github.fge.jsonschema.util.JsonLoader
 import com.google.common.base.Predicate
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
@@ -34,6 +38,9 @@ import hudson.ExtensionList
 import hudson.model.*
 import hudson.util.Secret
 import hudson.triggers.Trigger
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage
+import org.jenkinsci.plugins.pipeline.modeldefinition.parser.JSONParser
+
 import java.util.function.Function
 import jenkins.model.Jenkins
 import org.apache.commons.codec.digest.DigestUtils
@@ -999,5 +1006,18 @@ class Utils {
         RestartDeclarativePipelineCause cause = r.getCause(RestartDeclarativePipelineCause.class)
 
         return cause?.originStage
+    }
+
+    /**
+     * Convenience method for parsing a {@link ModelASTStage} from a JSON string
+     * @param stageJSON The JSON string representing the stage
+     * @return The parsed result of the JSON, or null
+     * @throws Exception If anything goes wrong in parsing the JSON.
+     */
+    static ModelASTStage parseStageFromJSON(String stageJSON) throws Exception {
+        JsonNode json = JsonLoader.fromString(stageJSON)
+        JsonTree jsonTree = new SimpleJsonTree(json)
+        JSONParser parser = new JSONParser(null)
+        return parser.parseStage(jsonTree)
     }
 }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
@@ -45,7 +45,6 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.Parameters
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Triggers
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor
-import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditionalDescriptor
 import org.jenkinsci.plugins.structs.SymbolLookup
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtils.groovy
@@ -40,7 +40,6 @@ import org.codehaus.groovy.ast.stmt.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.CommonUtils
 import org.jenkinsci.plugins.pipeline.modeldefinition.DescriptorLookupCache
 import org.jenkinsci.plugins.pipeline.modeldefinition.ModelStepLoader
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Parameters
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.Triggers
@@ -350,9 +349,6 @@ class ASTParserUtils {
             DeclarativeStageConditionalDescriptor parentDesc =
                 (DeclarativeStageConditionalDescriptor) SymbolLookup.get().findDescriptor(
                     DeclarativeStageConditional.class, original.name)
-            if (parentDesc instanceof GlobalStageConditionalDescriptor) {
-
-            }
             if (original instanceof ModelASTWhenCondition) {
                 ModelASTWhenCondition cond = (ModelASTWhenCondition) original
                 if (cond.children.isEmpty()) {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/Converter.groovy
@@ -111,7 +111,7 @@ class Converter {
         return compilationUnitToPipelineDef(cu, enabledOptionalValidators)
     }
 
-    private static GroovyClassLoader getCompilationClassLoader() {
+    static GroovyClassLoader getCompilationClassLoader() {
         return CpsThread.current()?.getExecution()?.getShell()?.classLoader ?:
             new GroovyClassLoader(Jenkins.instance.getPluginManager().uberClassLoader)
     }
@@ -134,7 +134,7 @@ class Converter {
         return compilationUnitToPipelineDef(cu, enabledOptionalValidators)
     }
 
-    private static CompilerConfiguration makeCompilerConfiguration() {
+    static CompilerConfiguration makeCompilerConfiguration() {
         CompilerConfiguration cc = GroovySandbox.createBaseCompilerConfiguration()
 
         ImportCustomizer ic = new ImportCustomizer()
@@ -158,7 +158,7 @@ class Converter {
      * @return The converted script
      */
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD")
-    private static ModelASTPipelineDef compilationUnitToPipelineDef(CompilationUnit cu,
+    static ModelASTPipelineDef compilationUnitToPipelineDef(CompilationUnit cu,
                                                                     final List<Class<? extends DeclarativeValidatorContributor>> enabledOptionalValidators = []) {
         final ModelASTPipelineDef[] model = new ModelASTPipelineDef[1]
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ModelParser.groovy
@@ -321,7 +321,7 @@ class ModelParser implements Parser {
 
             // Lazily evaluate prettyPrint(...) - i.e., only if AST_DEBUG_LOGGING is true.
             astDebugLog {
-                "Transformed runtime AST:\n${ -> prettyPrint(pipelineBlock.whole.arguments)}"
+                "Transformed runtime AST:\n${ -> prettyPrint(src)}"
             }
         }
 

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -802,26 +802,20 @@ class RuntimeASTTransformer {
         if (invisibles.size() == 0) {
             return when
         }
-        if (when == null) {
-            ModelASTWhen newWhen = new InvisibleWhen()
+        ModelASTWhen newWhen = new InvisibleWhen()
+        List<ModelASTWhenContent> newConditions = new ArrayList<>(invisibles)
 
-            newWhen.setConditions(invisibles)
-
-            return newWhen
-        } else {
+        if (when != null) {
             List<ModelASTWhenContent> originalConditions = when.getConditions()
-            List<ModelASTWhenContent> newConditions = new ArrayList<>(invisibles)
             newConditions.addAll(originalConditions)
-
-            ModelASTWhenCondition newParent = new InvisibleGlobalWhenCondition()
-            newParent.setName(SymbolLookup.getSymbolValue(AllOfConditional.class).first())
-            newParent.setChildren(newConditions)
-
-            ModelASTWhen newWhen = new InvisibleWhen()
             newWhen.setOriginalWhen(when)
-            newWhen.setConditions(Collections.singletonList(newParent))
-            return newWhen
         }
+        ModelASTWhenCondition newParent = new InvisibleGlobalWhenCondition()
+        newParent.setName(SymbolLookup.getSymbolValue(AllOfConditional.class).first())
+        newParent.setChildren(newConditions)
+
+        newWhen.setConditions(Collections.singletonList(newParent))
+        return newWhen
     }
 
     @CheckForNull

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ParametersDirective.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ParametersDirective.java
@@ -28,7 +28,7 @@ import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
 import hudson.model.ParameterDefinition;
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.CommonUtils;
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
 import org.jenkinsci.plugins.workflow.cps.Snippetizer;
@@ -99,7 +99,7 @@ public class ParametersDirective extends AbstractDirective<ParametersDirective> 
         public UninstantiatedDescribable customUninstantiate(ParameterDefinition param) {
             UninstantiatedDescribable step = UninstantiatedDescribable.from(param);
             if (param instanceof PasswordParameterDefinition && DescribableModel.of(PasswordParameterDefinition.class).getParameter("defaultValue") == null) {
-                Map<String, Object> newParamArgs = Utils.copyMapReplacingEntry(step.getArguments(), "defaultValueAsSecret", "defaultValue", Secret.class, Secret::getPlainText);
+                Map<String, Object> newParamArgs = CommonUtils.copyMapReplacingEntry(step.getArguments(), "defaultValueAsSecret", "defaultValue", Secret.class, Secret::getPlainText);
                 return step.withArguments(newParamArgs);
             }
             return step;

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtilsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/ASTParserUtilsTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser;
+
+import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.SourceUnit;
+import org.jenkinsci.plugins.pipeline.modeldefinition.BaseParserLoaderTest;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTPipelineDef;
+import org.junit.Test;
+
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.cert.Certificate;
+
+import static org.codehaus.groovy.control.Phases.CONVERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ASTParserUtilsTest extends BaseParserLoaderTest {
+    @Test
+    public void prettyPrintTransformed() throws Exception {
+        URL src = getClass().getResource("/when/whenEnv.groovy");
+
+        // We need to do our own parsing logic here to make sure we do the runtime transformation, and so that we can
+        // capture the CompilationUnit for comparison.
+        CompilationUnit cu = new CompilationUnit(
+            Converter.makeCompilerConfiguration(),
+            new CodeSource(src, new Certificate[0]),
+            Converter.getCompilationClassLoader());
+        cu.addSource(src);
+
+        final ModelASTPipelineDef[] model = new ModelASTPipelineDef[1];
+
+        cu.addPhaseOperation(new CompilationUnit.SourceUnitOperation() {
+            @Override
+            public void call(SourceUnit source) throws CompilationFailedException {
+                if (model[0] == null) {
+                    model[0] = new ModelParser(source).parse(false);
+                }
+            }
+        }, CONVERSION);
+
+        cu.compile(CONVERSION);
+
+        SourceUnit su = cu.iterator().next();
+        assertNotNull(su);
+
+        ModuleNode mn = su.getAST();
+        assertNotNull(mn);
+
+        // Replace object ids and the like so that we've got consistent output.
+        String prettyPrint = ASTParserUtils.prettyPrint(mn)
+            .replaceAll("DynamicVariable@.*", "DynamicVariable@something")
+            .replaceAll("VariableExpression@.*", "VariableExpression@something")
+            .replaceAll("(__model__.*?_\\d+)_\\d+__", "$1_something__")
+            .replaceAll("ConstantExpression\\[\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}", "ConstantExpression[some-uuid");
+        String expected = fileContentsFromResources("prettyPrintTransformedOutput.txt");
+        assertEquals(expected.split("\\n"), prettyPrint.split("\\n"));
+    }
+}

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformerTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformerTest.java
@@ -1,0 +1,148 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MapExpression;
+import org.codehaus.groovy.ast.tools.GeneralUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.InvisibleGlobalWhenCondition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenContent;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditional;
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditionalDescriptor;
+import org.jenkinsci.plugins.structs.SymbolLookup;
+import org.junit.Test;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.classX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
+
+public class RuntimeASTTransformerTest extends AbstractModelDefTest {
+
+    @Test
+    public void globalConditionalNoWhensMatching() throws Exception {
+        GlobalTestConditional.GlobalTestConditionalDescriptor desc = ExtensionList.lookupSingleton(GlobalTestConditional.GlobalTestConditionalDescriptor.class);
+        desc.skipStageName = "hello";
+
+        expect("twoStages")
+            .logNotContains("hello world")
+            .logContains("goodbye world")
+            .go();
+    }
+
+    @Test
+    public void globalConditionalNoWhensNotMatching() throws Exception {
+        GlobalTestConditional.GlobalTestConditionalDescriptor desc = ExtensionList.lookupSingleton(GlobalTestConditional.GlobalTestConditionalDescriptor.class);
+        desc.skipStageName = "something else";
+
+        expect("twoStages")
+            .logContains("hello world", "goodbye world")
+            .go();
+    }
+
+    @Test
+    public void globalConditionalExistingWhensMatching() throws Exception {
+        GlobalTestConditional.GlobalTestConditionalDescriptor desc = ExtensionList.lookupSingleton(GlobalTestConditional.GlobalTestConditionalDescriptor.class);
+        desc.skipStageName = "Two";
+
+        expect("when/whenEnv")
+            .logNotContains("Heal it", "Should never be reached")
+            .logContains("Ignore case worked")
+            .go();
+    }
+
+    @Test
+    public void globalConditionalExistingWhensNotMatching() throws Exception {
+        GlobalTestConditional.GlobalTestConditionalDescriptor desc = ExtensionList.lookupSingleton(GlobalTestConditional.GlobalTestConditionalDescriptor.class);
+        desc.skipStageName = "something else";
+
+        expect("when/whenEnv")
+            .logNotContains("Should never be reached")
+            .logContains("Heal it", "Ignore case worked")
+            .go();
+    }
+
+    public static class GlobalTestConditional extends GlobalStageConditional<GlobalTestConditional> {
+        private String skipStageName;
+        private String stageName;
+
+        @DataBoundConstructor
+        public GlobalTestConditional(String skipStageName) {
+            this.skipStageName = skipStageName;
+        }
+
+        @DataBoundSetter
+        public void setStageName(String stageName) {
+            this.stageName = stageName;
+        }
+
+        public String getStageName() {
+            return stageName;
+        }
+
+        public String getSkipStageName() {
+            return skipStageName;
+        }
+
+        @TestExtension
+        @Symbol("globalTest")
+        public static class GlobalTestConditionalDescriptor extends GlobalStageConditionalDescriptor<GlobalTestConditional> {
+            public String skipStageName;
+
+            @Override
+            public Map<String, Object> argMapForCondition(@NonNull InvisibleGlobalWhenCondition when) {
+                Map<String,Object> argMap = new TreeMap<>();
+
+                if (when.getName().equals("globalTest")) {
+                    argMap.put("skipStageName", skipStageName);
+                    argMap.put("stageName", when.getStageName());
+                }
+
+                return argMap;
+            }
+
+            @NonNull
+            @Override
+            public String getScriptClass() {
+                return getClass().getPackage().getName() + ".GlobalTestConditionalScript";
+            }
+        }
+    }
+}

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformerTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformerTest.java
@@ -34,9 +34,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTBranch;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditional;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditionalDescriptor;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -45,7 +43,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class RuntimeASTTransformerTest extends AbstractModelDefTest {
-    private void setupGlobalConditionals(String skipStageName, int maxStepCount) throws Exception {
+    private void setupGlobalConditionals(String skipStageName, int maxStepCount) {
         GlobalStageNameTestConditional.GlobalStageNameTestConditionalDescriptor nameDesc = ExtensionList.lookupSingleton(GlobalStageNameTestConditional.GlobalStageNameTestConditionalDescriptor.class);
         nameDesc.skipStageName = skipStageName;
 

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GlobalStageNameTestConditionalScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GlobalStageNameTestConditionalScript.groovy
@@ -22,22 +22,19 @@
  * THE SOFTWARE.
  */
 
-pipeline {
-    agent none
-    stages {
-        stage("hello") {
-            steps {
-                echo "hello world"
-            }
-        }
-        stage("goodbye") {
-            steps {
-                echo "goodbye world"
-                echo "no, really, we're leaving"
-            }
-        }
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditionalScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+
+class GlobalStageNameTestConditionalScript extends GlobalStageConditionalScript<RuntimeASTTransformerTest.GlobalStageNameTestConditional> {
+    GlobalStageNameTestConditionalScript(CpsScript s, RuntimeASTTransformerTest.GlobalStageNameTestConditional g) {
+        super(s, g)
+    }
+
+    @Override
+    boolean evaluate() {
+        return describable.skipStageName != describable.stageName
     }
 }
-
-
-

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GlobalStepCountTestConditionalScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GlobalStepCountTestConditionalScript.groovy
@@ -28,13 +28,13 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditiona
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 
-class GlobalTestConditionalScript extends GlobalStageConditionalScript<RuntimeASTTransformerTest.GlobalTestConditional> {
-    GlobalTestConditionalScript(CpsScript s, RuntimeASTTransformerTest.GlobalTestConditional g) {
+class GlobalStepCountTestConditionalScript extends GlobalStageConditionalScript<RuntimeASTTransformerTest.GlobalStepCountTestConditional> {
+    GlobalStepCountTestConditionalScript(CpsScript s, RuntimeASTTransformerTest.GlobalStepCountTestConditional g) {
         super(s, g)
     }
 
     @Override
     boolean evaluate() {
-        return describable.skipStageName != describable.stageName
+        return describable.evaluate()
     }
 }

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GlobalTestConditionalScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/parser/GlobalTestConditionalScript.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.parser
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.when.GlobalStageConditionalScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+
+class GlobalTestConditionalScript extends GlobalStageConditionalScript<RuntimeASTTransformerTest.GlobalTestConditional> {
+    GlobalTestConditionalScript(CpsScript s, RuntimeASTTransformerTest.GlobalTestConditional g) {
+        super(s, g)
+    }
+
+    @Override
+    boolean evaluate() {
+        return describable.skipStageName != describable.stageName
+    }
+}

--- a/pipeline-model-definition/src/test/resources/prettyPrintTransformedOutput.txt
+++ b/pipeline-model-definition/src/test/resources/prettyPrintTransformedOutput.txt
@@ -1,0 +1,299 @@
+- module:
+  - methods:
+  - statements:
+      - method 'ConstantExpression[pipeline]':
+        - var:
+          - name: this
+          - accessedVariable: null
+        - args:
+          - closure:
+            - block
+                - method 'ConstantExpression[__model__Declaration_19_something__]':
+                  - var:
+                    - name: this
+                    - accessedVariable: null
+                  - tuples:
+              - return:
+                - method 'ConstantExpression[getRoot_0]':
+                  - var:
+                    - name: __model__Root_18_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+  - classes:
+    - whenEnv
+    - class: generated.__model__Agent_1_something__
+      - methods:
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Agent:
+                - method 'ConstantExpression[call]':
+                  - var:
+                    - name: __model__Closure_0_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+      - properties:
+      - object initializers:
+    - class: generated.__model__Stage_3_something__
+      - methods:
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage:
+                - ConstantExpression[One]
+                - static method 'createStepsBlock':
+                  - org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+                  - args:
+                    - var:
+                      - name: __model__Variable_2_something__
+                      - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[false]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage:
+                - ConstantExpression[Two]
+                - static method 'createStepsBlock':
+                  - org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+                  - args:
+                    - var:
+                      - name: __model__Variable_4_something__
+                      - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - method 'ConstantExpression[getStageConditionals_0]':
+                  - var:
+                    - name: __model__StageConditionals_6_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[false]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage:
+                - ConstantExpression[Three]
+                - static method 'createStepsBlock':
+                  - org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+                  - args:
+                    - var:
+                      - name: __model__Variable_7_something__
+                      - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - method 'ConstantExpression[getStageConditionals_1]':
+                  - var:
+                    - name: __model__StageConditionals_6_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[false]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Stage:
+                - ConstantExpression[Four]
+                - static method 'createStepsBlock':
+                  - org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+                  - args:
+                    - var:
+                      - name: __model__Variable_9_something__
+                      - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - method 'ConstantExpression[getStageConditionals_2]':
+                  - var:
+                    - name: __model__StageConditionals_6_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[false]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+      - properties:
+      - object initializers:
+    - class: generated.__model__StageConditionals_6_something__
+      - methods:
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.StageConditionals:
+                - var:
+                  - name: __model__Variable_5_something__
+                  - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                - ConstantExpression[false]
+                - ConstantExpression[false]
+                - ConstantExpression[false]
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.StageConditionals:
+                - var:
+                  - name: __model__Variable_8_something__
+                  - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                - ConstantExpression[false]
+                - ConstantExpression[false]
+                - ConstantExpression[false]
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.StageConditionals:
+                - var:
+                  - name: __model__Variable_10_something__
+                  - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                - ConstantExpression[false]
+                - ConstantExpression[false]
+                - ConstantExpression[false]
+      - properties:
+      - object initializers:
+    - class: generated.__model__listExpression_12_something__
+      - methods:
+        - methodNode:
+          - block
+            - return:
+              - list:
+                - method 'ConstantExpression[getStage_0]':
+                  - var:
+                    - name: __model__Stage_3_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - method 'ConstantExpression[getStage_1]':
+                  - var:
+                    - name: __model__Stage_3_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - method 'ConstantExpression[getStage_2]':
+                  - var:
+                    - name: __model__Stage_3_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - method 'ConstantExpression[getStage_3]':
+                  - var:
+                    - name: __model__Stage_3_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+        - methodNode:
+          - block
+              - binary:
+                - left:
+                - var:
+                  - name: __model__extendedList_11_something__
+                  - accessedVariable: org.codehaus.groovy.ast.expr.VariableExpression@something
+               - op: ("=":  "=" )
+                - right:
+                - list:
+              - method 'ConstantExpression[addAll]':
+                - var:
+                  - name: __model__extendedList_11_something__
+                  - accessedVariable: org.codehaus.groovy.ast.expr.VariableExpression@something
+                - args:
+                  - method 'ConstantExpression[getlistExpression_0]':
+                    - var:
+                      - name: __model__listExpression_12_something__
+                      - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                    - tuples:
+            - return:
+              - var:
+                - name: __model__extendedList_11_something__
+                - accessedVariable: org.codehaus.groovy.ast.expr.VariableExpression@something
+      - properties:
+      - object initializers:
+    - class: generated.__model__Stages_13_something__
+      - methods:
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Stages:
+                - method 'ConstantExpression[getlistExpression_1]':
+                  - var:
+                    - name: __model__listExpression_12_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+      - properties:
+      - object initializers:
+    - class: generated.__model__Environment_15_something__
+      - methods:
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Environment:
+                - static method 'instanceFromMap':
+                  - org.jenkinsci.plugins.pipeline.modeldefinition.model.Environment$EnvironmentResolver
+                  - args:
+                    - map:
+                        - ConstantExpression[FOO]
+                        - method 'ConstantExpression[call]':
+                          - var:
+                            - name: __model__Closure_14_something__
+                            - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                          - tuples:
+                - static method 'instanceFromMap':
+                  - org.jenkinsci.plugins.pipeline.modeldefinition.model.Environment$EnvironmentResolver
+                  - args:
+                    - map:
+      - properties:
+      - object initializers:
+    - class: generated.__model__Root_18_something__
+      - methods:
+        - methodNode:
+          - block
+            - return:
+              - constructor of org.jenkinsci.plugins.pipeline.modeldefinition.model.Root:
+                - method 'ConstantExpression[getAgent_0]':
+                  - var:
+                    - name: __model__Agent_1_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - method 'ConstantExpression[getStages_0]':
+                  - var:
+                    - name: __model__Stages_13_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - ConstantExpression[null]
+                - method 'ConstantExpression[getEnvironment_0]':
+                  - var:
+                    - name: __model__Environment_15_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - ConstantExpression[null]
+                - ConstantExpression[null]
+                - method 'ConstantExpression[call]':
+                  - var:
+                    - name: __model__Closure_16_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - method 'ConstantExpression[call]':
+                  - var:
+                    - name: __model__Closure_17_something__
+                    - accessedVariable: org.codehaus.groovy.ast.DynamicVariable@something
+                  - tuples:
+                - ConstantExpression[null]
+                - ConstantExpression[some-uuid]
+      - properties:
+      - object initializers:

--- a/pipeline-model-definition/src/test/resources/twoStages.groovy
+++ b/pipeline-model-definition/src/test/resources/twoStages.groovy
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pipeline {
+    agent none
+    stages {
+        stage("hello") {
+            steps {
+                echo "hello world"
+            }
+        }
+        stage("goodbye") {
+            steps {
+                echo "goodbye world"
+            }
+        }
+    }
+}
+
+
+

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/DeclarativeStageConditionalDescriptor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/DeclarativeStageConditionalDescriptor.java
@@ -61,20 +61,36 @@ public abstract class DeclarativeStageConditionalDescriptor<S extends Declarativ
         return !"config.jelly".equals(getConfigPage());
     }
 
+    /**
+     * Whether this conditional is an invisible global conditional. Defaults to false.
+     */
+    public boolean isInvisible() {
+        return false;
+    }
+
     public abstract Expression transformToRuntimeAST(@CheckForNull ModelASTWhenContent original);
 
     /**
      * Get all {@link DeclarativeStageConditionalDescriptor}s.
      *
-     * @return a list of all {@link DeclarativeStageConditionalDescriptor}s registered.`
+     * @return a list of all {@link DeclarativeStageConditionalDescriptor}s registered, except for invisible global conditionals.
      */
     public static List<DeclarativeStageConditionalDescriptor> all() {
-        ExtensionList<DeclarativeStageConditionalDescriptor> descs = ExtensionList.lookup(DeclarativeStageConditionalDescriptor.class);
-        return descs.stream().sorted(Comparator.comparing(DeclarativeStageConditionalDescriptor::getName)).collect(Collectors.toList());
+        return allIncludingInvisible().stream().filter(d -> !d.isInvisible()).collect(Collectors.toList());
     }
 
     public static List<DeclarativeStageConditionalDescriptor> forGenerator() {
         return all().stream().filter(DeclarativeStageConditionalDescriptor::inDirectiveGenerator).collect(Collectors.toList());
+    }
+
+    private static List<DeclarativeStageConditionalDescriptor> allIncludingInvisible() {
+        ExtensionList<DeclarativeStageConditionalDescriptor> descs = ExtensionList.lookup(DeclarativeStageConditionalDescriptor.class);
+        return descs.stream()
+            .sorted(Comparator.comparing(DeclarativeStageConditionalDescriptor::getName)).collect(Collectors.toList());
+    }
+
+    public static List<DeclarativeStageConditionalDescriptor> allInvisible() {
+        return allIncludingInvisible().stream().filter(DeclarativeStageConditionalDescriptor::isInvisible).collect(Collectors.toList());
     }
 
     public static List<String> allNames() {

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/GlobalStageConditional.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/GlobalStageConditional.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.when;
+
+/**
+ * Globally defined conditionals which are checked for all stages in all builds of all jobs.
+ */
+public abstract class GlobalStageConditional<S extends GlobalStageConditional<S>> extends DeclarativeStageConditional<S> {
+
+    @Override
+    public GlobalStageConditionalDescriptor getDescriptor() {
+        return (GlobalStageConditionalDescriptor) super.getDescriptor();
+    }
+}

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/GlobalStageConditionalDescriptor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/GlobalStageConditionalDescriptor.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.when;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.MapExpression;
+import org.codehaus.groovy.ast.tools.GeneralUtils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.CommonUtils;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.InvisibleGlobalWhenCondition;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenContent;
+
+import java.util.Map;
+
+import static org.codehaus.groovy.ast.tools.GeneralUtils.args;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.callX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.classX;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.constX;
+
+/**
+ * Base descriptor for {@link GlobalStageConditional}
+ */
+public abstract class GlobalStageConditionalDescriptor<S extends GlobalStageConditional<S>> extends DeclarativeStageConditionalDescriptor<S> {
+
+    /**
+     * Generates a map of strings to objects which {@link #transformToRuntimeAST(ModelASTWhenContent)} will use for instantiating
+     * the {@link GlobalStageConditional} for this descriptor.
+     *
+     * @param when The when condition to be inspected
+     * @return A map of arguments to use for instantiation.
+     */
+    public abstract Map<String,Object> argMapForCondition(@NonNull InvisibleGlobalWhenCondition when);
+
+    @Override
+    public final boolean isInvisible() {
+        return true;
+    }
+
+    @Override
+    public final Expression transformToRuntimeAST(@CheckForNull ModelASTWhenContent when) {
+        if (when instanceof InvisibleGlobalWhenCondition) {
+            InvisibleGlobalWhenCondition invisibleWhen = (InvisibleGlobalWhenCondition) when;
+
+            MapExpression m = new MapExpression();
+            argMapForCondition(invisibleWhen).forEach((k, v) -> m.addMapEntryExpression(constX(k), constX(v)));
+
+            return callX(ClassHelper.make(CommonUtils.class),
+                "instantiateDescribable",
+                args(classX(clazz), m));
+        }
+        return GeneralUtils.constX(null);
+    }
+}

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/GlobalStageConditionalScript.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/GlobalStageConditionalScript.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2021, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.pipeline.modeldefinition.when;
+
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
+
+public abstract class GlobalStageConditionalScript<S extends GlobalStageConditional<S>>
+        extends DeclarativeStageConditionalScript<S> {
+
+    public GlobalStageConditionalScript(CpsScript s, S c) {
+        super(s, c);
+    }
+
+    public abstract boolean evaluate();
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-64508](https://issues.jenkins.io/browse/JENKINS-64508)
* Description:
    * Adds a new extension point and parse/transformation logic for globally defined when conditions that will be evaluated for every stage run on the controller when configured.
    * Also get the debug pretty printing for post-AST transformation to actually do something kinda useful again.
* Documentation changes:
    * n/a - no user-facing changes
* Users/aliases to notify:
    * ...
