### PR TITLE
Reduce depth of `Closure`s being `call`ed

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -82,7 +82,7 @@ class ModelInterpreter implements Serializable {
                                 // the whole pipeline and don't want firstError to be set.
                                 firstError = null
                                 toolsBlock(root.tools, root.agent, null) {
-                                    firstError = evaluateSequentialStages(root, root.stages, firstError, null, restartedStage, null).call()
+                                    firstError = evaluateSequentialStages(root, root.stages, firstError, null, restartedStage, null)
 
                                     // Execute post-build actions now that we've finished all parallel.
                                     try {
@@ -148,50 +148,47 @@ class ModelInterpreter implements Serializable {
      * @param restartedStageName the name of the stage we're restarting at. Null if this is not a restarted build or this is
      *     called from a nested stage.
      * @param skippedReason Possibly null reason the container for the stages was skipped.
-     * @return A closure to execute (TODO just run directly)
      */
     def evaluateSequentialStages(Root root, Stages stages, Throwable firstError, Stage parent, String restartedStageName,
                                  SkippedStageReason skippedReason) {
-        return {
-            try {
-                boolean skippedForRestart = restartedStageName != null
-                stages.stages.each { thisStage ->
-                    if (skippedForRestart) {
-                        // Check if we're skipping for restart but are now on the stage we're supposed to restart on.
-                        if (thisStage.name == restartedStageName) {
-                            // If so, set skippedForRestart to false, and if the skippedReason is for restart, wipe that out too.
-                            skippedForRestart = false
-                            if (skippedReason instanceof SkippedStageReason.Restart) {
-                                skippedReason = null
-                            }
-                        } else {
-                            // If we skipped for restart and this isn't the restarted name, create a new reason.
-                            skippedReason = new SkippedStageReason.Restart(thisStage.name, restartedStageName)
+        try {
+            boolean skippedForRestart = restartedStageName != null
+            stages.stages.each { thisStage ->
+                if (skippedForRestart) {
+                    // Check if we're skipping for restart but are now on the stage we're supposed to restart on.
+                    if (thisStage.name == restartedStageName) {
+                        // If so, set skippedForRestart to false, and if the skippedReason is for restart, wipe that out too.
+                        skippedForRestart = false
+                        if (skippedReason instanceof SkippedStageReason.Restart) {
+                            skippedReason = null
                         }
-                    }
-                    try {
-                        evaluateStage(root, thisStage.agent ?: root.agent, thisStage, firstError, parent, skippedReason).call()
-                    } catch (Throwable e) {
-                        Utils.markStageFailedAndContinued(thisStage.name)
-                        if (firstError == null) {
-                            firstError = e
-                        }
-                    }
-                    if (skippedForRestart) {
-                        Utils.markStartAndEndNodesInStageAsNotExecuted(thisStage.name)
+                    } else {
+                        // If we skipped for restart and this isn't the restarted name, create a new reason.
+                        skippedReason = new SkippedStageReason.Restart(thisStage.name, restartedStageName)
                     }
                 }
-            } finally {
-                // And finally, run the post stage steps if this was a parallel parent.
-                if (skippedReason == null && parent != null &&
-                    root.hasSatisfiedConditions(parent.post, script.getProperty("currentBuild"), parent, firstError)) {
-                    Utils.logToTaskListener("Post stage")
-                    firstError = runPostConditions(parent.post, parent.agent ?: root.agent, firstError, parent.name)
+                try {
+                    evaluateStage(root, thisStage.agent ?: root.agent, thisStage, firstError, parent, skippedReason)
+                } catch (Throwable e) {
+                    Utils.markStageFailedAndContinued(thisStage.name)
+                    if (firstError == null) {
+                        firstError = e
+                    }
+                }
+                if (skippedForRestart) {
+                    Utils.markStartAndEndNodesInStageAsNotExecuted(thisStage.name)
                 }
             }
-
-            return firstError
+        } finally {
+            // And finally, run the post stage steps if this was a parallel parent.
+            if (skippedReason == null && parent != null &&
+                root.hasSatisfiedConditions(parent.post, script.getProperty("currentBuild"), parent, firstError)) {
+                Utils.logToTaskListener("Post stage")
+                firstError = runPostConditions(parent.post, parent.agent ?: root.agent, firstError, parent.name)
+            }
         }
+
+        return firstError
     }
 
     /**
@@ -208,11 +205,13 @@ class ModelInterpreter implements Serializable {
         def parallelStages = [:]
         thisStage?.parallel?.stages?.each { content ->
             if (skippedReason != null) {
-                parallelStages.put(content.name,
-                    evaluateStage(root, parentAgent, content, firstError, thisStage, skippedReason.cloneWithNewStage(content.name)))
+                parallelStages.put(content.name, {
+                    evaluateStage(root, parentAgent, content, firstError, thisStage, skippedReason.cloneWithNewStage(content.name))
+                })
             } else {
-                parallelStages.put(content.name,
-                    evaluateStage(root, thisStage.agent ?: parentAgent, content, firstError, thisStage, null))
+                parallelStages.put(content.name, {
+                    evaluateStage(root, thisStage.agent ?: parentAgent, content, firstError, thisStage, null)
+                })
             }
         }
         if (!parallelStages.isEmpty() && ( thisStage.failFast || root.options?.options?.get("parallelsAlwaysFailFast") != null) ) {
@@ -238,61 +237,58 @@ class ModelInterpreter implements Serializable {
      * @param firstError An error that's already occurred earlier in the build. Can be null.
      * @param parent The possible parent stage, defaults to null.
      * @param skippedReason Possibly null reason this stage's parent, and therefore itself, is skipped.
-     * @return TODO just run directly
      */
     def evaluateStage(Root root, Agent parentAgent, Stage thisStage, Throwable firstError, Stage parent,
                       SkippedStageReason skippedReason) {
-        return {
-            script.stage(thisStage.name) {
-                try {
-                    if (skippedReason != null) {
-                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
-                    } else if (firstError != null) {
-                        skippedReason = new SkippedStageReason.Failure(thisStage.name)
-                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
-                    } else if (skipUnstable(root.options)) {
-                        skippedReason = new SkippedStageReason.Unstable(thisStage.name)
-                        skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
-                    } else {
-                        // if this a is a matrix generated stage, evaluate the matrix axis values first
-                        // These are literals that guaranteed not to depend on other variables
-                        // Users will expect them to be available at all times in a particular cell in a matrix.
-                        withEnvBlock(thisStage.getMatrixCellEnvVars(script)) {
+        script.stage(thisStage.name) {
+            try {
+                if (skippedReason != null) {
+                    skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent)
+                } else if (firstError != null) {
+                    skippedReason = new SkippedStageReason.Failure(thisStage.name)
+                    skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent)
+                } else if (skipUnstable(root.options)) {
+                    skippedReason = new SkippedStageReason.Unstable(thisStage.name)
+                    skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent)
+                } else {
+                    // if this a is a matrix generated stage, evaluate the matrix axis values first
+                    // These are literals that guaranteed not to depend on other variables
+                    // Users will expect them to be available at all times in a particular cell in a matrix.
+                    withEnvBlock(thisStage.getMatrixCellEnvVars(script)) {
 
-                            def whenEvaluator = new WhenEvaluator(thisStage.when)
+                        def whenEvaluator = new WhenEvaluator(thisStage.when)
 
-                            if (whenEvaluator.passedOrNotEvaluatedBeforeOptions()) {
-                                inWrappers(thisStage.options?.wrappers) {
-                                    if (whenEvaluator.passedOrNotEvaluatedBeforeInput()) {
-                                        stageInput(thisStage.input) {
-                                            if (thisStage?.parallel != null) {
-                                                if (whenEvaluator.passedOrNotEvaluated()) {
-                                                    withCredentialsBlock(thisStage.environment) {
-                                                        withEnvBlock(thisStage.getEnvVars(script)) {
-                                                            script.parallel(getParallelStages(root, parentAgent, thisStage, firstError, null))
-                                                        }
+                        if (whenEvaluator.passedOrNotEvaluatedBeforeOptions()) {
+                            inWrappers(thisStage.options?.wrappers) {
+                                if (whenEvaluator.passedOrNotEvaluatedBeforeInput()) {
+                                    stageInput(thisStage.input) {
+                                        if (thisStage?.parallel != null) {
+                                            if (whenEvaluator.passedOrNotEvaluated()) {
+                                                withCredentialsBlock(thisStage.environment) {
+                                                    withEnvBlock(thisStage.getEnvVars(script)) {
+                                                        script.parallel(getParallelStages(root, parentAgent, thisStage, firstError, null))
                                                     }
                                                 }
-                                            } else {
-                                                if (whenEvaluator.passedOrNotEvaluatedBeforeAgent()) {
-                                                    inDeclarativeAgent(thisStage, root, thisStage.agent) {
-                                                        if (whenEvaluator.passedOrNotEvaluated()) {
-                                                            withCredentialsBlock(thisStage.environment) {
-                                                                withEnvBlock(thisStage.getEnvVars(script)) {
-                                                                    toolsBlock(thisStage.tools, thisStage.agent ?: root.agent, parent?.tools ?: root.tools) {
-                                                                        if (thisStage?.stages) {
-                                                                            def nestedError = evaluateSequentialStages(root, thisStage.stages, firstError,
-                                                                                                                       thisStage, null, null).call()
+                                            }
+                                        } else {
+                                            if (whenEvaluator.passedOrNotEvaluatedBeforeAgent()) {
+                                                inDeclarativeAgent(thisStage, root, thisStage.agent) {
+                                                    if (whenEvaluator.passedOrNotEvaluated()) {
+                                                        withCredentialsBlock(thisStage.environment) {
+                                                            withEnvBlock(thisStage.getEnvVars(script)) {
+                                                                toolsBlock(thisStage.tools, thisStage.agent ?: root.agent, parent?.tools ?: root.tools) {
+                                                                    if (thisStage?.stages) {
+                                                                        def nestedError = evaluateSequentialStages(root, thisStage.stages, firstError,
+                                                                                                                    thisStage, null, null)
 
-                                                                            // Propagate any possible error from the sequential stages
-                                                                            // as if it were an error thrown directly.
-                                                                            if (nestedError != null) {
-                                                                                throw nestedError
-                                                                            }
-                                                                        } else {
-                                                                            // Execute the actual stage and potential post-stage actions
-                                                                            executeSingleStage(root, thisStage, parentAgent)
+                                                                        // Propagate any possible error from the sequential stages
+                                                                        // as if it were an error thrown directly.
+                                                                        if (nestedError != null) {
+                                                                            throw nestedError
                                                                         }
+                                                                    } else {
+                                                                        // Execute the actual stage and potential post-stage actions
+                                                                        executeSingleStage(root, thisStage, parentAgent)
                                                                     }
                                                                 }
                                                             }
@@ -304,30 +300,30 @@ class ModelInterpreter implements Serializable {
                                     }
                                 }
                             }
-                            if (!whenEvaluator.passed) {
-                                skippedReason = new SkippedStageReason.When(thisStage.name)
-                                skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent).call()
-                            }
+                        }
+                        if (!whenEvaluator.passed) {
+                            skippedReason = new SkippedStageReason.When(thisStage.name)
+                            skipStage(root, parentAgent, thisStage, firstError, skippedReason, parent)
                         }
                     }
-                } catch (Throwable e) {
-                    Utils.markStageFailedAndContinued(thisStage.name)
-                    if (firstError == null) {
-                        firstError = e
-                    }
-                } finally {
-                    // And finally, run the post stage steps if this was a parallel parent.
-                    if (skippedReason == null &&
-                        root.hasSatisfiedConditions(thisStage.post, script.getProperty("currentBuild"), thisStage, firstError) &&
-                            thisStage?.parallel != null) {
-                        Utils.logToTaskListener("Post stage")
-                        firstError = runPostConditions(thisStage.post, thisStage.agent ?: parentAgent, firstError, thisStage.name)
-                    }
                 }
+            } catch (Throwable e) {
+                Utils.markStageFailedAndContinued(thisStage.name)
+                if (firstError == null) {
+                    firstError = e
+                }
+            } finally {
+                // And finally, run the post stage steps if this was a parallel parent.
+                if (skippedReason == null &&
+                    root.hasSatisfiedConditions(thisStage.post, script.getProperty("currentBuild"), thisStage, firstError) &&
+                        thisStage?.parallel != null) {
+                    Utils.logToTaskListener("Post stage")
+                    firstError = runPostConditions(thisStage.post, thisStage.agent ?: parentAgent, firstError, thisStage.name)
+                }
+            }
 
-                if (firstError != null) {
-                    throw firstError
-                }
+            if (firstError != null) {
+                throw firstError
             }
         }
     }
@@ -358,26 +354,23 @@ class ModelInterpreter implements Serializable {
         }
     }
 
-    // TODO just run directly rather than returning closure
     def skipStage(Root root, Agent parentAgent, Stage thisStage, Throwable firstError, SkippedStageReason reason,
                   Stage parentStage) {
-        return {
-            Utils.logToTaskListener(reason.message)
-            def stepContextFlowNodeId = getFlowNodeId();
-            Utils.markStageWithTag(thisStage.name, stepContextFlowNodeId, StageStatus.TAG_NAME, reason.stageStatus)
-            if (thisStage?.parallel != null) {
-                Map<String, Closure> parallelToSkip = getParallelStages(root, parentAgent, thisStage, firstError, reason)
-                script.parallel(parallelToSkip)
-                if (reason instanceof SkippedStageReason.Restart) {
-                    parallelToSkip.keySet().each { k -> Utils.markStartAndEndNodesInStageAsNotExecuted(k) }
-                }
-            } else if (thisStage?.stages != null) {
-                String restartedStage = null
-                if (reason instanceof SkippedStageReason.Restart) {
-                    restartedStage = reason.restartedStage
-                }
-                evaluateSequentialStages(root, thisStage.stages, firstError, thisStage, restartedStage, reason).call()
+        Utils.logToTaskListener(reason.message)
+        def stepContextFlowNodeId = getFlowNodeId();
+        Utils.markStageWithTag(thisStage.name, stepContextFlowNodeId, StageStatus.TAG_NAME, reason.stageStatus)
+        if (thisStage?.parallel != null) {
+            Map<String, Closure> parallelToSkip = getParallelStages(root, parentAgent, thisStage, firstError, reason)
+            script.parallel(parallelToSkip)
+            if (reason instanceof SkippedStageReason.Restart) {
+                parallelToSkip.keySet().each { k -> Utils.markStartAndEndNodesInStageAsNotExecuted(k) }
             }
+        } else if (thisStage?.stages != null) {
+            String restartedStage = null
+            if (reason instanceof SkippedStageReason.Restart) {
+                restartedStage = reason.restartedStage
+            }
+            evaluateSequentialStages(root, thisStage.stages, firstError, thisStage, restartedStage, reason)
         }
     }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -31,6 +31,7 @@ import hudson.Launcher
 import hudson.model.Result
 import org.jenkinsci.plugins.pipeline.StageStatus
 import org.jenkinsci.plugins.pipeline.modeldefinition.Messages
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript2
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption
 import org.jenkinsci.plugins.pipeline.modeldefinition.steps.CredentialWrapper
@@ -564,7 +565,12 @@ class ModelInterpreter implements Serializable {
                 script.error 'Unrecognized agent type'
                 return null
             }
-            return declarativeAgent.getScript(script).run(body).call()
+            def script = declarativeAgent.getScript(script)
+            if (script instanceof DeclarativeAgentScript2) {
+                script.run(body)
+            } else {
+                script.run(body).call()
+            }
         }
     }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AnyScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/AnyScript.groovy
@@ -39,7 +39,7 @@ class AnyScript extends DeclarativeAgentScript<Any> {
     Closure run(Closure body) {
         return {
             script.node {
-                CheckoutScript.doCheckout(script, describable, null, body).call()
+                CheckoutScript.doCheckout2(script, describable, null, body)
             }
         }
     }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -27,30 +27,27 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
 
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript2
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
-class LabelScript extends DeclarativeAgentScript<Label> {
+class LabelScript extends DeclarativeAgentScript2<Label> {
 
     LabelScript(CpsScript s, Label a) {
         super(s, a)
     }
 
     @Override
-    Closure run(Closure body) {
-        Closure run = {
-            script.node(describable?.label) {
-                CheckoutScript.doCheckout2(script, describable, describable.customWorkspace, body)
-            }
-        }
+    void run(Closure body) {
         if (describable.retries > 1) {
-            return {
-                script.retry(count: describable.retries, conditions: [script.agent(), script.nonresumable()]) {
-                    run.call()
+            script.retry(count: describable.retries, conditions: [script.agent(), script.nonresumable()]) {
+                script.node(describable?.label) {
+                    CheckoutScript.doCheckout2(script, describable, describable.customWorkspace, body)
                 }
             }
         } else {
-            run
+            script.node(describable?.label) {
+                CheckoutScript.doCheckout2(script, describable, describable.customWorkspace, body)
+            }
         }
     }
 }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelScript.groovy
@@ -40,7 +40,7 @@ class LabelScript extends DeclarativeAgentScript<Label> {
     Closure run(Closure body) {
         Closure run = {
             script.node(describable?.label) {
-                CheckoutScript.doCheckout(script, describable, describable.customWorkspace, body).call()
+                CheckoutScript.doCheckout2(script, describable, describable.customWorkspace, body)
             }
         }
         if (describable.retries > 1) {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NoneScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NoneScript.groovy
@@ -25,7 +25,7 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
 
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript2
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class NoneScript extends DeclarativeAgentScript2<None> {

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NoneScript.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/NoneScript.groovy
@@ -28,14 +28,14 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
-class NoneScript extends DeclarativeAgentScript<None> {
+class NoneScript extends DeclarativeAgentScript2<None> {
 
     NoneScript(CpsScript s, None a) {
         super(s, a)
     }
 
     @Override
-    Closure run(Closure body) {
-        return body
+    void run(Closure body) {
+        body.call()
     }
 }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/BasicModelDefTest.java
@@ -78,7 +78,7 @@ public class BasicModelDefTest extends AbstractModelDefTest {
 
     @Issue("JENKINS-47363")
     // Give this a longer timeout
-    @Test(timeout=5 * 60 * 1000)
+    @Test(timeout=10 * 60 * 1000)
     public void stages300() throws Exception {
         assumeFalse("can exceed even 5m timeout", Functions.isWindows());
         RuntimeASTTransformer.SCRIPT_SPLITTING_TRANSFORMATION = true;

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
@@ -25,7 +25,7 @@
 
 package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
 
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript2
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class LabelAndOtherFieldAgentScript extends DeclarativeAgentScript2<LabelAndOtherFieldAgent> {

--- a/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
+++ b/pipeline-model-definition/src/test/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/impl/LabelAndOtherFieldAgentScript.groovy
@@ -28,22 +28,20 @@ package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
-class LabelAndOtherFieldAgentScript extends DeclarativeAgentScript<LabelAndOtherFieldAgent> {
+class LabelAndOtherFieldAgentScript extends DeclarativeAgentScript2<LabelAndOtherFieldAgent> {
 
     LabelAndOtherFieldAgentScript(CpsScript s, LabelAndOtherFieldAgent a) {
         super(s, a)
     }
 
     @Override
-    Closure run(Closure body) {
+    void run(Closure body) {
         script.echo "Running in labelAndOtherField with otherField = ${describable.getOtherField()}"
         script.echo "And nested: ${describable.getNested()}"
         Label l = (Label) Label.DescriptorImpl.instanceForName("label", [label: describable.label])
         l.inStage = describable.inStage
         l.doCheckout = describable.doCheckout
         LabelScript labelScript = (LabelScript) l.getScript(script)
-        return labelScript.run {
-            body.call()
-        }
+        labelScript.run(body)
     }
 }

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgent.java
@@ -28,6 +28,7 @@ import hudson.ExtensionPoint;
 import java.util.Map;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import java.util.logging.Logger;
 import org.jenkinsci.plugins.pipeline.modeldefinition.options.DeclarativeOption;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptDescribable;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptScript;
@@ -41,6 +42,9 @@ import org.jenkinsci.plugins.workflow.cps.GroovySourceFileAllowlist;
  * @author Andrew Bayer
  */
 public abstract class DeclarativeAgent<A extends DeclarativeAgent<A>> extends WithScriptDescribable<A> implements ExtensionPoint {
+
+    private static final Logger LOGGER = Logger.getLogger(DeclarativeAgent.class.getName());
+
     protected boolean inStage;
     protected boolean doCheckout;
     protected String subdirectory;
@@ -53,7 +57,11 @@ public abstract class DeclarativeAgent<A extends DeclarativeAgent<A>> extends Wi
 
         cpsScript.getClass().getClassLoader().loadClass("org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript");
 
-        return super.getScript(cpsScript);
+        var script = super.getScript(cpsScript);
+        if (script instanceof DeclarativeAgentScript) {
+            LOGGER.warning(() -> script.getClass().getName() + " should implement " + DeclarativeAgentScript2.class.getName());
+        }
+        return script;
     }
 
     public void setInStage(boolean inStage) {

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript.java
@@ -34,5 +34,6 @@ public abstract class DeclarativeAgentScript<A extends DeclarativeAgent<A>> exte
         super(s, a);
     }
 
+    // TODO define optimized version that runs body directly rather than returning Closure
     public abstract Closure run(Closure body);
 }

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript.java
@@ -27,13 +27,12 @@ import groovy.lang.Closure;
 import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptScript;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 
-
+@Deprecated
 public abstract class DeclarativeAgentScript<A extends DeclarativeAgent<A>> extends WithScriptScript<A> {
 
     public DeclarativeAgentScript(CpsScript s, A a) {
         super(s, a);
     }
 
-    // TODO define optimized version that runs body directly rather than returning Closure
     public abstract Closure run(Closure body);
 }

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript2.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/DeclarativeAgentScript2.java
@@ -22,23 +22,17 @@
  * THE SOFTWARE.
  */
 
+package org.jenkinsci.plugins.pipeline.modeldefinition.agent;
 
-package org.jenkinsci.plugins.pipeline.modeldefinition.agent.impl
+import groovy.lang.Closure;
+import org.jenkinsci.plugins.pipeline.modeldefinition.withscript.WithScriptScript;
+import org.jenkinsci.plugins.workflow.cps.CpsScript;
 
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript
-import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript2
-import org.jenkinsci.plugins.workflow.cps.CpsScript
+public abstract class DeclarativeAgentScript2<A extends DeclarativeAgent<A>> extends WithScriptScript<A> {
 
-class AnyScript extends DeclarativeAgentScript2<Any> {
-
-    AnyScript(CpsScript s, Any a) {
-        super(s, a)
+    public DeclarativeAgentScript2(CpsScript s, A a) {
+        super(s, a);
     }
 
-    @Override
-    void run(Closure body) {
-        script.node {
-            CheckoutScript.doCheckout2(script, describable, null, body)
-        }
-    }
+    public abstract void run(Closure body);
 }

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/RetryableDeclarativeAgent.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/agent/RetryableDeclarativeAgent.java
@@ -28,21 +28,18 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * A type of {@code agent} option that supports automatic retries.
- * Usage from your {@link DeclarativeAgentScript#run} would look something like:
+ * Usage from your {@link DeclarativeAgentScript2#run} would look something like:
  * <pre>{@code
- * Closure run = {
- *     script.node {
- *         CheckoutScript.doCheckout(script, describable, null, body).call()
- *     }
- * }
  * if (describable.retries > 1) {
- *     return {
- *         script.retry(count: describable.retries, conditions: [script.agent(), script.nonresumable()]) {
- *             run.call()
+ *     script.retry(count: describable.retries, conditions: [script.agent(), script.nonresumable()]) {
+ *         script.node {
+ *             CheckoutScript.doCheckout2(script, describable, null, body)
  *         }
  *     }
  * } else {
- *     run
+ *     script.node {
+ *         CheckoutScript.doCheckout2(script, describable, null, body)
+ *     }
  * }}</pre>
  */
 public abstract class RetryableDeclarativeAgent<A extends RetryableDeclarativeAgent<A>> extends DeclarativeAgent<A> {

--- a/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
+++ b/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
@@ -30,6 +30,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class CheckoutScript implements Serializable {
     
+    // TODO define optimized version that runs body directly rather than returning Closure
     static Closure doCheckout(CpsScript script, DeclarativeAgent agent, String customWorkspace = null, Closure body) {
         return {
             if (customWorkspace) {

--- a/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
+++ b/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
@@ -30,19 +30,23 @@ import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class CheckoutScript implements Serializable {
     
-    // TODO define optimized version that runs body directly rather than returning Closure
+    @Deprecated
     static Closure doCheckout(CpsScript script, DeclarativeAgent agent, String customWorkspace = null, Closure body) {
         return {
-            if (customWorkspace) {
-                script.ws(customWorkspace) {
-                    checkoutAndRun(script, agent, body)
-                }
-            } else {
-                checkoutAndRun(script, agent, body)
-            }
+            doCheckout2(script, agent, customWorkspace, body)
         }
     }
-    
+
+    static void doCheckout2(CpsScript script, DeclarativeAgent agent, String customWorkspace = null, Closure body) {
+        if (customWorkspace) {
+            script.ws(customWorkspace) {
+                checkoutAndRun(script, agent, body)
+            }
+        } else {
+            checkoutAndRun(script, agent, body)
+        }
+    }
+
     private static void checkoutAndRun(CpsScript script, DeclarativeAgent agent, Closure body) {
         def checkoutMap = [:]
 

--- a/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
+++ b/pipeline-model-extensions/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/agent/CheckoutScript.groovy
@@ -35,35 +35,31 @@ class CheckoutScript implements Serializable {
         return {
             if (customWorkspace) {
                 script.ws(customWorkspace) {
-                    checkoutAndRun(script, agent, body).call()
+                    checkoutAndRun(script, agent, body)
                 }
             } else {
-                checkoutAndRun(script, agent, body).call()
+                checkoutAndRun(script, agent, body)
             }
         }
     }
     
-    private static Closure checkoutAndRun(CpsScript script, DeclarativeAgent agent, Closure body) {
-        return {
-            def checkoutMap = [:]
+    private static void checkoutAndRun(CpsScript script, DeclarativeAgent agent, Closure body) {
+        def checkoutMap = [:]
 
-            if (agent.isDoCheckout() && agent.hasScmContext(script)) {
-                String subDir = agent.subdirectory
-                if (subDir != null && subDir != "") {
-                    script.dir(subDir) {
-                        checkoutMap.putAll(performCheckout(script, agent))
-                    }
-                } else {
+        if (agent.isDoCheckout() && agent.hasScmContext(script)) {
+            String subDir = agent.subdirectory
+            if (subDir != null && subDir != "") {
+                script.dir(subDir) {
                     checkoutMap.putAll(performCheckout(script, agent))
                 }
-            }
-            if (checkoutMap) {
-                script.withEnv(checkoutMap.collect { k, v -> "${k}=${v}" }) {
-                    body.call()
-                }
             } else {
-                body.call()
+                checkoutMap.putAll(performCheckout(script, agent))
             }
+        }
+        if (checkoutMap) {
+            script.withEnv(checkoutMap.collect { k, v -> "${k}=${v}" }, body)
+        } else {
+            body.call()
         }
     }
 


### PR DESCRIPTION
Output from https://github.com/jenkinsci/workflow-support-plugin/pull/305 indicate that a lot of stack frames are `Closure.call`. In some cases this is actually helping to structure code. In others, it is not. Two half-cheese, half-sausage pizzas are just one cheese and one sausage pizza.

[CloudBees-internal issue](https://cloudbees.atlassian.net/browse/BEE-54716)
