### PR TITLE
Call `Jenkins.setNodes` to adapt to core change in 2.302

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -54,6 +54,8 @@ public class AgentTest extends AbstractModelDefTest {
         s2.setLabelString("other-label");
         s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
                 new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "second")));
+
+        j.jenkins.setNodes(j.jenkins.getNodes());
     }
 
     @Issue("JENKINS-37932")


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/5450#issuecomment-888512618 and following discussion. Whether the new core behavior is a genuine regression is hard to pin down because I am not exactly sure how this test worked before—`Slave.setNumExecutors` updates a field but has no other effect itself.
