### PR TITLE
Update plugin BOM and jenkins version

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -53,25 +53,6 @@
         <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>codenarc-maven-plugin</artifactId>
-        <version>0.22-1</version>
-        <configuration>
-          <groovyVersion>2.4.7</groovyVersion>
-          <sourceDirectory>${project.basedir}/src/main/</sourceDirectory>
-          <maxPriority1Violations>0</maxPriority1Violations>
-        </configuration>
-        <executions>
-          <execution>
-            <id>codenarc</id>
-            <goals>
-              <goal>codenarc</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemProperties combine.children="append">

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -53,6 +53,25 @@
         <artifactId>gmavenplus-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>codenarc-maven-plugin</artifactId>
+        <version>0.22-1</version>
+        <configuration>
+          <groovyVersion>2.4.7</groovyVersion>
+          <sourceDirectory>${project.basedir}/src/main/</sourceDirectory>
+          <maxPriority1Violations>0</maxPriority1Violations>
+        </configuration>
+        <executions>
+          <execution>
+            <id>codenarc</id>
+            <goals>
+              <goal>codenarc</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemProperties combine.children="append">

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
@@ -161,6 +161,7 @@ public class LibrariesTest extends AbstractModelDefTest {
     @Test
     public void folderLibraryParsing() throws Exception {
         otherRepo.init();
+        otherRepo.git("config", "--global", "core.longpaths", "true");
         otherRepo.git("checkout", "-b", "test");
         otherRepo.write("src/org/foo/Zot.groovy", "package org.foo;\n" +
                 "\n" +

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
@@ -161,6 +161,7 @@ public class LibrariesTest extends AbstractModelDefTest {
     @Test
     public void folderLibraryParsing() throws Exception {
         otherRepo.init();
+        // longpaths to support longer filenames for windows. Only needs to be set once.
         otherRepo.git("config", "--global", "core.longpaths", "true");
         otherRepo.git("checkout", "-b", "test");
         otherRepo.write("src/org/foo/Zot.groovy", "package org.foo;\n" +

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.37</version>
     <relativePath />
   </parent>
 
@@ -74,8 +74,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
-        <version>1117.v62a_f6a_01de98</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1198.v387c834fca_1a_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -83,12 +83,6 @@
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
         <version>2.2</version>
-      </dependency>
-      <!-- TODO remove this dependency when it is available in the plugin-pom -->
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>jenkins-test-harness</artifactId>
-        <version>1697.v6b_1e34cb_4ee6</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -100,6 +94,11 @@
         <artifactId>jcabi-matchers</artifactId>
         <version>1.5.3</version>
         <exclusions>
+          <exclusion>
+            <!-- RequireUpperBoundDeps conflict with XStream -->
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
           <exclusion>
             <!-- replaced by org.hamcrest:hamcrest -->
             <groupId>org.hamcrest</groupId>
@@ -161,7 +160,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/pipeline-model-definition-plugin</gitHubRepo>
-    <jenkins.version>2.321</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
     <java.level>8</java.level>
     <groovy.version>2.4.12</groovy.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.37</version>
+    <version>4.31</version>
     <relativePath />
   </parent>
 
@@ -74,8 +74,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
-        <version>1198.v387c834fca_1a_</version>
+        <artifactId>bom-2.319.x</artifactId>
+        <version>1117.v62a_f6a_01de98</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -83,6 +83,12 @@
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
         <version>2.2</version>
+      </dependency>
+      <!-- TODO remove this dependency when it is available in the plugin-pom -->
+      <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-test-harness</artifactId>
+        <version>1697.v6b_1e34cb_4ee6</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
@@ -94,11 +100,6 @@
         <artifactId>jcabi-matchers</artifactId>
         <version>1.5.3</version>
         <exclusions>
-          <exclusion>
-            <!-- RequireUpperBoundDeps conflict with XStream -->
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
           <exclusion>
             <!-- replaced by org.hamcrest:hamcrest -->
             <groupId>org.hamcrest</groupId>
@@ -160,7 +161,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/pipeline-model-definition-plugin</gitHubRepo>
-    <jenkins.version>2.332.1</jenkins.version>
+    <jenkins.version>2.321</jenkins.version>
     <java.level>8</java.level>
     <groovy.version>2.4.12</groovy.version>
   </properties>


### PR DESCRIPTION
This PR refiles the BOM portion of #498 as it was reverted in #501 due to windows CI failures.

Failures generated are `filename too long`. See: https://github.com/jenkinsci/pipeline-model-definition-plugin/runs/5580211853

See also: https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/499

cc @basil 