### PR TITLE
Assume that configured agents are online

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -64,6 +64,7 @@ import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Andrew Bayer
@@ -109,7 +110,7 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
         return null;
     }
 
-    @Before
+    @Before // TODO rather use FlagRule
     public void setUpFeatureFlags() {
         defaultScriptSplitting = RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION;
         defaultScriptSplittingAllowLocalVariables = RuntimeASTTransformer.SCRIPT_SPLITTING_ALLOW_LOCAL_VARIABLES;
@@ -126,6 +127,9 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
     @Before
     public void setUp() throws Exception {
         ToolInstallations.configureMaven3();
+        for (Node n : j.jenkins.getNodes()) {
+            assumeTrue(n + " was offline", n.toComputer().isOnline());
+        }
     }
 
     public static final List<String> SHOULD_PASS_CONFIGS = ImmutableList.of(


### PR DESCRIPTION
Subclasses of `AbstractModelDefTest` frequently have blocks like https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/3f496434de4cf2fb618bf85d4fa306978a485630/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java#L64-L70 which invariably use `createOnlineSlave`. Yet according to test failures described in https://github.com/jenkinsci/bom/issues/613#issuecomment-969300344, occasionally these agents go offline for reasons not currently understood but probably environmental. Since this is very likely not a bug in tested plugin code, it ought not cause a test failure.
