### PR TITLE
Clarify rest api request method and content-type

### DIFF
--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -6,42 +6,55 @@ All API endpoints are exposed under `JENKINS_URL/pipeline-model-schema` or `JENK
 
 ### JSON Schema
 * *URL*: `JENKINS_URL/pipeline-model-schema/json`
+* *Method*: GET/POST
 * *Parameters*: None
 * *Info*: JSON schema for the JSON representation of the model.
 * *Returns*: The JSON schema
 
 ### Validation of `Jenkinsfile`
 * *URL*: `JENKINS_URL/pipeline-model-converter/validateJenkinsfile`
+* *Method*: POST
+* *Content-Type*: application/x-www-form-urlencoded
 * *Parameters*: `jenkinsfile` - the `Jenkinsfile` contents
 * *Info*: Takes a `Jenkinsfile` and validates its syntax, semantics, steps, parameters etc on the Jenkins master.
 * *Returns*: JSON with a `result` field that will either be `success` or `failure`. If `failure`, there'll be an additional array in the `errors` field of the error messages encountered.
 
 ### Validation of JSON representation
 * *URL*: `JENKINS_URL/pipeline-model-converter/validateJson`
+* *Method*: POST
+* *Content-Type*: application/x-www-form-urlencoded
 * *Parameters*: `json` - the JSON representation
 * *Info*: Takes a JSON representation of the model and validates its syntax, semantics, steps, parameters etc on the Jenkins master.
 * *Returns*: JSON with a `result` field that will either be `success` or `failure`. If `failure`, there'll be an additional array in the `errors` field of the error messages encountered.
 
 ### Conversion to JSON representation from Jenkinsfile
 * *URL*: `JENKINS_URL/pipeline-model-converter/toJson`
+* *Method*: POST
+* *Content-Type*: application/x-www-form-urlencoded
 * *Parameters*: `jenkinsfile` - the `Jenkinsfile` contents
 * *Info*: Takes a `Jenkinsfile` and converts it to the JSON representation for its `pipeline` step.
 * *Returns*: JSON with a `result` field that will either be `success` or `failure`. If `success`, the JSON representation will be in the `json` field. If `failure`, there'll be an additional array in the `errors` field of the error messages encountered.
 
 ### Conversion to Jenkinsfile from JSON representation
 * *URL*: `JENKINS_URL/pipeline-model-converter/toJenkinsfile`
+* *Method*: POST
+* *Content-Type*: application/x-www-form-urlencoded
 * *Parameters*: `json` - the JSON representation of the model
 * *Info*: Takes the JSON representation of the model and converts it to the contents for a `Jenkinsfile` invoking the `pipeline` step.
 * *Returns*: JSON with a `result` field that will either be `success` or `failure`. If `success`, the `Jenkinsfile` contents will be in the `jenkinsfile` field. If `failure`, there'll be an additional array in the `errors` field of the error messages encountered.
 
 ### Conversion of one or more steps to JSON representation from Groovy
 * *URL*: `JENKINS_URL/pipeline-model-converter/stepsToJson`
+* *Method*: POST
+* *Content-Type*: application/x-www-form-urlencoded
 * *Parameters*: `jenkinsfile` - the Groovy representation of the steps
 * *Info*: Takes a snippet of Groovy code containing one or more steps and converts it to the JSON representation for the step(s) it contains.
 * *Returns*: JSON with a `result` field that will either be `success` or `failure`. If `success`, the JSON representation will be in the `json` field. If `failure`, there'll be an additional array in the `errors` field of the error messages encountered.
 
 ### Conversion of one more steps to Groovy from JSON representation
 * *URL*: `JENKINS_URL/pipeline-model-converter/stepsToJenkinsfile`
+* *Method*: POST
+* *Content-Type*: application/x-www-form-urlencoded
 * *Parameters*: `json` - the JSON representation of the steps
 * *Info*: Takes the JSON representation of the steps and converts it to a snippet of Groovy code executing those steps.
 * *Returns*: JSON with a `result` field that will either be `success` or `failure`. If `success`, the Groovy contents will be in the `jenkinsfile` field. If `failure`, there'll be an additional array in the `errors` field of the error messages encountered.


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * The api doc did not indicate the requested content-type before. I tried to use `form-data`, which caused encoding issue. After some research, `x-www-form-urlencoded`  should be used instead. So add more detailed in api doc to clarify rest api request method and content-type
* Documentation changes:
    * Not need to change jenkins.io
* Users/aliases to notify:
    * ...
