### PR TITLE
Use Eclipse Temurin in the CD action, not AdoptOpenJDK

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,9 +47,9 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 8
     - name: Release
       uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0


### PR DESCRIPTION
## Use Eclipse Temurin in the CD action, not AdoptOpenJDK

See https://github.com/jenkinsci/jenkins/pull/6406 for more details

The 'adopt' distribution has moved to Eclipse Temurin and won't be updated at the AdoptOpenJDK location.  Switch to the Temurin distribution so that we use a current version of Java.

- Bump actions/setup-java from 2 to 3 (dependabot proposed in #300)
- Use Eclipse Temurin in the action, not AdoptOpenJDK

Supersedes https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/511

* JENKINS issue(s):
    * n/a
* Description:
    * The 'adopt' distribution has moved to Eclipse Temurin and won't be updated at the AdoptOpenJDK location.  Switch to the Temurin distribution so that we use a current version of Java.
* Documentation changes:
    * No documentation changes needed
* Users/aliases to notify:
    * n/a
