### PR TITLE
Allow valid agent types in PCT context

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/AbstractModelDefTest.java
@@ -82,19 +82,22 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
     @Rule public GitSampleRepoRule otherRepo = new GitSampleRepoRule();
     @Rule public GitSampleRepoRule thirdRepo = new GitSampleRepoRule();
 
-    protected static String legalAgentTypes = "";
+    protected String legalAgentTypes = "";
 
-    @BeforeClass
-    public static void setUpPreClass() throws Exception {
-        List<String> agentTypes = new ArrayList<>();
+    @Before
+    public void setUpPreClass() {
+        // Ensure that the agent types expected to be contributed by this plugin are present
+        NavigableSet<String> agentTypes = new TreeSet<>(List.of("any", "label", "none", "otherField"));
 
+        // Allow agent types to be contributed by other plugins; for example, the Kubernetes plugin PCT context
         for (DeclarativeAgentDescriptor d : j.jenkins.getExtensionList(DeclarativeAgentDescriptor.class)) {
             String symbol = symbolFromDescriptor(d);
             if (symbol != null) {
                 agentTypes.add(symbol);
             }
         }
-        legalAgentTypes = "[" + StringUtils.join(agentTypes.stream().sorted().collect(Collectors.toList()), ", ") + "]";
+
+        legalAgentTypes = "[" + String.join(", ", agentTypes) + "]";
     }
 
     private static String symbolFromDescriptor(Descriptor d) {
@@ -223,7 +226,7 @@ public abstract class AbstractModelDefTest extends AbstractDeclarativeTest {
         result.add(new Object[]{"invalidWrapperType", "Invalid option type \"echo\". Valid option types:"});
         result.add(new Object[]{"invalidStageWrapperType", "Invalid option type \"echo\". Valid option types:"});
 
-        result.add(new Object[]{"unknownBareAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", legalAgentTypes)});
+        result.add(new Object[]{"unknownBareAgentType", Messages.ModelValidatorImpl_InvalidAgentType("foo", "[any, label, none, otherField]")});
         result.add(new Object[]{"agentMissingRequiredParam", Messages.ModelValidatorImpl_MultipleAgentParameters("otherField", "[label, otherField]")});
         result.add(new Object[]{"agentUnknownParamForType", Messages.ModelValidatorImpl_InvalidAgentParameter("fruit", "otherField", "[label, otherField, nested]")});
         result.add(new Object[]{"notificationsSectionRemoved", "object instance has properties which are not allowed by the schema"});

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ErrorsEndpointOpsTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/endpoints/ErrorsEndpointOpsTest.java
@@ -28,6 +28,7 @@ import org.htmlunit.WebRequest;
 import org.htmlunit.util.NameValuePair;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.jenkinsci.plugins.pipeline.modeldefinition.Messages;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -73,6 +74,17 @@ public class ErrorsEndpointOpsTest extends AbstractModelDefTest {
         JSONObject resultData = result.getJSONObject("data");
         assertNotNull(resultData);
         assertEquals("Result wasn't a failure - " + result.toString(2), "failure", resultData.getString("result"));
+
+        /*
+         * If the error message contains the list of legal agent types, ensure that agent types contributed by other
+         * plugins (for example, the Kubernetes plugin in PCT context) are present. Note that we can't do this from
+         * AbstractModelDefTest#configsWithErrors because determining this list requires Jenkins to be started, and
+         * Jenkins has not yet been started when we are determining the parameters for the JUnit parameterized test.
+         */
+        if (expectedError.equals(
+                Messages.ModelValidatorImpl_InvalidAgentType("foo", "[any, label, none, otherField]"))) {
+            expectedError = Messages.ModelValidatorImpl_InvalidAgentType("foo", legalAgentTypes);
+        }
 
         assertTrue("Errors array (" + resultData.getJSONArray("errors").toString(2) + ") didn't contain expected error '" + expectedError + "'",
                 foundExpectedErrorInJSON(resultData.getJSONArray("errors"), expectedError));

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorsJSONParserTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ErrorsJSONParserTest.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.validator;
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
 import org.jenkinsci.plugins.pipeline.modeldefinition.BaseParserLoaderTest;
+import org.jenkinsci.plugins.pipeline.modeldefinition.Messages;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -46,6 +47,17 @@ public class ErrorsJSONParserTest extends BaseParserLoaderTest {
 
     @Test
     public void parseAndValidateJSONWithError() throws Exception {
+        /*
+         * If the error message contains the list of legal agent types, ensure that agent types contributed by other
+         * plugins (for example, the Kubernetes plugin in PCT context) are present. Note that we can't do this from
+         * AbstractModelDefTest#configsWithErrors because determining this list requires Jenkins to be started, and
+         * Jenkins has not yet been started when we are determining the parameters for the JUnit parameterized test.
+         */
+        if (expectedError.equals(
+                Messages.ModelValidatorImpl_InvalidAgentType("foo", "[any, label, none, otherField]"))) {
+            expectedError = Messages.ModelValidatorImpl_InvalidAgentType("foo", legalAgentTypes);
+        }
+
         findErrorInJSON(expectedError, configName);
     }
 }


### PR DESCRIPTION
While trying to add the Kubernetes plugins to `jenkinsci/bom` in https://github.com/jenkinsci/bom/pull/2417 I got some test failures of the form:

> "error": "Invalid agent type \"foo\" specified. Must be one of [any, kubernetes, label, none, otherField]"
}]) didn't contain expected error 'Invalid agent type "foo" specified. Must be one of [any, label, none, otherField]'

The existing test logic had tried to deal with this case by defining a `legalAgentTypes` field, but it was flawed in a few ways:

- It was not used consistently in `AbstractModelDefTest#configsWithErrors`: `unknownBareAgentType` used it but not `unknownAgentType`
- Any usage of `legalAgentTypes` from `AbstractModelDefTest#configsWithErrors` was flawed and yielding the empty string (thus making the test pass erroneously) because Jenkins had not been started when populating the list during JUnit parameterized test initialization
- It did not assert that the types expected to be contributed by this plugin itself were present

This PR fixes all three mistakes by:

- Consistently _not_ using `legalAgentTypes` in `AbstractModelDefTest#configsWithErrors`, since that is too early for it to be used
- Making the field non-static so that it cannot be used too early by accident in the future
- Ensuring that any tests that need `legalAgentTypes` use it in the test itself, after Jenkins startup (currently this list includes `ErrorsEndpointOpsTest`, `ErrorsJSONParserTest`, and `ValidatorTest`)
- Asserting that the types expected to be contributed by this plugin are present

### Testing done

To test this PR I reproduced the original problem by adding the Kubernetes plugins to the test classpath and verified the BOM error occurred. Next I applied the changes from this PR and verified the problem was fixed. Then I removed the Kubernetes plugins from the test classpath and verified the tests still passed in the non-PCT scenario.