### PR TITLE
In validation and elsewhere, prefer metasteps to other non-step descriptors

### DIFF
--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -69,6 +69,22 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DescriptorLookupCache.java
+++ b/pipeline-model-api/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/DescriptorLookupCache.java
@@ -119,7 +119,19 @@ public class DescriptorLookupCache {
             return null;
         } else if (describable == null) {
             if (!describableMap.containsKey(n)) {
-                Descriptor<? extends Describable> d = SymbolLookup.get().findDescriptor(Describable.class, n);
+                Descriptor<? extends Describable> d = null;
+
+                // Prefer metasteps, falling back on any old describable.
+                for (StepDescriptor metaStep : StepDescriptor.metaStepsOf(n)) {
+                    d = SymbolLookup.get().findDescriptor(metaStep.getMetaStepArgumentType(), n);
+                    if (d != null) {
+                        break;
+                    }
+                }
+                // Fall back on a non-metastep describable
+                if (d == null) {
+                    d = SymbolLookup.get().findDescriptor(Describable.class, n);
+                }
                 describableMap.put(n, d);
             }
 

--- a/pipeline-model-api/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DescriptorLookupCacheTest.java
+++ b/pipeline-model-api/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DescriptorLookupCacheTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2016, CloudBees, Inc.
+ * Copyright (c) 2021, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,71 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package org.jenkinsci.plugins.pipeline.modeldefinition;
 
-import htmlpublisher.HtmlPublisherTarget;
-import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.model.Descriptor;
-import hudson.model.Slave;
 import org.jenkinsci.Symbol;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.testMetaStep.Curve;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
-
-/**
- * @author Andrew Bayer
- */
-public class StepsTest extends AbstractModelDefTest {
-
-    private static Slave s;
-
-    @BeforeClass
-    public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setNumExecutors(10);
-        s.setLabelString("some-label");
-    }
+public class DescriptorLookupCacheTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
-    public void nestedTreeSteps() throws Exception {
-        expect("steps/nestedTreeSteps")
-                .logContains("[Pipeline] { (foo)", "[Pipeline] timeout", "[Pipeline] retry", "hello")
-                .go();
-    }
-
-    @Test
-    public void metaStepSyntax() throws Exception {
-        env(s).set();
-        expect("steps/metaStepSyntax")
-            .archives("msg.out", "hello world")
-            .archives("msg2.out", "goodbye world")
-            // Note that this test for the validator choosing a metastep over a random describable is inconsistent for
-            // the failure state - sometimes it works when it shouldn't for no obvious reason. A better test of this that
-            // will fail consistently is in pipeline-model-api's DescriptorLookupCacheTest#lookupFunctionPrefersMetaStep,
-            // but this is left here to be safe.
-            .logContains("wrapping in a 123-gon", "hi from in rhombus")
-            .go();
-    }
-
-    @Issue("JENKINS-41456")
-    @Test
-    public void htmlPublisher() throws Exception {
-        WorkflowRun b = expect("steps/htmlPublisher")
-                .logContains("[Pipeline] { (foo)")
-                .go();
-
-        HtmlPublisherTarget.HTMLBuildAction buildReport = b.getAction(HtmlPublisherTarget.HTMLBuildAction.class);
-        assertNotNull(buildReport);
-        assertEquals("Test Report", buildReport.getHTMLTarget().getReportName());
+    public void lookupFunctionPrefersMetaStep() throws Exception {
+        Descriptor<? extends Describable> d = DescriptorLookupCache.getPublicCache().lookupFunction("rhombus");
+        assertEquals(Rhombus.DescriptorImpl.class, d.getClass());
     }
 
     public static final class FakeRhombus extends AbstractDescribableImpl<FakeRhombus> {
@@ -116,7 +77,12 @@ public class StepsTest extends AbstractModelDefTest {
 
         @Symbol("rhombus")
         @TestExtension
-        public static class DescriptorImpl extends Descriptor<Curve> {}
-
+        public static class DescriptorImpl extends Descriptor<Curve> {
+            @Nonnull
+            @Override
+            public String getDisplayName() {
+                return "rhombus curve";
+            }
+        }
     }
 }

--- a/pipeline-model-definition/src/test/resources/json/steps/metaStepSyntax.json
+++ b/pipeline-model-definition/src/test/resources/json/steps/metaStepSyntax.json
@@ -70,6 +70,23 @@
               "value": "[$class: 'ArtifactArchiver', artifacts: 'msg2.out', fingerprint: true]"
             }
           }]
+        },
+        {
+          "name": "rhombus",
+          "arguments":           {
+            "isLiteral": true,
+            "value": 123
+          },
+          "children": [          {
+            "name": "echo",
+            "arguments": [            {
+              "key": "message",
+              "value":               {
+                "isLiteral": true,
+                "value": "hi from in rhombus"
+              }
+            }]
+          }]
         }
       ]
     }]

--- a/pipeline-model-definition/src/test/resources/steps/metaStepSyntax.groovy
+++ b/pipeline-model-definition/src/test/resources/steps/metaStepSyntax.groovy
@@ -33,6 +33,9 @@ pipeline {
                 writeFile text: 'goodbye world', file: 'msg2.out'
                 archiveArtifacts(allowEmptyArchive: true, artifacts: 'msg.out')
                 step([$class: 'ArtifactArchiver', artifacts: 'msg2.out', fingerprint: true])
+                rhombus(123) {
+                    echo 'hi from in rhombus'
+                }
             }
         }
     }


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * We always prefer `StepDescriptor`s to other `Descriptor`s, but can still hit symbol collisions and end up with the wrong `Descriptor` for a metastep symbol. It's not consistent across all cases - I think it has something to do with which `Symbol`-annotated class gets checked first in the symbol lookup, but I really can't be sure. So when we're looking up functions, we should prefer first `StepDescriptor`s, then `Descriptor`s for a metastep, and finally any ol' arbitrary `Descriptor`.
    * Note that I had trouble getting a full end-to-end test to fail correctly - something about the `Symbol`-annotated class check ordering or, worse, some caching of lookups that actually do what they're supposed to do before we even get there. I really can't tell. So there is a test in `pipeline-model-defintion`'s `StepsTest`, but it tends to always pass even when it shouldn't. I've added a new test to `pipeline-model-api`'s `DescriptorCacheLookupTest`, which tests the `lookupFunction` method directly and does fail correctly when expected. 
* Documentation changes:
    * n/a
* Users/aliases to notify:
    * ...
