### PR TITLE
[JENKINS-72841] Add `TagsAction` on all relevant stages

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -258,14 +258,10 @@ class Utils {
             // find potential heads stopping when parent reached
             def result = scanner.filteredNodes(execution.currentHeads, [parentFlowNode], CommonUtils.isStageWithOptionalName(stageName))
 
-            result.find {
+            stage = result.find {
                 // work back to parent and make sure head is parented to the stage
                 def match = scanner.findFirstMatch(it, { flowNode -> flowNode.getId() == parentFlowNode.getId() })
-                if (match != null) {
-                    stage = it
-                    return true
-                }
-                return false
+                return match != null
             }
         } else {
             stage = scanner.findFirstMatch(execution.currentHeads, null, CommonUtils.isStageWithOptionalName(stageName))

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -256,9 +256,11 @@ class Utils {
             // find potential heads stopping when parent reached
             def result = new DepthFirstScanner().filteredNodes(execution.currentHeads, [parentFlowNode], CommonUtils.isStageWithOptionalName(stageName))
 
-            stage = result.find {
+            stage = result.find { potentialHead ->
                 // work back to parent and make sure head is parented to the stage
-                def match = new DepthFirstScanner().findFirstMatch(it, { flowNode -> flowNode.getId() == parentFlowNode.getId() })
+                def match = potentialHead.iterateEnclosingBlocks().find { blockStartNode ->
+                    blockStartNode.getId() == parentFlowNode.getId()
+                }
                 return match != null
             }
         } else {

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -251,20 +251,18 @@ class Utils {
     }
 
     private static FlowNode scanForStageFlowNode(FlowNode parentFlowNode, FlowExecution execution, String stageName) {
-        DepthFirstScanner scanner = new DepthFirstScanner()
-
         FlowNode stage
         if (parentFlowNode != null) {
             // find potential heads stopping when parent reached
-            def result = scanner.filteredNodes(execution.currentHeads, [parentFlowNode], CommonUtils.isStageWithOptionalName(stageName))
+            def result = new DepthFirstScanner().filteredNodes(execution.currentHeads, [parentFlowNode], CommonUtils.isStageWithOptionalName(stageName))
 
             stage = result.find {
                 // work back to parent and make sure head is parented to the stage
-                def match = scanner.findFirstMatch(it, { flowNode -> flowNode.getId() == parentFlowNode.getId() })
+                def match = new DepthFirstScanner().findFirstMatch(it, { flowNode -> flowNode.getId() == parentFlowNode.getId() })
                 return match != null
             }
         } else {
-            stage = scanner.findFirstMatch(execution.currentHeads, null, CommonUtils.isStageWithOptionalName(stageName))
+            stage = new DepthFirstScanner().findFirstMatch(execution.currentHeads, null, CommonUtils.isStageWithOptionalName(stageName))
         }
         stage
     }

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -332,7 +332,7 @@ class Utils {
 
     }
 
-    private static void markStageWithTag(String stageName, FlowNode parentStageFlowNode, String tagName, String tagValue) {
+    static void markStageWithTag(String stageName, FlowNode parentStageFlowNode, String tagName, String tagValue) {
         List<FlowNode> matched = findStageFlowNodes(stageName, null, parentStageFlowNode)
 
         matched.each { currentNode ->

--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -332,7 +332,7 @@ class Utils {
 
     }
 
-    static void markStageWithTag(String stageName, FlowNode parentStageFlowNode, String tagName, String tagValue) {
+    private static void markStageWithTag(String stageName, FlowNode parentStageFlowNode, String tagName, String tagValue) {
         List<FlowNode> matched = findStageFlowNodes(stageName, null, parentStageFlowNode)
 
         matched.each { currentNode ->

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -362,7 +362,7 @@ class ModelInterpreter implements Serializable {
                   Stage parentStage) {
         return {
             Utils.logToTaskListener(reason.message)
-            Utils.markStageWithTag(thisStage.name, StageStatus.TAG_NAME, reason.stageStatus)
+            Utils.markStageWithTag(thisStage.name, parentStage?.name, StageStatus.TAG_NAME, reason.stageStatus)
             if (thisStage?.parallel != null) {
                 Map<String, Closure> parallelToSkip = getParallelStages(root, parentAgent, thisStage, firstError, reason)
                 script.parallel(parallelToSkip)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
@@ -53,6 +53,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 /**
@@ -227,6 +229,17 @@ public class MatrixTest extends AbstractModelDefTest {
                         "{ (Branch: Matrix - OS_VALUE = 'windows', BROWSER_VALUE = 'safari')",
                         "{ (Branch: Matrix - OS_VALUE = 'mac', BROWSER_VALUE = 'safari')")
                 .go();
+    }
+
+    @Test
+    public void matrixPipelineMultipleWhenSkipped() throws Exception {
+        WorkflowRun run = expect("matrix/matrixStagesHaveStatusWhenMultipleSkipped")
+                .go();
+
+        DepthFirstScanner scanner = new DepthFirstScanner();
+        List<FlowNode> currentHeads = scanner.filteredNodes(run.getExecution(), (node) -> node.getAction(TagsAction.class) != null);
+
+        assertThat(currentHeads, hasSize(2));
     }
 
     @Ignore("Scenario covered by matrixPipelineTwoAxisExcludeNot ")

--- a/pipeline-model-definition/src/test/resources/matrix/matrixStagesHaveStatusWhenMultipleSkipped.groovy
+++ b/pipeline-model-definition/src/test/resources/matrix/matrixStagesHaveStatusWhenMultipleSkipped.groovy
@@ -1,0 +1,31 @@
+pipeline {
+    agent none
+    stages {
+        stage('BuildAndTest') {
+            matrix {
+                agent any
+                axes {
+                    axis {
+                        name 'PLATFORM'
+                        values 'linux', 'windows'
+                    }
+                    axis {
+                        name 'BROWSER'
+                        values 'firefox'
+                    }
+                }
+                stages {
+                    stage('Build') {
+                        when {
+                            branch 'testing'
+                        }
+                        steps {
+                            echo "Do Build1 for ${PLATFORM} - ${BROWSER}"
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-72841](https://issues.jenkins.io/browse/JENKINS-72841)
    * Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/220
* Description:
    * Previously skipping stages would only be tagged for the first occurrence of the stage. This now checks that the stage is a child of the parent stage. This was only a problem for matrix builds
* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * ...

Before:
<img width="759" alt="image" src="https://github.com/jenkinsci/pipeline-model-definition-plugin/assets/21194782/00dc1a7a-4cb3-4183-92b1-85fa4efe447d">

After:

<img width="809" alt="image" src="https://github.com/jenkinsci/pipeline-model-definition-plugin/assets/21194782/635c032e-f348-4ee4-94c4-bf820b99c5ae">

see https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/220
