### PR TITLE
Check statement type before casting to ExpressionStatement

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -1257,8 +1257,11 @@ class RuntimeASTTransformer {
             if (SCRIPT_SPLITTING_TRANSFORMATION) {
                 ArrayList<DeclarationExpression> declarations = new ArrayList<DeclarationExpression>()
                 moduleNode.statementBlock.statements.each { item ->
-                    if (((ExpressionStatement) item).expression instanceof DeclarationExpression) {
-                        declarations.add((DeclarationExpression) ((ExpressionStatement) item).expression)
+                    if (item instanceof ExpressionStatement) {
+                        ExpressionStatement es = (ExpressionStatement) item
+                        if (es.expression instanceof DeclarationExpression) {
+                            declarations.add((DeclarationExpression) es.expression)
+                        }
                     }
                 }
 


### PR DESCRIPTION
* JENKINS issue(s):
    * See https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/405#issuecomment-771677208.
* Description:
    * #405 introduced an unchecked cast to `ExpressionStatement` when `SCRIPT_SPLITTING_TRANSFORMATION` was active which caused failures in Pipelines that had other types of top-level statements. This PR moves that cast behind an `instanceof` check.
    * Side note: Do we not have SpotBugs here? Or does it not work with the code in `src/main/groovy` or something? I think that normally it would catch this kind of issue.
* Documentation changes:
    * N/A
* Users/aliases to notify:
    * @eplodn
