### PR TITLE
Remove space from environment variable

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -85,7 +85,7 @@ class RuntimeASTTransformer {
      */
     @SuppressFBWarnings(value="MS_SHOULD_BE_FINAL", justification="For access from script console")
     public static boolean SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES = SystemProperties.getBoolean(
-            RuntimeASTTransformer.class.getName() + ". SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES",
+            RuntimeASTTransformer.class.getName() + ".SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES",
             false
     )
 


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * Pull request #405 introduced a new environment variable `SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES`. However, there is a typo in the variable, resulting in not being able to set this variable. This leaves the variable to the default.
* Documentation changes:
    * No documentation changes needed, it's just a typo.
* Users/aliases to notify:
    * @bitwiseman 
