### PR TITLE
[JENKINS-70808] Add a specific isRestartable method that accept a sta…

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
@@ -38,6 +38,7 @@ import org.acegisecurity.AccessDeniedException;
 import org.jenkinsci.plugins.pipeline.StageStatus;
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils;
 import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStage;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStages;
 import org.jenkinsci.plugins.pipeline.modeldefinition.causes.RestartDeclarativePipelineCause;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -168,6 +169,30 @@ public class RestartDeclarativePipelineAction implements Action {
             }
         }
         return stages;
+    }
+
+    /**
+     * Returns whether a stage is restartable.
+     * @param stageName the stage name
+     * @return true is restartable, false otherwise
+     */
+    public boolean isRestartable(String stageName) {
+        FlowExecution execution = getExecution();
+        if (execution != null) {
+            ExecutionModelAction execAction = run.getAction(ExecutionModelAction.class);
+            if (execAction != null) {
+                ModelASTStages stages = execAction.getStages();
+                if (stages != null) {
+                    for (ModelASTStage s : stages.getStages()) {
+                        if(s.getName().equals(stageName)) {
+                            return !Utils.stageHasStatusOf(s.getName(), execution,
+                                StageStatus.getSkippedForFailure(), StageStatus.getSkippedForUnstable());
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     public String getCheckUrl() {


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-70808](https://issues.jenkins.io/browse/JENKINS-70808)
* Description:
    * Add a method to specifically check if a stage is restartable that will return as soon as one is found and will not check the status of other irrelevant stages. To be consumed downstream by blueocean-pipeline-api-impl at https://github.com/jenkinsci/blueocean-plugin/blob/49440310221d3e68040c0a46842b8a91d0a577be/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineNodeImpl.java#L189-L193.
* Users/aliases to notify:
    * @olamy
