### PR TITLE
[JENKINS-75468] Fix Generator rendering/generation of "options" directive

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/OptionsDirective.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/OptionsDirective.java
@@ -46,6 +46,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,7 +59,7 @@ public class OptionsDirective extends AbstractDirective<OptionsDirective> {
     @DataBoundConstructor
     public OptionsDirective(List<Describable> options) {
         if (options != null) {
-            this.options.addAll(options);
+            this.options.addAll(options.stream().filter(Objects::nonNull).toList());
         }
     }
 

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGenerator/index.jelly
@@ -43,7 +43,7 @@
                 </f:block>
                 <f:section title="${%Directives}"/>
                 <!-- Similar to f:dropdownDescriptorSelector, but adds fallback content to block, and JENKINS-25130 adds per-selection help: -->
-                <j:set var="item" value="${it.getItem(request)}"/>
+                <j:set var="item" value="${it.getItem(request2)}"/>
                 <d:taglib uri="local">
                     <d:tag name="listDirectives">
                         <j:set var="inStage" value="false"/>

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/generator/DirectiveGeneratorTest.java
@@ -419,6 +419,17 @@ public class DirectiveGeneratorTest {
                 "}");
     }
 
+    @Issue("JENKINS-75468")
+    @Test
+    public void optionsHandlesNullProperties() throws Exception {
+        List<Describable> o = new ArrayList<>();
+        // This can happen in at least one known instance; the descriptor for OverrideIndexTriggersJobProperty
+        // (from branch-api) will return a null instance if the incoming form data says it hasn't been selected.
+        o.add(null);
+        OptionsDirective options = new OptionsDirective(o);
+        dg.assertGenerateDirective(options, "options {\n}");
+    }
+
     @Test
     public void tools() throws Exception {
         ToolsDirective tools = new ToolsDirective(Collections.singletonList(new ToolsDirective.SymbolAndName("maven::::apache-maven-3.0.1")));


### PR DESCRIPTION
* JENKINS issue(s):
    * https://issues.jenkins.io/browse/JENKINS-75468
* Description:
    * Fixes NPEs which stop snippet generation from fully working
* Documentation changes:
    * Bug fix; no new functionality
* Users/aliases to notify:
    * @basil 

This contains the same fix from https://github.com/jenkinsci/workflow-cps-plugin/pull/1003 and a second fix, both which are needed for the `overrideIndexTriggers` option to render/generate properly.

Before the fix, both a regular pipeline job and multibranch job would result in the same UI
the same stacktrace at the time it was rendered.  They also had the same lack of snippet and resulting stacktrace when actually generating the output.  This representative screenshot is for a multibranch job (which *should* be configurable):
![image](https://github.com/user-attachments/assets/9fe1b2a9-bca9-4412-951c-9360c3d9aae6)


With this fix, no stacktraces are generated in any scenario.  A regular pipeline job still looks the same, but generates a valid snippet:
![image](https://github.com/user-attachments/assets/ecee2d83-71c5-46a9-8846-c5a1c3d30cf5)

A multibranch job now shows the actual config options and all three possible combinations (only one shown here) generate the correct snippet:
![image](https://github.com/user-attachments/assets/afe750d5-c017-4315-8efd-5e4ca58baf21)

That property has been [returning `null`](https://github.com/jenkinsci/branch-api-plugin/blame/d4e0cb42cdaf341c6fa7bf778688a4968cc21dce/src/main/java/jenkins/branch/OverrideIndexTriggersJobProperty.java#L77) for many years.  This may have been broken for that long, but if I had to guess, there may have been a UI change that made it relevant.

It seems weird to me that for a multibranch project, you basically have to select it twice to actually use it: once from the menu, and then clicking the checkbox.  Or from another angle, that property isn't relevant for plain pipeline jobs yet shows up in the dropdown; it would make more sense to not be in the list at all.

In other words, maybe at one point that (seemingly redundant) level of indirection was not present and the act of selecting it from the dropdown made it "selected" (thus returning a valid object rather than `null`).