### PR TITLE
Use GroovySourceFileAllowlist to adapt to SECURITY-359 changes

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
@@ -32,6 +32,8 @@ import org.jenkinsci.plugins.workflow.cps.CpsThread;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
 /**
  * Loads the main "pipeline" step as well as the additional CPS-transformed code it depends on.
@@ -70,6 +72,16 @@ public class ModelStepLoader extends GlobalVariable {
     @Initializer(after = InitMilestone.EXTENSIONS_AUGMENTED)
     public static void invalidateOptionTypeCaches() {
         Options.invalidateCaches();
+    }
+
+    @Extension
+    public static class ModelInterpreterAllowlist extends GroovySourceFileAllowlist {
+        private final String scriptUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy")).toString();
+
+        @Override
+        public boolean isAllowed(String groovyResourceUrl) {
+            return groovyResourceUrl.equals(scriptUrl);
+        }
     }
 
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
@@ -30,10 +30,9 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.model.Options;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.CpsThread;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
+import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Objects;
-import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
 /**
  * Loads the main "pipeline" step as well as the additional CPS-transformed code it depends on.
@@ -76,7 +75,7 @@ public class ModelStepLoader extends GlobalVariable {
 
     @Extension
     public static class ModelInterpreterAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy")).toString();
+        private final String scriptUrl = ModelStepLoader.class.getResource("/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/ModelStepLoader.java
@@ -75,7 +75,7 @@ public class ModelStepLoader extends GlobalVariable {
 
     @Extension
     public static class ModelInterpreterAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = ModelStepLoader.class.getResource("/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy").toString();
+        private final String scriptUrl = ModelStepLoader.class.getResource("ModelInterpreter.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeLogConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeLogConditional.java
@@ -38,7 +38,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
 import java.util.regex.Pattern;
+import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
 /**
  * Conditional that checks the messages in the changelog.
@@ -89,5 +91,19 @@ public class ChangeLogConditional extends DeclarativeStageConditional<ChangeLogC
     @Restricted(NoExternalUse.class)
     public static String expandForMultiLine(String pattern) {
         return "(?m)(?s)^[^\\r\\n]*?" + pattern + "[^\\r\\n]*?$";
+    }
+
+    /**
+     * AbstractChangelogConditionalScriptAllowlist.groovy is a superclass of the Groovy scripts for some subclasses of
+     * {@link DeclarativeStageConditional}, but does not have any direct equivalent Java class, so we just allow it here.
+     */
+    @Extension
+    public static class ChangelogConditionalScriptAllowlist extends GroovySourceFileAllowlist {
+        private final String scriptUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/AbstractChangelogConditionalScript.groovy")).toString();
+
+        @Override
+        public boolean isAllowed(String groovyResourceUrl) {
+            return groovyResourceUrl.equals(scriptUrl);
+        }
     }
 }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeLogConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeLogConditional.java
@@ -32,15 +32,14 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTWhenContent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.parser.ASTParserUtils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditional;
 import org.jenkinsci.plugins.pipeline.modeldefinition.when.DeclarativeStageConditionalDescriptor;
+import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Objects;
 import java.util.regex.Pattern;
-import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
 /**
  * Conditional that checks the messages in the changelog.
@@ -99,7 +98,7 @@ public class ChangeLogConditional extends DeclarativeStageConditional<ChangeLogC
      */
     @Extension
     public static class ChangelogConditionalScriptAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/AbstractChangelogConditionalScript.groovy")).toString();
+        private final String scriptUrl = ChangeLogConditional.class.getResource("/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/AbstractChangelogConditionalScript.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeLogConditional.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/ChangeLogConditional.java
@@ -98,7 +98,7 @@ public class ChangeLogConditional extends DeclarativeStageConditional<ChangeLogC
      */
     @Extension
     public static class ChangelogConditionalScriptAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = ChangeLogConditional.class.getResource("/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/AbstractChangelogConditionalScript.groovy").toString();
+        private final String scriptUrl = ChangeLogConditional.class.getResource("AbstractChangelogConditionalScript.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest$ComplexDeclarativeAgentScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest$ComplexDeclarativeAgentScript.groovy
@@ -1,0 +1,1 @@
+// All implementations of WithScriptDescribable must have an associated Groovy source file.

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -108,7 +108,7 @@ public abstract class DeclarativeAgent<A extends DeclarativeAgent<A>> extends Wi
 
     @Extension
     public static class CheckoutScriptAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = DeclarativeAgent.class.getResource("/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy").toString();
+        private final String scriptUrl = DeclarativeAgent.class.getResource("CheckoutScript.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -27,11 +27,14 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
 import hudson.ExtensionPoint;
 import java.util.Map;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.Objects;
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptDescribable;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptScript;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.CpsThread;
+import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
 
 /**
  * Implementations for {@link DeclarativeAgentDescriptor} - pluggable agent backends for Declarative Pipelines.
@@ -102,6 +105,16 @@ public abstract class DeclarativeAgent<A extends DeclarativeAgent<A>> extends Wi
     @Override
     public DeclarativeAgentDescriptor getDescriptor() {
         return (DeclarativeAgentDescriptor) super.getDescriptor();
+    }
+
+    @Extension
+    public static class CheckoutScriptAllowlist extends GroovySourceFileAllowlist {
+        private final String scriptUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy")).toString();
+
+        @Override
+        public boolean isAllowed(String groovyResourceUrl) {
+            return groovyResourceUrl.equals(scriptUrl);
+        }
     }
 
 }

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -28,7 +28,6 @@ import hudson.ExtensionPoint;
 import java.util.Map;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import java.util.Objects;
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptDescribable;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptScript;
@@ -109,7 +108,7 @@ public abstract class DeclarativeAgent<A extends DeclarativeAgent<A>> extends Wi
 
     @Extension
     public static class CheckoutScriptAllowlist extends GroovySourceFileAllowlist {
-        private final String scriptUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy")).toString();
+        private final String scriptUrl = DeclarativeAgent.class.getResource("/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy").toString();
 
         @Override
         public boolean isAllowed(String groovyResourceUrl) {

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescriptor.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/withscript/WithScriptDescriptor.java
@@ -75,9 +75,9 @@ public abstract class WithScriptDescriptor<T extends WithScriptDescribable<T>> e
     }
 
     @SuppressFBWarnings(value = "UI_INHERITANCE_UNSAFE_GETRESOURCE", justification = "We intentionally want to use the class loader for the subclass in this case")
-    protected @NonNull URL getScriptResource() {
-        String scriptFile = getScriptClass().replace('.', '/') + ".groovy";
-        return Objects.requireNonNull(getClass().getClassLoader().getResource(scriptFile),
+    private @NonNull URL getScriptResource() {
+        String scriptFile = '/' + getScriptClass().replace('.', '/') + ".groovy";
+        return Objects.requireNonNull(getClass().getResource(scriptFile),
                 () -> "Unable to find resource file: " + scriptFile);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,23 @@
         <artifactId>json-schema-validator</artifactId>
         <version>2.2.14</version>
       </dependency>
+      <dependency>
+        <!-- TODO: Remove once this version is included in BOM -->
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>script-security</artifactId>
+        <version>1172.v35f6a_0b_8207e</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-cps</artifactId>
+        <version>2699.v7231c3b_4a_231</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/538 -->
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-cps</artifactId>
+        <version>2699.v7231c3b_4a_231</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/538 -->
+        <classifier>tests</classifier>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,12 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2699.v7231c3b_4a_231</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/538 -->
+        <version>${workflow-cps-plugin.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2699.v7231c3b_4a_231</version> <!-- TODO: https://github.com/jenkinsci/workflow-cps-plugin/pull/538 -->
+        <version>${workflow-cps-plugin.version}</version>
         <classifier>tests</classifier>
       </dependency>
     </dependencies>
@@ -147,6 +147,7 @@
     <gitHubRepo>jenkinsci/pipeline-model-definition-plugin</gitHubRepo>
     <jenkins.version>2.332.1</jenkins.version>
     <groovy.version>2.4.12</groovy.version>
+    <workflow-cps-plugin.version>2692.v76b_089ccd026</workflow-cps-plugin.version> <!-- TODO: Delete this property and the dependencyManagement entries that use it once this version is included in the BOM -->
   </properties>
 
   <profiles>


### PR DESCRIPTION
See https://github.com/jenkinsci/workflow-cps-plugin/pull/538. The fix for SECURITY-359 added a new API that should be used by plugins that define Groovy DSLs. Declarative defines two main kinds of Groovy DSLs:

* `ModelInterpreter.groovy` via `ModelStepLoader`: The main declarative syntax
* Various Groovy files via subclasses of `WithScriptDescribable`: Extensions related to `agent` (`DeclarativeAgent`, used by other plugins, specifically `docker-workflow`, `kubernetes`, and `amazon-ecs`) and `when` (`DeclarativeStageConditional`).`

This PR implements `GroovySourceFileAllowlist` for various individual files, but also for `WithScriptDescribable` in a generic way that automatically allows the scripts used by subclasses. This allows us to remove entries from `default-allowlist` upstream in `workflow-cps`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue