### PR TITLE
Remove assumption that configured agents are online

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -65,7 +65,6 @@ import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
 import static org.jvnet.hudson.test.JenkinsMatchers.matchesPattern;
 
 /**
@@ -123,9 +122,6 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
     @Before
     public void setUp() throws Exception {
         ToolInstallations.configureMaven3();
-        for (Node n : j.jenkins.getNodes()) {
-            assumeTrue(n + " was offline", n.toComputer().isOnline());
-        }
     }
 
     public static final List<String> SHOULD_PASS_CONFIGS = ImmutableList.of(


### PR DESCRIPTION
#462 (arguably) made sense at the time. Yet after #527, the effect was that a lot of tests (e.g., `LibrariesTest`) started being skipped all the time.
