### PR TITLE
use valid password for test code

### DIFF
--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/steps/CredentialWrapperStepTest.java
@@ -120,7 +120,7 @@ public class CredentialWrapperStepTest extends AbstractModelDefTest {
         folderStore.addCredentials(Domain.global(), c);
 
         File crt = new File(CredentialWrapperStepTest.class.getResource("dummy.p12").toURI());
-        CertificateCredentialsImpl certCred = new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "certCred1", "sample", "test", 
+        CertificateCredentialsImpl certCred = new CertificateCredentialsImpl(CredentialsScope.GLOBAL, "certCred1", "sample", "password", 
                 new CertificateCredentialsImpl.UploadedKeyStoreSource(new FileParameterValue.FileItemImpl(crt), null));
         store.addCredentials(Domain.global(), certCred);
     }


### PR DESCRIPTION
amends #723 that was working as the KeyStore was not validated.

However https://github.com/jenkinsci/credentials-plugin/pull/543 now validates the keystore and hence this test started failing as the password did not match

* JENKINS issue(s):
    * Issue link or n/a
* Description:
    * ...
* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * ...
