### PR TITLE
Update inconsistent style for Declarative Directive Generator

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/PostDirective/config.jelly
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/generator/PostDirective/config.jelly
@@ -29,8 +29,8 @@
         for more information on the <code>post</code> directive.
         <f:entry title="${%Conditions}" help="${descriptor.getHelpPage()}">
             <j:forEach var="c" items="${descriptor.getPossibleConditions()}">
-                <div>
-                    <input type="checkbox" name="conditions" json="${c.getKey()}" value="${c.getKey()}">${c.getValue()}</input>
+                <div class="jenkins-form-item tr">
+                    <f:checkbox title="${c.getValue()}" field="conditions" json="${c.getKey()}" />
                 </div>
             </j:forEach>
         </f:entry>


### PR DESCRIPTION
* JENKINS issue(s):
    * n/a
* Description:
    * Use consistent style for Declarative Directive Generator
    * **Before**
    ![CleanShot 2025-06-26 at 20 28 48@2x](https://github.com/user-attachments/assets/5c900067-0708-4fc2-965f-01d1bd738762)
    * **After**
    ![CleanShot 2025-06-26 at 20 34 02@2x](https://github.com/user-attachments/assets/f124558a-76d0-4499-a250-838033acdfdb)

* Documentation changes:
    * Link to related jenkins.io PR or explanation for why doc change not needed
* Users/aliases to notify:
    * ...
