### PR TITLE
calling setLabels on an agent will not persist the node.

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AgentTest.java
@@ -44,18 +44,18 @@ public class AgentTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("some-label");
+        s = j.createSlave("some-label", null);
         s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
                 new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "first")));
         s.setNumExecutors(2);
 
-        s2 = j.createOnlineSlave();
-        s2.setLabelString("other-label");
+        s2 = j.createSlave("other-label", null);
         s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
                 new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "second")));
 
         j.jenkins.setNodes(j.jenkins.getNodes());
+        j.waitOnline(s);
+        j.waitOnline(s2);
     }
 
     @Issue("JENKINS-37932")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -69,9 +69,9 @@ public class BasicModelDefTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
+        s = j.createSlave("some-label", null);
         s.setNumExecutors(10);
-        s.setLabelString("some-label");
+        j.waitOnline(s);
     }
 
     @Issue("JENKINS-47363")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DurabilityTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/DurabilityTest.java
@@ -76,8 +76,7 @@ public class DurabilityTest extends AbstractDeclarativeTest {
             @Override public void evaluate() throws Throwable {
                 RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION = true;
                 logger.record(CpsFlowExecution.class, Level.WARNING).capture(100);
-                DumbSlave s = story.j.createOnlineSlave();
-                s.setLabelString("remote quick");
+                DumbSlave s = story.j.createSlave("remote quick", null);
                 s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true")));
 
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "demo");
@@ -169,8 +168,7 @@ public class DurabilityTest extends AbstractDeclarativeTest {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 logger.record(CpsFlowExecution.class, Level.WARNING).capture(100);
-                DumbSlave s = story.j.createOnlineSlave();
-                s.setLabelString("remote quick");
+                DumbSlave s = story.j.createSlave("remote quick", null);
                 s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true")));
 
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "demo");

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/EnvironmentTest.java
@@ -43,8 +43,7 @@ public class EnvironmentTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("some-label");
+        s = j.createSlave("some-label", null);
         s.getNodeProperties().add(
                 new EnvironmentVariablesNodeProperty(
                         new EnvironmentVariablesNodeProperty.Entry("HAS_BACKSLASHES", "C:\\Windows"),

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/LibrariesTest.java
@@ -53,9 +53,8 @@ public class LibrariesTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
+        s = j.createSlave("some-label", null);
         s.setNumExecutors(10);
-        s.setLabelString("some-label");
     }
 
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
@@ -66,22 +66,18 @@ public class MatrixTest extends AbstractModelDefTest {
     private static String password;
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("agent-one some-label");
+        s = j.createSlave("agent-one some-label", null);
         s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
             new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "first")));
         s.setNumExecutors(10);
 
-        linux = j.createOnlineSlave();
-        linux.setLabelString("linux-agent");
+        linux = j.createSlave("linux-agent", null);
         linux.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
             new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "linux agent")));
-        mac = j.createOnlineSlave();
-        mac.setLabelString("mac-agent");
+        mac = j.createSlave("mac-agent", null);
         mac.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
             new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "mac agent")));
-        windows = j.createOnlineSlave();
-        windows.setLabelString("windows-agent");
+        windows = j.createSlave("windows-agent", null);
         windows.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true"),
             new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "windows agent")));
     }
@@ -529,12 +525,10 @@ public class MatrixTest extends AbstractModelDefTest {
     @Issue("JENKINS-46809")
     @Test
     public void matrixStagesGroupsAndStages() throws Exception {
-        Slave s = j.createOnlineSlave();
-        s.setLabelString("first-agent");
+        Slave s = j.createSlave("first-agent", null);
         s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "first agent")));
 
-        Slave s2 = j.createOnlineSlave();
-        s2.setLabelString("second-agent");
+        Slave s2 = j.createSlave("second-agent", null);
         s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "second agent")));
 
         WorkflowRun b = expect("matrix/matrixStagesGroupsAndStages")
@@ -609,12 +603,10 @@ public class MatrixTest extends AbstractModelDefTest {
     @Issue("JENKINS-53734")
     @Test
     public void matrixStagesNestedInSequential() throws Exception {
-        Slave s = j.createOnlineSlave();
-        s.setLabelString("first-agent");
+        Slave s = j.createSlave("first-agent", null);
         s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "first agent")));
 
-        Slave s2 = j.createOnlineSlave();
-        s2.setLabelString("second-agent");
+        Slave s2 = j.createSlave("second-agent", null);
         s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "second agent")));
 
         expect("matrix/matrixStagesNestedInSequential")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParallelTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParallelTest.java
@@ -63,12 +63,10 @@ public class ParallelTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
+        s = j.createSlave("first-agent some-label", null);
         s.setNumExecutors(10);
-        s.setLabelString("first-agent some-label");
         s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "first agent")));
-        s2 = j.createOnlineSlave();
-        s2.setLabelString("second-agent");
+        s2 = j.createSlave("second-agent", null);
         s2.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("WHICH_AGENT", "second agent")));
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -43,8 +43,7 @@ public class PostStageTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("here");
+        s = j.createSlave("here", null);
     }
 
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ScriptStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ScriptStepTest.java
@@ -36,8 +36,7 @@ public class ScriptStepTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("some-label");
+        s = j.createSlave("some-label", null);
     }
 
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/SerializationTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/SerializationTest.java
@@ -65,9 +65,8 @@ public class SerializationTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
+        s = j.createSlave("some-label test", null);
         s.setNumExecutors(4);
-        s.setLabelString("some-label test");
         s.getNodeProperties().add(new EnvironmentVariablesNodeProperty(new EnvironmentVariablesNodeProperty.Entry("ONAGENT", "true")));
     }
 

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/StepsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/StepsTest.java
@@ -50,9 +50,8 @@ public class StepsTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
+        s = j.createSlave("some-label", null);
         s.setNumExecutors(10);
-        s.setLabelString("some-label");
     }
 
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ToolsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ToolsTest.java
@@ -42,8 +42,7 @@ public class ToolsTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("some-label");
+        s = j.createSlave("some-label", null);
     }
 
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ValidatorTest.java
@@ -65,8 +65,7 @@ public class ValidatorTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("some-label");
+        s = j.createSlave("some-label", null);
     }
 
     @Issue("JENKINS-39011")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageMultibranchTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageMultibranchTest.java
@@ -49,8 +49,7 @@ public class WhenStageMultibranchTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("here");
+        s = j.createSlave("here", null);
     }
 
     @Test

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/WhenStageTest.java
@@ -85,8 +85,7 @@ public class WhenStageTest extends AbstractModelDefTest {
 
     @BeforeClass
     public static void setUpAgent() throws Exception {
-        s = j.createOnlineSlave();
-        s.setLabelString("here");
+        s = j.createSlave("here", null);
     }
 
     @Test


### PR DESCRIPTION
in older versions of Jenkins the tests would be less flaky as adding any
Node would cause all labels to be re-evaluated, so when creating a few
agents and adding labels in a loop the last one created would at least
deterministically ensure that all previous agents labels where correct.

However since 2.332 (jenkinsci/jenkins#5882)
only labels part of a node added or removed would be updated, and when
creating the agents they where created without labels, which where added
later.

This has the potential to cause tests to be flaky depending on when the periodic
trimLabels was called (or at least on other timing related things)

Additionally creating agents and waiting for them to come oneline is
slow. A job can be scheduled and the pipeline will run and then wait for the node to be
available,
so we can do other things whilst the agent is connecting.

* JENKINS issue(s):
    * Issue link or n/a
* Description:
    * ...
* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * ...
