### PR TITLE
Make security scanners happy about XRAY-178804 Rhino XXE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,16 @@
         <artifactId>json-schema-validator</artifactId>
         <version>2.2.14</version>
       </dependency>
+      <dependency>
+        <!-- XRAY-178804 indirect dependency of json-schema-validator.
+              No new version of json-schema-validator is available and seems abandoned.
+              The XXE is not reachable from this plugin and a new schema validator library is needed,
+              but in the meantime manage the rhino dependency to satisfy security scanners.
+        -->
+        <groupId>org.mozilla</groupId>
+        <artifactId>rhino</artifactId>
+        <version>1.7.14</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
No new version of json-schema-validator is available and seems abandoned.
The XXE is not reachable from this plugin and a new schema validator library is needed,
but in the meantime manage the rhino dependency to satisfy security scanners.
