### PR TITLE
Drop dependency on ASM

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/parser/RuntimeASTTransformer.groovy
@@ -61,7 +61,6 @@ import java.util.stream.Collectors
 
 import static org.codehaus.groovy.ast.tools.GeneralUtils.*
 import static org.jenkinsci.plugins.pipeline.modeldefinition.parser.ASTParserUtils.*
-import static org.objectweb.asm.Opcodes.ACC_PUBLIC
 
 /**
  * Transforms a given {@link ModelASTPipelineDef} into the {@link Root} used for actual runtime. Also attaches a
@@ -1120,6 +1119,8 @@ public class RuntimeASTTransformer {
      *      This is less effective, but still an improvement.
      */
     static final class Wrapper {
+        private static final int ACC_PUBLIC = 1
+
         private final SourceUnit sourceUnit
         private final ModuleNode moduleNode
         private final Set<String> nameSet = new HashSet<>()


### PR DESCRIPTION
This plugin currently depends on ASM, provided by Jenkins core. We'd eventually like to drop ASM from Jenkins core and move it into a library plugin, so this PR prepares this plugin by dropping this plugin's dependency on ASM. The dependency was only used in one place for a constant, and since this constant is unlikely to ever change we can simply inline it.

## Testing done

`mvn clean verify -Dtest=InjectedTest,org.jenkinsci.plugins.pipeline.modeldefinition.parser.RuntimeASTTransformerTest`