### PR TITLE
Require Jenkins 2.426.1 instead of 2.426

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/pipeline-model-definition-plugin</gitHubRepo>
-    <jenkins.version>2.426</jenkins.version>
+    <jenkins.version>2.426.1</jenkins.version>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>2612.v3d6a_2128c0ef</version>
+        <version>2671.va_73a_b_4c103fb_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.75</version>
+    <version>4.76</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>2671.va_73a_b_4c103fb_</version>
+        <version>2675.v1515e14da_7a_6</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.74</version>
+    <version>4.75</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.426.x</artifactId>
-        <version>2555.v3190a_8a_c60c6</version>
+        <version>2612.v3d6a_2128c0ef</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.426.1, not 2.426

Plugin bill of materials bom-2.426.x requires 2.426.1 now, not 2.426.

* Bump org.jenkins-ci.plugins:plugin from 4.73 to 4.74
* Use parent pom 4.75
* Require Jenkins 2.426.1, not 2.426
* Use bom-2.426-x 2612.v3d6a_2128c0ef

No documentation change needed other than the changelog entry declaring that this changes the minimum Jenkins version from 2.426 to 2.426.1.

Also includes or supersedes the following pull requests:

* #677
* #676
* #636
