### PR TITLE
Fix typo in issue id

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -1289,7 +1289,7 @@ class RuntimeASTTransformer {
                             declarationNames.add("Unrecognized declaration structure: " + left.toString())
                         }
                     }
-                    throw new IllegalStateException("[JENKINS-34987] SCRIPT_SPLITTING_TRANSFORMATION is an experimental feature of Declarative Pipeline and is incompatible with local variable declarations inside a Jenkinsfile. " +
+                    throw new IllegalStateException("[JENKINS-37984] SCRIPT_SPLITTING_TRANSFORMATION is an experimental feature of Declarative Pipeline and is incompatible with local variable declarations inside a Jenkinsfile. " +
                             "As a temporary workaround, you can add the '@Field' annotation to these local variable declarations. " +
                             "However, use of Groovy variables in Declarative pipeline, with or without the '@Field' annotation, is not recommended or supported. " +
                             "To use less effective script splitting which allows local variable declarations without changing your pipeline code, set SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES=true . " +


### PR DESCRIPTION
SCRIPT_SPLITTING_TRANSFORMATION should be JENKINS-37984, NOT JENKINS-34987.

* JENKINS issue(s):
    * https://issues.jenkins.io/browse/JENKINS-37984
    * https://issues.jenkins.io/browse/JENKINS-34987
* Description:
    * There was a typo in the issue id.
* Documentation changes:
    * The Jenkins error message references the wrong issue id, which makes the error message misleading.
* Users/aliases to notify:
    * @jglick 
