### PR TITLE
Remove dead test code

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
@@ -150,16 +150,6 @@ public class DirectiveGeneratorTest {
                         "}");
     }
 
-    // TODO: Remove once we move to a baseline of 2.281 or later
-    private String trimParamOrEmpty() {
-        if (Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.281"))) {
-            return "";
-        }
-        else {
-            return ", trim: false";
-        }
-    }
-
     @Test
     public void fullInput() throws Exception {
         InputDirective input = new InputDirective("hello");
@@ -180,7 +170,7 @@ public class DirectiveGeneratorTest {
                         "  submitterParameter 'subParam'\n" +
                         "  parameters {\n" +
                         // StringParameterDefinition added trim field in 2.90
-                        "    string defaultValue: 'steve', description: 'Hey, a string', name: 'aString'" + trimParamOrEmpty() + "\n" +
+                        "    string defaultValue: 'steve', description: 'Hey, a string', name: 'aString'\n" +
                         "    booleanParam defaultValue: true, description: 'A boolean now', name: 'aBool'\n" +
                         "  }\n" +
                         "}");
@@ -394,7 +384,7 @@ public class DirectiveGeneratorTest {
         ParametersDirective params = new ParametersDirective(p);
 
         dg.assertGenerateDirective(params, "parameters {\n" +
-                "  string defaultValue: 'some default', description: 'Hey, a description with a \\' in it.', name: 'SOME_STRING'" + trimParamOrEmpty() + "\n" +
+                "  string defaultValue: 'some default', description: 'Hey, a description with a \\' in it.', name: 'SOME_STRING'\n" +
                 "}");
     }
 
@@ -407,7 +397,7 @@ public class DirectiveGeneratorTest {
         ParametersDirective params = new ParametersDirective(p);
 
         dg.assertGenerateDirective(params, "parameters {\n" +
-                "  string defaultValue: 'some default', description: 'Hey, a description with a \\' in it.', name: 'SOME_STRING'" + trimParamOrEmpty() + "\n" +
+                "  string defaultValue: 'some default', description: 'Hey, a description with a \\' in it.', name: 'SOME_STRING'\n" +
                 "  booleanParam defaultValue: true, description: 'This will default to true.', name: 'SOME_BOOL'\n" +
                 "}");
     }


### PR DESCRIPTION
## Remove dead test code

* Description:

The VersionNumber() of the running Jenkins controller used for the tests will never be less than the Jenkins minimum version defined in the plugin pom.  Remove the conditional so that it is not a distraction in the test suite source code.
