### PR TITLE
Refine build comparison in `PreserveStashesJobProperty`

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/properties/PreserveStashesJobProperty.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/properties/PreserveStashesJobProperty.java
@@ -107,7 +107,7 @@ public class PreserveStashesJobProperty extends OptionalJobProperty<WorkflowJob>
                     int bc = prop.getBuildCount();
                     if (bc > 0) {
                         for (WorkflowRun recentRun : j.getBuilds().completedOnly().limit(bc)) {
-                            if (recentRun != null && recentRun.equals(r)) {
+                            if (recentRun != null && recentRun.getNumber() == r.getNumber()) {
                                 return false;
                             }
                         }


### PR DESCRIPTION
https://github.com/jenkinsci/bom/pull/2105 turned up a test regression seen in https://github.com/jenkinsci/workflow-job-plugin/pull/357#issuecomment-1561105285 which was easily reproduced. Confusingly, stashes were being deleted from the most recent build (11) of the project, which had just been run, despite it being marked to preserve stashes from the last two builds. Even more confusingly, the `shouldClearAll` implementation correctly returned builds 11 and 10 from `j.getBuilds().completedOnly().limit(bc)`, yet claimed that 11 should be cleared nonetheless. It turned out that the comparison via `Object.equals` was failing for two copies (`WorkflowRun`s) of build 11, due to use of `RunLoadCounter` in the test: a subtle change in timing caused the stash clearing check for 11 to run after `buildAndAssertSuccess` returned and the next `countLoads` had started, so the `RunList` was working on the new copy while `shouldClearAll` had been passed the old copy. Inserting a short sleep in the test (to delay invalidating the build cache until after stash clearing has been processed) fixes it, but it would better to avoid relying on object identity here to begin with, as it is not necessarily safe when lazy loading is involved; comparing build numbers should be ore reliable.