### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,12 @@
-buildPlugin(timeout: 120, useContainerAgent: true, configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  timeout: 120, // reduce test failures due to timeout
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 11],
 ])

--- a/pipeline-model-api/pom.xml
+++ b/pipeline-model-api/pom.xml
@@ -67,8 +67,6 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <scope>test</scope>
-      <!-- TODO: Remove version declaration when workflow-cps plugin 3691.v28b_14c465a_b_b_ or newer is in plugin BOM -->
-      <version>3691.v28b_14c465a_b_b_</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -80,21 +78,11 @@
       <artifactId>workflow-cps</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
-      <!-- TODO: Remove version declaration when workflow-cps plugin 3691.v28b_14c465a_b_b_ or newer is in plugin BOM -->
-      <version>3691.v28b_14c465a_b_b_</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
-      <!-- TODO: Remove version declaration when git plugin 5.1.0 or newer is in plugin BOM -->
-      <version>5.1.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pipeline-model-definition/pom.xml
+++ b/pipeline-model-definition/pom.xml
@@ -87,23 +87,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <!-- TODO: Remove version declaration when workflow-cps plugin 3691.v28b_14c465a_b_b_ or newer is in plugin BOM -->
-      <version>3691.v28b_14c465a_b_b_</version>
-      <exclusions>
-        <exclusion>
-          <!-- TODO: Remove exclusion when workflow cps requires git plugin 5.1.0 or newer -->
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>git</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
-      <!-- TODO: Remove version declaration when workflow-cps plugin 3691.v28b_14c465a_b_b_ or newer is in plugin BOM -->
-      <version>3691.v28b_14c465a_b_b_</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -167,14 +156,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
-      <!-- TODO: Remove version declaration when git plugin 5.1.0 or newer is in plugin BOM -->
-      <version>5.1.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -235,14 +216,6 @@
       <artifactId>git</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
-      <!-- TODO: Remove version declaration when git plugin 5.1.0 or newer is in plugin BOM -->
-      <version>5.1.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pipeline-model-extensions/pom.xml
+++ b/pipeline-model-extensions/pom.xml
@@ -60,15 +60,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
-      <!-- TODO: Remove version declaration when workflow-cps plugin 3691.v28b_14c465a_b_b_ or newer is in plugin BOM -->
-      <version>3691.v28b_14c465a_b_b_</version>
-      <exclusions>
-        <exclusion>
-          <!-- TODO: Remove exclusion when workflow cps requires git plugin 5.1.0 or newer -->
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>git</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -90,14 +81,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
       <scope>test</scope>
-      <!-- TODO: Remove version declaration when git plugin 5.1.0 or newer is in plugin BOM -->
-      <version>5.1.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.66</version>
+    <version>4.73</version>
     <relativePath />
   </parent>
 
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2143.ve4c3c9ec790a</version>
+        <version>2401.v7a_d68f8d0b_09</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.387.x</artifactId>
-        <version>2401.v7a_d68f8d0b_09</version>
+        <version>2465.va_e76ed7b_3061</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Test with Java 21

Java 21 released Sep 19, 2023. We'd like to announce full support for Java 21 in early October and would like the most used plugins to be compiling and testing with Java 21.  The acceptance test harness and plugin bill of materials tests are already passing with Java 21.  This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

This pull request includes and supersedes:

* #668

This pull request and #668 supersede the following pull requests:

* #674
* #670
* #669
* #664
* #636

* JENKINS issue(s):
    * n/a
* Description:
    * See the text at the top of the pull request
* Documentation changes:
    * No documentation changes required because all changes are internal to the plugin
* Users/aliases to notify:
    * @jglick
    * @rsandell
