### PR TITLE
Simplify `AnyScript`

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AnyScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AnyScript.groovy
@@ -25,6 +25,7 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
 
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
@@ -36,11 +37,10 @@ class AnyScript extends DeclarativeAgentScript<Any> {
 
     @Override
     Closure run(Closure body) {
-        Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: null])
-        l.copyFlags(describable)
-        LabelScript labelScript = (LabelScript) l.getScript(script)
-        return labelScript.run {
-            body.call()
+        return {
+            script.node {
+                CheckoutScript.doCheckout(script, describable, null, body).call()
+            }
         }
     }
 }


### PR DESCRIPTION
Simplifying a rather roundabout system to just be like https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/12b420f036e5e4d114791602b896c5790567f7a6/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy#L41-L45 except without the `label` and `customWorkspace` fields. The weird logic seems to have been introduced in #94, at which time perhaps it made sense but it seems `CheckoutScript` when introduced in #123 was not also used here.
