### PR TITLE
[JENKINS-66247] Properly report an unrecognized `agent` type

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/model/Agent.groovy
@@ -82,6 +82,9 @@ class Agent extends MappedClosure<Object,Agent> implements Serializable {
         String foundSymbol = findSymbol()
         if (foundSymbol != null) {
             DeclarativeAgentDescriptor foundDescriptor = DeclarativeAgentDescriptor.byName(foundSymbol)
+            if (foundDescriptor == null) {
+                return null
+            }
             def val = getMap().get(foundSymbol)
             def argMap = [:]
             if (val instanceof Map) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -586,7 +586,12 @@ class ModelInterpreter implements Serializable {
                 body.call()
             }.call()
         } else {
-            return agent.getDeclarativeAgent(root, context).getScript(script).run {
+            def declarativeAgent = agent.getDeclarativeAgent(root, context)
+            if (declarativeAgent == null) {
+                script.error 'Unrecognized agent type'
+                return null
+            }
+            return declarativeAgent.getScript(script).run {
                 body.call()
             }.call()
         }


### PR DESCRIPTION
Formerly this would just throw a NPE, observed in https://github.com/jenkinsci/bom/pull/587.

This patch does _not_ solve the actual bug, which is that https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/f06ef76fb39148bf1ee166f39e2ae191fee81955/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/None.java#L43 is not found, due to https://github.com/jenkinsci/lib-annotation-indexer/pull/10 via https://github.com/jenkinsci/plugin-pom/pull/424.

#442 did not reproduce the issue because then we are compiling `pipeline-model-definition` with the same version of core as we are running tests with. You need to run in PCT to see the problem.