### PR TITLE
remove lib.form.hetero-list.hetero-list

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ToolsDirective/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/ToolsDirective/config.jelly
@@ -70,8 +70,6 @@
             </d:tag>
         </d:taglib>
 
-        <st:adjunct includes="lib.form.hetero-list.hetero-list"/>
-
         <j:set var="targetType" value="${it.class}"/>
         <div class="hetero-list-container with-drag-drop one-each">
             <div class="repeatable-insertion-point" />

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2465.va_e76ed7b_3061</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>2555.v3190a_8a_c60c6</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -133,7 +133,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/pipeline-model-definition-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.426</jenkins.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
See https://github.com/jenkinsci/jenkins/pull/8418#discussion_r1337479191

hetero-list adjunct was removed in https://github.com/jenkinsci/jenkins/pull/8418
If this adjunct gets called, a large stack trace error should appear in the logs.

### Testing
Done locally, but I was not able to identify the gui interface for the ToolsDirective that would exercise the adjunct.

