### PR TITLE
[JENKINS-72841] - Pass flow node ID when skipping stage

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/Utils.groovy
@@ -312,17 +312,24 @@ class Utils {
         CpsThread thread = CpsThread.current()
         FlowExecution execution = thread.execution
 
-        def stepContextFlowNode = execution.getNode(stepContextFlowNodeId)
+        try {
+            def stepContextFlowNode = execution.getNode(stepContextFlowNodeId)
+            if (stepContextFlowNode == null) {
+                return;
+            }
 
-        int count = 0
-        for (FlowNode node : stepContextFlowNode.iterateEnclosingBlocks()) {
-            if (CommonUtils.isStageWithOptionalName(stageName).test(node) || isParallelBranchFlowNode(stageName).apply(node)) {
-                addTagToFlowNode(node, tagName, tagValue)
-                count++
+            int count = 0
+            for (FlowNode node : stepContextFlowNode.iterateEnclosingBlocks()) {
+                if (CommonUtils.isStageWithOptionalName(stageName).test(node) || isParallelBranchFlowNode(stageName).apply(node)) {
+                    addTagToFlowNode(node, tagName, tagValue)
+                    count++
+                }
+                if (count == 2) {
+                    break
+                }
             }
-            if (count == 2) {
-                break
-            }
+        } catch (IOException e) {
+            // Ignore.
         }
     }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -244,16 +244,15 @@ class ModelInterpreter implements Serializable {
                       SkippedStageReason skippedReason) {
         return {
             script.stage(thisStage.name) {
-                def flowNodeId = getFlowNodeId()
                 try {
                     if (skippedReason != null) {
-                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent, flowNodeId).call()
+                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
                     } else if (firstError != null) {
                         skippedReason = new SkippedStageReason.Failure(thisStage.name)
-                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent, flowNodeId).call()
+                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
                     } else if (skipUnstable(root.options)) {
                         skippedReason = new SkippedStageReason.Unstable(thisStage.name)
-                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent, flowNodeId).call()
+                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
                     } else {
                         // if this a is a matrix generated stage, evaluate the matrix axis values first
                         // These are literals that guaranteed not to depend on other variables
@@ -307,7 +306,7 @@ class ModelInterpreter implements Serializable {
                             }
                             if (!whenEvaluator.passed) {
                                 skippedReason = new SkippedStageReason.When(thisStage.name)
-                                skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent, flowNodeId).call()
+                                skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
                             }
                         }
                     }
@@ -366,9 +365,10 @@ class ModelInterpreter implements Serializable {
     }
 
     def skipStage(Root root, Agent parentAgent, Stage thisStage, Throwable firstError, SkippedStageReason reason,
-                  Stage parentStage, String stepContextFlowNodeId) {
+                  Stage parentStage) {
         return {
             Utils.logToTaskListener(reason.message)
+            def stepContextFlowNodeId = getFlowNodeId();
             Utils.markStageWithTag(thisStage.name, stepContextFlowNodeId, StageStatus.TAG_NAME, reason.stageStatus)
             if (thisStage?.parallel != null) {
                 Map<String, Closure> parallelToSkip = getParallelStages(root, parentAgent, thisStage, firstError, reason)

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
@@ -53,6 +53,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.*;
 
 /**
@@ -227,6 +229,17 @@ public class MatrixTest extends AbstractModelDefTest {
                         "{ (Branch: Matrix - OS_VALUE = 'windows', BROWSER_VALUE = 'safari')",
                         "{ (Branch: Matrix - OS_VALUE = 'mac', BROWSER_VALUE = 'safari')")
                 .go();
+    }
+
+    @Test
+    public void matrixPipelineMultipleWhenSkipped() throws Exception {
+        WorkflowRun run = expect("matrix/matrixStagesHaveStatusWhenMultipleSkipped")
+                .go();
+
+        DepthFirstScanner scanner = new DepthFirstScanner();
+        List<FlowNode> currentHeads = scanner.filteredNodes(run.getExecution(), (node) -> node.getAction(TagsAction.class) != null);
+
+        assertThat(currentHeads, hasSize(2));
     }
 
     @Ignore("Scenario covered by matrixPipelineTwoAxisExcludeNot ")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/MatrixTest.java
@@ -237,7 +237,13 @@ public class MatrixTest extends AbstractModelDefTest {
                 .go();
 
         DepthFirstScanner scanner = new DepthFirstScanner();
-        List<FlowNode> currentHeads = scanner.filteredNodes(run.getExecution(), (node) -> node.getAction(TagsAction.class) != null);
+        List<FlowNode> currentHeads = scanner.filteredNodes(run.getExecution(), (node) -> {
+            TagsAction action = node.getAction(TagsAction.class);
+            if (action != null) {
+                return "SKIPPED_FOR_CONDITIONAL".equals(action.getTagValue(StageStatus.TAG_NAME));
+            }
+            return false;
+        });
 
         assertThat(currentHeads, hasSize(2));
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParallelTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParallelTest.java
@@ -259,21 +259,21 @@ public class ParallelTest extends AbstractModelDefTest {
         - 2:  FlowStartNode
         - 3:  foo stage start
         - 4:  foo stage body
-        - 5:  parallel start
-        - 7:  first branch start
-        - 8:  second branch start
-        - 9:  first stage start
-        - 11: second stage start
-        - 12: second stage body
-        - 14: inner-first stage start (probably)
+        - 6:  parallel start
+        - 8:  first branch start
+        - 9:  second branch start
+        - 10:  first stage start
+        - 12: second stage start
+        - 13: second stage body
+        - 16: inner-first stage start (probably)
         - 44: inner-second stage start (probably)
 
-        All three parallel stages should share 5,4,3,2.
-        Sequential stages in the second branch should share 8,5,4,3,2.
+        All three parallel stages should share 6,4,3,2.
+        Sequential stages in the second branch should share 9,6,4,3,2.
          */
-        assertEquals(Arrays.asList("7", "5", "4", "3", "2"), tailOfList(startFirst.getAllEnclosingIds()));
-        assertEquals(Arrays.asList("12", "11", "8", "5", "4", "3", "2"), tailOfList(startInnerFirst.getAllEnclosingIds()));
-        assertEquals(Arrays.asList("12", "11", "8", "5", "4", "3", "2"), tailOfList(startInnerSecond.getAllEnclosingIds()));
+        assertEquals(Arrays.asList("8", "6", "4", "3", "2"), tailOfList(startFirst.getAllEnclosingIds()));
+        assertEquals(Arrays.asList("13", "12", "9", "6", "4", "3", "2"), tailOfList(startInnerFirst.getAllEnclosingIds()));
+        assertEquals(Arrays.asList("13", "12", "9", "6", "4", "3", "2"), tailOfList(startInnerSecond.getAllEnclosingIds()));
     }
 
     @Issue("JENKINS-53734")

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParallelTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/ParallelTest.java
@@ -259,21 +259,21 @@ public class ParallelTest extends AbstractModelDefTest {
         - 2:  FlowStartNode
         - 3:  foo stage start
         - 4:  foo stage body
-        - 6:  parallel start
-        - 8:  first branch start
-        - 9:  second branch start
-        - 10:  first stage start
-        - 12: second stage start
-        - 13: second stage body
-        - 16: inner-first stage start (probably)
+        - 5:  parallel start
+        - 7:  first branch start
+        - 8:  second branch start
+        - 9:  first stage start
+        - 11: second stage start
+        - 12: second stage body
+        - 14: inner-first stage start (probably)
         - 44: inner-second stage start (probably)
 
-        All three parallel stages should share 6,4,3,2.
-        Sequential stages in the second branch should share 9,6,4,3,2.
+        All three parallel stages should share 5,4,3,2.
+        Sequential stages in the second branch should share 8,5,4,3,2.
          */
-        assertEquals(Arrays.asList("8", "6", "4", "3", "2"), tailOfList(startFirst.getAllEnclosingIds()));
-        assertEquals(Arrays.asList("13", "12", "9", "6", "4", "3", "2"), tailOfList(startInnerFirst.getAllEnclosingIds()));
-        assertEquals(Arrays.asList("13", "12", "9", "6", "4", "3", "2"), tailOfList(startInnerSecond.getAllEnclosingIds()));
+        assertEquals(Arrays.asList("7", "5", "4", "3", "2"), tailOfList(startFirst.getAllEnclosingIds()));
+        assertEquals(Arrays.asList("12", "11", "8", "5", "4", "3", "2"), tailOfList(startInnerFirst.getAllEnclosingIds()));
+        assertEquals(Arrays.asList("12", "11", "8", "5", "4", "3", "2"), tailOfList(startInnerSecond.getAllEnclosingIds()));
     }
 
     @Issue("JENKINS-53734")

--- a/pipeline-model-definition/src/test/resources/matrix/matrixStagesHaveStatusWhenMultipleSkipped.groovy
+++ b/pipeline-model-definition/src/test/resources/matrix/matrixStagesHaveStatusWhenMultipleSkipped.groovy
@@ -1,0 +1,31 @@
+pipeline {
+    agent none
+    stages {
+        stage('BuildAndTest') {
+            matrix {
+                agent any
+                axes {
+                    axis {
+                        name 'PLATFORM'
+                        values 'linux', 'windows'
+                    }
+                    axis {
+                        name 'BROWSER'
+                        values 'firefox'
+                    }
+                }
+                stages {
+                    stage('Build') {
+                        when {
+                            branch 'testing'
+                        }
+                        steps {
+                            echo "Do Build1 for ${PLATFORM} - ${BROWSER}"
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* JENKINS issue(s):
    * [JENKINS-72841](https://issues.jenkins.io/browse/JENKINS-72841)
    * Fixes https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/220
    * Fixes https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/698
* Description:
    * Previously skipping stages would only be tagged for the first occurrence of the stage. This now passes the flow node id rather than guessing by stage name
* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * ...

Before:
<img width="759" alt="image" src="https://github.com/jenkinsci/pipeline-model-definition-plugin/assets/21194782/00dc1a7a-4cb3-4183-92b1-85fa4efe447d">

After:

<img width="809" alt="image" src="https://github.com/jenkinsci/pipeline-model-definition-plugin/assets/21194782/635c032e-f348-4ee4-94c4-bf820b99c5ae">

see https://github.com/jenkinsci/pipeline-graph-view-plugin/issues/220
