### PR TITLE
Set `child.scm.*.inherit.append.path=false`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </developer>
   </developers>
 
-  <scm>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>


### PR DESCRIPTION
Amends #464 to work around a silly default in Maven which dates to CVS/Subversion days.

```diff
--- before.xml	2021-11-17 13:51:54.820443485 -0500
+++ after.xml	2021-11-17 13:54:08.380403669 -0500
@@ -46,10 +46,10 @@
       <name>Andrew Bayer</name>
     </developer>
   </developers>
-  <scm>
-    <connection>scm:git:git://github.com/jenkinsci/pipeline-model-definition-plugin.git/pipeline-stage-tags-metadata</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git/pipeline-stage-tags-metadata</developerConnection>
-    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin/pipeline-stage-tags-metadata</url>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:git://github.com/jenkinsci/pipeline-model-definition-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pipeline-model-definition-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pipeline-model-definition-plugin</url>
   </scm>
   <distributionManagement>
     <repository>
```

See [docs](https://maven.apache.org/ref/3.8.3/maven-model-builder/#Inheritance_Assembly).

Not urgent since PCT knows to strip off this junk anyway.
