### PR TITLE
[JENKINS-34987] Improved output for local variable declarations with script splitting

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -110,6 +110,7 @@ public class BasicModelDefTest extends AbstractModelDefTest {
         RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES = false;
         expect(Result.FAILURE,"basic/stages100WithOutsideVarAndFunc")
             .logContains("add the '@Field' annotation to these local variable declarations")
+            .logContains("firstVar, secondVar, someVar")
             .logNotContains("Method code too large!")
             .go();
     }

--- a/pipeline-model-definition/src/test/resources/basic/stages100WithOutsideVarAndFunc.groovy
+++ b/pipeline-model-definition/src/test/resources/basic/stages100WithOutsideVarAndFunc.groovy
@@ -23,6 +23,7 @@
  */
 
 def someVar = "Hi there"
+def (firstVar, secondVar) = [1, 2]
 def someFunc() {
     return "This comes from a function"
 }


### PR DESCRIPTION
## JENKINS issue(s)
JENKINS-34987 , #405, #412
    
## Description

Per suggestion from @dwnusbaum, I've improved the output for variable declarations to only include the name.  The space was a bit more complex that just a stream statement since `getVariableExpression()` will throw for some types of declarations.
    
* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * ...
