### PR TITLE
Upgrade plugin parent POM from 4.56 to 4.57

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.56</version>
+    <version>4.57</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Sorry for another build PR so soon after the last one. This is needed for the forthcoming PCT multi-module mode to pull in the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658) via https://github.com/jenkinsci/maven-hpi-plugin/pull/453. I tested this successfully with the latest update to the multimodule project branch of PCT, which is now doing `mvn process test-classes` rather than `mvn install`, therefore requiring the fix for [JENKINS-62658](https://issues.jenkins.io/browse/JENKINS-62658). With these changes you can now successfully run `mvn process-test-classes` in the root directory of the repository, which was not possible with the old version of Maven HPI plugin.

CC @car-roll @jglick @olamy