### PR TITLE
[JENKINS-72136] Remove inline onclick handlers for generate directive button

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
@@ -78,34 +78,10 @@
                 </f:dropdownList>
                 <j:set var="id" value="${h.generateId()}"/>
                 <f:block>
-                    <input type="button" value="${%Generate Declarative Directive}" onclick="handlePrototype_${id}(); return false" class="submit-button primary"/>
+                    <span class="directive-generator-button-reference-holder" data-id="${id}" data-fullurl="${rootURL}/${it.GENERATE_URL}" />
+                    <input id="prototypeButton_${id}" type="button" value="${%Generate Declarative Directive}" class="submit-button primary"/>
                     <f:textarea id="prototypeText_${id}" readonly="true" style="margin-top: 10px" />
-                    <script>
-                        function handlePrototype_${id}() {
-                        buildFormTree(document.forms.config);
-                        // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
-                        // TODO simplify when Prototype.js is removed
-                        var json = Object.toJSON ? Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype) : JSON.stringify(JSON.parse(document.forms.config.elements.json.value).prototype);
-                        if (!json) {
-                        return; // just a separator
-                        }
-                        fetch('${rootURL}/${it.GENERATE_URL}', {
-                            method: 'post',
-                            headers: crumb.wrap({
-                                "Content-Type": "application/x-www-form-urlencoded",
-                            }),
-                            body: new URLSearchParams({
-                                json: json,
-                            }),
-                        }).then((rsp) => {
-                            if (rsp.ok) {
-                                rsp.text().then((responseText) => {
-                                    document.getElementById('prototypeText_${id}').value = responseText;
-                                });
-                            }
-                        });
-                        }
-                    </script>
+                    <st:adjunct includes="org.jenkinsci.plugins.pipeline.modeldefinition.generator.DirectiveGenerator.indexScript"/>
                 </f:block>
             </f:form>
         </l:main-panel>

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/indexScript.js
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/indexScript.js
@@ -1,0 +1,34 @@
+Behaviour.specify(".directive-generator-button-reference-holder", 'prototype', 0, function (e) {
+    var url = e.getAttribute('data-fullurl');
+    var id = e.getAttribute('data-id');
+    var button = document.getElementById('prototypeButton_'+id);
+
+    button.onclick = function(el) {
+       handlePrototype(url,id);
+       return false;
+    }
+});
+function handlePrototype(url,id) {
+    buildFormTree(document.forms.config);
+    // TODO JSON.stringify fails in some circumstances: https://gist.github.com/jglick/70ec4b15c1f628fdf2e9 due to Array.prototype.toJSON
+    // TODO simplify when Prototype.js is removed
+    var json = Object.toJSON ? Object.toJSON(JSON.parse(document.forms.config.elements.json.value).prototype) : JSON.stringify(JSON.parse(document.forms.config.elements.json.value).prototype);
+    if (!json) {
+    return; // just a separator
+    }
+    fetch(url, {
+        method: 'post',
+        headers: crumb.wrap({
+            "Content-Type": "application/x-www-form-urlencoded",
+        }),
+        body: new URLSearchParams({
+            json: json,
+        }),
+    }).then((rsp) => {
+        if (rsp.ok) {
+            rsp.text().then((responseText) => {
+                document.getElementById('prototypeText_'+id).value = responseText;
+            });
+        }
+    });
+    }


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins.io/browse/JENKINS-72136
* Description:
    * Inline handlers were showing in console. Used the recommendations given in the issue.
* Documentation changes:
    * There is no feature change but just a minor change for security reasons.
* Users/aliases to notify:
    * n/a
 
Testing:
Screenshots:
Before:
![Screenshot from 2023-10-12 11-16-04](https://github.com/jenkinsci/pipeline-model-definition-plugin/assets/47060152/6e8c1091-a666-4edd-b413-e9ef22830d6e)
After:

![Screenshot from 2023-10-12 11-17-57](https://github.com/jenkinsci/pipeline-model-definition-plugin/assets/47060152/8543f77c-e27e-4f6b-8dbb-84078b1013ea)

mvn tests run and changes appear in mvn:hpi run