### PR TITLE
Remove JCabi Matchers

### DIFF
--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -211,11 +211,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.jcabi</groupId>
-      <artifactId>jcabi-matchers</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -58,13 +58,13 @@ import java.nio.charset.Charset;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.jcabi.matchers.RegexMatchers.containsPattern;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
+import static org.jvnet.hudson.test.JenkinsMatchers.matchesPattern;
 
 /**
  * @author Andrew Bayer
@@ -564,7 +564,7 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
             if (logMatches != null) {
                 String log = JenkinsRule.getLog(run);
                 for (String pattern : logMatches) {
-                    assertThat(log, containsPattern(pattern));
+                    assertThat(log, matchesPattern(pattern));
                 }
             }
             if (hasFailureCause) {

--- a/pom.xml
+++ b/pom.xml
@@ -90,28 +90,6 @@
         <version>2.2</version>
       </dependency>
       <dependency>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-matchers</artifactId>
-        <version>1.5.3</version>
-        <exclusions>
-          <exclusion>
-            <!-- RequireUpperBoundDeps conflict with XStream -->
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <!-- replaced by org.hamcrest:hamcrest -->
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-          </exclusion>
-          <exclusion>
-            <!-- replaced by org.hamcrest:hamcrest -->
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pipeline-milestone-step</artifactId>
         <version>100.v60a_03cd446e1</version>


### PR DESCRIPTION
This test dependency has caused us a lot of pain with `RequireUpperBoundDeps`. Simpler just to remove it and rely on the Jenkins Test Harness instead. CC @car-roll 