### PR TITLE
allow types other than string literals axis values

### DIFF
--- a/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
+++ b/pipeline-model-definition/src/main/groovy/org/jenkinsci/plugins/pipeline/modeldefinition/validator/ModelValidatorImpl.groovy
@@ -820,13 +820,6 @@ class ModelValidatorImpl implements ModelValidator {
             valid = false
         }
 
-        axis.values.each { value ->
-            if (!value.literal) {
-                errorCollector.error(value, Messages.ModelParser_ExpectedStringLiteralButGot(value.value))
-                valid = false
-            }
-        }
-
         return validateFromContributors(axis, valid)
     }
 


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins.io/browse/JENKINS-62127
* Description:
    * Lift the restriction that axis values must be string literals.
* Documentation changes:
    * This restriction doesn't appear to be documented, so I didn't make any changes on that front (but I might be missing something)
* Users/aliases to notify:
    * None

Given that scripted pipelines already do support this functionality, it seems reasonable to lift this limitation for declarative pipelines?
