### PR TITLE
Fix tables-to-divs issues in directive generator

### DIFF
--- a/pipeline-model-definition/src/main/resources/lib/pipelinemodeldefinition/blockWrapper.jelly
+++ b/pipeline-model-definition/src/main/resources/lib/pipelinemodeldefinition/blockWrapper.jelly
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
+    <j:choose>
+        <j:when test="${divBasedFormLayout}">
+            <d:invokeBody/>
+        </j:when>
+        <j:otherwise>
+            <table width="100%">
+                <d:invokeBody/>
+            </table>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/EnvironmentDirective/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/EnvironmentDirective/config.jelly
@@ -23,13 +23,13 @@
   ~ THE SOFTWARE.
   -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:c="/lib/credentials" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:p="/lib/pipelinemodeldefinition">
     <f:block>
         See <a href="https://jenkins.io/doc/book/pipeline/syntax/#environment" target="_blank">the online documentation</a>
         for more information on the <code>environment</code> directive.
         <f:entry title="${%Environment Variables}" help="${descriptor.getHelpPage()}">
             <f:repeatable var="env" items="${instance.getEnv()}">
-                <table width="100%">
+                <p:blockWrapper>
                     <f:entry title="${%Name}" help="${descriptor.getEnvHelp('name')}">
                         <f:textbox name="env.name" value="${env.name}" />
                     </f:entry>
@@ -42,7 +42,7 @@
                             <f:repeatableDeleteButton />
                         </div>
                     </f:entry>
-                </table>
+                </p:blockWrapper>
             </f:repeatable>
         </f:entry>
     </f:block>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/LibrariesDirective/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/LibrariesDirective/config.jelly
@@ -23,13 +23,13 @@
   ~ THE SOFTWARE.
   -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:p="/lib/pipelinemodeldefinition">
     <f:block>
         See <a href="https://jenkins.io/doc/book/pipeline/syntax/#libraries" target="_blank">the online documentation</a>
         for more information on the <code>libraries</code> directive.
         <f:entry title="${%Libraries}" help="${descriptor.getHelpPage()}">
             <f:repeatable var="libs" items="${instance.getLibs()}">
-                <table width="100%">
+                <p:blockWrapper>
                     <f:entry title="${%Name}" help="${descriptor.getLibHelp('name')}">
                         <f:textbox name="libs.name" value="${libs.name}" />
                     </f:entry>
@@ -41,7 +41,7 @@
                             <f:repeatableDeleteButton />
                         </div>
                     </f:entry>
-                </table>
+                </p:blockWrapper>
             </f:repeatable>
         </f:entry>
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ToolsDirective/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ToolsDirective/config.jelly
@@ -23,7 +23,7 @@
   ~ THE SOFTWARE.
   -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:d="jelly:define" xmlns:local="local">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout" xmlns:d="jelly:define" xmlns:local="local" xmlns:p="/lib/pipelinemodeldefinition">
     <f:block>
         See <a href="https://jenkins.io/doc/book/pipeline/syntax/#tools" target="_blank">the online documentation</a>
         for more information on the <code>tools</code> directive.
@@ -31,15 +31,29 @@
         <d:taglib uri="local">
             <d:tag name="body">
                 <j:set var="help" value="${d.helpFile}" />
-                <table style="width:100%">
-                    <tr>
-                        <td colspan="3">
-                            <div class="dd-handle">
-                                <b>${d.displayName}</b>
+                <p:blockWrapper>
+                    <j:choose>
+                        <j:when test="${divBasedFormLayout}">
+                            <div class="tr">
+                                <div colspan="3">
+                                    <div class="dd-handle">
+                                        <b>${d.displayName}</b>
+                                    </div>
+                                </div>
+                                <f:helpLink url="${help}"/>
                             </div>
-                        </td>
-                        <f:helpLink url="${help}"/>
-                    </tr>
+                        </j:when>
+                        <j:otherwise>
+                            <tr>
+                                <td colspan="3">
+                                    <div class="dd-handle">
+                                        <b>${d.displayName}</b>
+                                    </div>
+                                </td>
+                                <f:helpLink url="${help}"/>
+                            </tr>
+                        </j:otherwise>
+                    </j:choose>
                     <!-- TODO: help support is unintuitive; people should be able to see help from drop-down menu -->
                     <j:if test="${help!=null}">
                         <f:helpArea />
@@ -52,7 +66,7 @@
                             <f:repeatableDeleteButton value="${attrs.deleteCaption}" />
                         </div>
                     </f:block>
-                </table>
+                </p:blockWrapper>
             </d:tag>
         </d:taglib>
 
@@ -73,7 +87,7 @@
                     <div name="tools" title="${symbol}: ${d.displayName}" tooltip="${d.tooltip}" descriptorId="${d.id}">
                         <j:set var="capture" value="" />
                         <local:body>
-                            <l:renderOnDemand tag="tr" clazz="config-page" capture="d,it,instance,symbol,${capture}">
+                            <l:renderOnDemand tag="${divBasedFormLayout ? 'div' : 'tr'}" clazz="config-page" capture="d,it,instance,symbol,${capture}">
                                 <l:ajax>
                                     <f:entry title="${%Version}">
                                         <select class="setting-input" name="symbolAndName">


### PR DESCRIPTION
The declarative directive generators had some issues with it after the
migration from tables to divs, particularly in the tools section. Make
the necessary changes for compatibility with 2.264 and higher.

* JENKINS issue(s):
    * n/a
* Documentation changes:
    * not needed as bugfix only
* Users/aliases to notify:
    * @bitwiseman 
