### PR TITLE
fix(pct): Add the optional matrix-project dependency in test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
         <artifactId>rhino</artifactId>
         <version>1.7.15</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>matrix-project</artifactId>
+        <scope>test</scope>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
We got [an error](https://ci.jenkins.io/job/Tools/job/bom/job/master/4118/testReport/junit/org.jenkinsci.plugins.pipeline_model_definition/InjectedTest/pct_pipeline_model_definition_plugin_2_492_x___testPluginActive/) during the latest BOM build.

As per https://github.com/jenkinsci/bom/blob/master/CONTRIBUTING.md#failed-to-load---update-required

>This message usually shows that an optional dependency of a plugin is not being updated by the Plugin Compatibility Tester (PCT) and that update is needed by another plugin. This is a known issue in PCT.
> Workarounds include:
> - Add the optional dependency in test scope to the affected plugin. The workaround leaves an unnecessary test dependency in the affected plugin in order to avoid the issue
> - Pin an older version of the optional plugin on older LTS lines if the issue is not visible in the weekly line. This only works if the specific issue is not visible on the weekly line.
 
 I then added the optional dependency in test scope.