### PR TITLE
Adapting `LibrariesTest`, `MultipleUnnamedParametersTest`, and `ScriptStepTest` to jenkinsci/jenkins#5425

### DIFF
--- a/pipeline-model-definition/src/test/resources/errors/globalLibraryNonStepBody.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/globalLibraryNonStepBody.groovy
@@ -24,9 +24,7 @@
 
 
 pipeline {
-    agent {
-        label "master"
-    }
+    agent any
     stages {
         stage("foo") {
             steps {

--- a/pipeline-model-definition/src/test/resources/errors/globalLibraryObjectMethodCall.groovy
+++ b/pipeline-model-definition/src/test/resources/errors/globalLibraryObjectMethodCall.groovy
@@ -24,9 +24,7 @@
 
 
 pipeline {
-    agent {
-        label "master"
-    }
+    agent any
     stages {
         stage("foo") {
             steps {

--- a/pipeline-model-definition/src/test/resources/json/libraries/globalLibrarySuccess.json
+++ b/pipeline-model-definition/src/test/resources/json/libraries/globalLibrarySuccess.json
@@ -77,10 +77,6 @@
     }]
   }],
   "agent":   {
-    "type": "label",
-    "argument":     {
-      "isLiteral": true,
-      "value": "master"
-    }
+    "type": "any"
   }
 }}

--- a/pipeline-model-definition/src/test/resources/libraries/globalLibrarySuccess.groovy
+++ b/pipeline-model-definition/src/test/resources/libraries/globalLibrarySuccess.groovy
@@ -24,9 +24,7 @@
 
 
 pipeline {
-    agent {
-        label "master"
-    }
+    agent any
     stages {
         stage("foo") {
             steps {

--- a/pipeline-model-definition/src/test/resources/libraries/globalLibrarySuccessInScript.groovy
+++ b/pipeline-model-definition/src/test/resources/libraries/globalLibrarySuccessInScript.groovy
@@ -24,9 +24,7 @@
 
 
 pipeline {
-    agent {
-        label "master"
-    }
+    agent any
     stages {
         stage("foo") {
             steps {


### PR DESCRIPTION
More breakage from jenkinsci/jenkins#5425, discovered when running PCT against a recent core incremental. This gets these tests to pass against both old and new cores.