### PR TITLE
Delete `<scm>` sections from submodules

### DIFF
--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -37,13 +37,6 @@
   <description>Model API for Declarative Pipeline</description>
   <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
 
-  <scm>
-    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
-    <tag>${scmTag}</tag>
-  </scm>
-
   <dependencies>
     <!-- JSON schema stuff -->
     <dependency>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -85,13 +85,6 @@
     </plugins>
   </build>
 
-  <scm>
-    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
-    <tag>${scmTag}</tag>
-  </scm>
-
   <dependencies>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-model-extensions/pom.xml
+++ b/pipeline-model-extensions/pom.xml
@@ -50,13 +50,6 @@
     </plugins>
   </build>
   
-  <scm>
-    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
-    <tag>${scmTag}</tag>
-  </scm>
-
   <dependencies>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>

--- a/pipeline-stage-tags-metadata/pom.xml
+++ b/pipeline-stage-tags-metadata/pom.xml
@@ -36,13 +36,6 @@
   <description>Library plugin for Pipeline stage tag metadata</description>
   <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
 
-  <scm>
-    <connection>scm:git:https://github.com/jenkinsci/pipeline-model-definition-plugin</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
-    <tag>${scmTag}</tag>
-  </scm>
-
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/463 deployed a bad incremental POM. `gitHubRepo` is correctly used in the parent POM, but then `<scm>` is being overridden in plugins inside it. This seems to be a common mistake.
