### PR TITLE
Bump `jenkins-test-harness.version`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,8 @@
     <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
+    <!-- TODO until in parent -->
+    <jenkins-test-harness.version>2516.vc8fe6b_362b_19</jenkins-test-harness.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
Pick up https://github.com/jenkinsci/jenkins-test-harness/pull/1042 to unblock https://github.com/jenkinsci/bom/pull/5884 without waiting for it to appear in a parent POM.