### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
@@ -84,16 +84,25 @@
                         function handlePrototype_${id}() {
                         buildFormTree(document.forms.config);
                         // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
-                        var json = Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype);
+                        // TODO simplify when Prototype.js is removed
+                        var json = Object.toJSON ? Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype) : JSON.stringify(JSON.parse(document.forms.config.elements.json.value).prototype);
                         if (!json) {
                         return; // just a separator
                         }
-                        new Ajax.Request('${rootURL}/${it.GENERATE_URL}', {
-                        method: 'POST',
-                        parameters: {json: json},
-                        onSuccess: function(r) {
-                        document.getElementById('prototypeText_${id}').value = r.responseText;
-                        }
+                        fetch('${rootURL}/${it.GENERATE_URL}', {
+                            method: 'post',
+                            headers: crumb.wrap({
+                                "Content-Type": "application/x-www-form-urlencoded",
+                            }),
+                            body: new URLSearchParams({
+                                json: json,
+                            }),
+                        }).then((rsp) => {
+                            if (rsp.ok) {
+                                rsp.text().then((responseText) => {
+                                    document.getElementById('prototypeText_${id}').value = responseText;
+                                });
+                            }
                         });
                         }
                     </script>


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), and generated several Declarative snippets on the snippets page, stepping through the new code in the debugger to ensure it was working as intended.