### PR TITLE
core.longpaths config no longer needed for windows git

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
@@ -161,8 +161,6 @@ public class LibrariesTest extends AbstractModelDefTest {
     @Test
     public void folderLibraryParsing() throws Exception {
         otherRepo.init();
-        // longpaths to support longer filenames for windows. Only needs to be set once.
-        otherRepo.git("config", "--global", "core.longpaths", "true");
         otherRepo.git("checkout", "-b", "test");
         otherRepo.write("src/org/foo/Zot.groovy", "package org.foo;\n" +
                 "\n" +


### PR DESCRIPTION
https://github.com/jenkins-infra/pipeline-library/pull/334 should remove the need to call `core.longpaths` for windows git.