### PR TITLE
Update inconsistent style for restart from stage

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction/index.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction/index.jelly
@@ -35,11 +35,13 @@
                 </p>
                 <f:form action="restart" method="POST" name="restart">
                     <f:entry field="stageName" title="${%Stage Name}">
-                        <select name="stageName">
-                            <j:forEach var="stage" items="${it.restartableStages}">
-                                <f:option value="${stage}">${stage}</f:option>
-                            </j:forEach>
-                        </select>
+                        <div class="jenkins-select">
+                            <select class="jenkins-select__input" name="stageName">
+                                <j:forEach var="stage" items="${it.restartableStages}">
+                                    <f:option value="${stage}">${stage}</f:option>
+                                </j:forEach>
+                            </select>
+                        </div>
                     </f:entry>
                     <f:bottomButtonBar>
                         <f:submit value="${%Run}"/>


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * Use consistent style for restart from stage
    - **Before** ![CleanShot 2025-04-24 at 13 02 47](https://github.com/user-attachments/assets/401ddb70-c302-46c8-baae-d49fe04bddb7)
    * **After** ![CleanShot 2025-04-24 at 13 01 37](https://github.com/user-attachments/assets/d9b249c8-1ded-4549-9bc4-1740fd49a1bc)

* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * ...
