### PR TITLE
Update plugin parent POM and plugin BOM

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -53,25 +53,6 @@
         <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>codenarc-maven-plugin</artifactId>
-        <version>0.22-1</version>
-        <configuration>
-          <groovyVersion>2.4.7</groovyVersion>
-          <sourceDirectory>${project.basedir}/src/main/</sourceDirectory>
-          <maxPriority1Violations>0</maxPriority1Violations>
-        </configuration>
-        <executions>
-          <execution>
-            <id>codenarc</id>
-            <goals>
-              <goal>codenarc</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemProperties combine.children="append">

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.37</version>
     <relativePath />
   </parent>
 
@@ -74,8 +74,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
-        <version>1117.v62a_f6a_01de98</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1198.v387c834fca_1a_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -83,12 +83,6 @@
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
         <version>2.2</version>
-      </dependency>
-      <!-- TODO remove this dependency when it is available in the plugin-pom -->
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-test-harness</artifactId>
-        <version>1697.v6b_1e34cb_4ee6</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -100,6 +94,11 @@
         <artifactId>jcabi-matchers</artifactId>
         <version>1.5.3</version>
         <exclusions>
+          <exclusion>
+            <!-- RequireUpperBoundDeps conflict with XStream -->
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
           <exclusion>
             <!-- replaced by org.hamcrest:hamcrest -->
             <groupId>org.hamcrest</groupId>
@@ -161,7 +160,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/pipeline-model-definition-plugin</gitHubRepo>
-    <jenkins.version>2.321</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
     <java.level>8</java.level>
     <groovy.version>2.4.12</groovy.version>
   </properties>


### PR DESCRIPTION
Updates the plugin parent POM from a weekly to an LTS, along with updating the plugin BOM accordingly. This is necessary in order to be able to test this plugin on Java 17, as I am trying to do in jenkinsci/bom#935. The CodeNarc Maven plugin doesn't seem to work at all on Java 17, but it appears to be adding little value so I just removed it. With these changes I can run `mvn clean verify -Dtest=org.jenkinsci.plugins.pipeline.modeldefinition.DeclarativePipelineTest -DfailIfNoTests=false -Djenkins-test-harness.version=1721.v385389722736 '-DargLine=--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED'` successfully on Java 17. CC @car-roll 