### PR TITLE
Fix race condition in parallel stage post-condition evaluation

### DIFF
--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/ModelInterpreter.groovy
@@ -723,7 +723,15 @@ class ModelInterpreter implements Serializable {
                 Closure c = responder.closureForSatisfiedCondition(conditionName, runWrapper,
                     stageName, stageError)
                 if (c != null) {
-                    runWrapper.rawBuild.@result = logicalResult
+                    // For stage-level post conditions, avoid temporarily mutating the
+                    // global build result. During parallel execution, this mutation is
+                    // visible to sibling stages and causes a race condition where a
+                    // sibling's post evaluation reads a dirty global result. For
+                    // pipeline-level post (stageName == null), the mutation is safe
+                    // because there is no concurrent execution at that point.
+                    if (stageName == null) {
+                        runWrapper.rawBuild.@result = logicalResult
+                    }
                     catchRequiredContextForNode(agentContext) {
                         delegateAndExecute(c)
                     }
@@ -738,16 +746,18 @@ class ModelInterpreter implements Serializable {
                     stageError = e
                 }
             } finally {
-                Result currentResult = Result.fromString(runWrapper.currentResult);
-                // We can't leave the result set because it will interfere with the
-                // final build result, so we reset it to the original value unless
-                // the actual value changed inside of the post condition.However,
-                // if the build result is set to the logical build result manually,
-                // then after the post condition it will be set back to the original
-                // value. This seems ok since the logical result is the same and so
-                // will be reset for any later post conditions.
-                if (currentResult == logicalResult && logicalResult != originalResult) {
-                    runWrapper.rawBuild.@result = originalResult // Intentionally using .@ to bypass the setter which does not allow nulls.
+                if (stageName == null) {
+                    Result currentResult = Result.fromString(runWrapper.currentResult);
+                    // We can't leave the result set because it will interfere with the
+                    // final build result, so we reset it to the original value unless
+                    // the actual value changed inside of the post condition. However,
+                    // if the build result is set to the logical build result manually,
+                    // then after the post condition it will be set back to the original
+                    // value. This seems ok since the logical result is the same and so
+                    // will be reset for any later post conditions.
+                    if (currentResult == logicalResult && logicalResult != originalResult) {
+                        runWrapper.rawBuild.@result = originalResult // Intentionally using .@ to bypass the setter which does not allow nulls.
+                    }
                 }
             }
         }

--- a/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/compat/ModelInterpreter.groovy
+++ b/pipeline-model-definition/src/main/resources/org/jenkinsci/plugins/pipeline/modeldefinition/compat/ModelInterpreter.groovy
@@ -763,7 +763,15 @@ class ModelInterpreter implements Serializable {
                 Closure c = responder.closureForSatisfiedCondition(conditionName, runWrapper,
                     stageName, stageError)
                 if (c != null) {
-                    runWrapper.rawBuild.@result = logicalResult
+                    // For stage-level post conditions, avoid temporarily mutating the
+                    // global build result. During parallel execution, this mutation is
+                    // visible to sibling stages and causes a race condition where a
+                    // sibling's post evaluation reads a dirty global result. For
+                    // pipeline-level post (stageName == null), the mutation is safe
+                    // because there is no concurrent execution at that point.
+                    if (stageName == null) {
+                        runWrapper.rawBuild.@result = logicalResult
+                    }
                     catchRequiredContextForNode(agentContext) {
                         delegateAndExecute(c)
                     }
@@ -778,16 +786,18 @@ class ModelInterpreter implements Serializable {
                     stageError = e
                 }
             } finally {
-                Result currentResult = Result.fromString(runWrapper.currentResult);
-                // We can't leave the result set because it will interfere with the
-                // final build result, so we reset it to the original value unless
-                // the actual value changed inside of the post condition.However,
-                // if the build result is set to the logical build result manually,
-                // then after the post condition it will be set back to the original
-                // value. This seems ok since the logical result is the same and so
-                // will be reset for any later post conditions.
-                if (currentResult == logicalResult && logicalResult != originalResult) {
-                    runWrapper.rawBuild.@result = originalResult // Intentionally using .@ to bypass the setter which does not allow nulls.
+                if (stageName == null) {
+                    Result currentResult = Result.fromString(runWrapper.currentResult);
+                    // We can't leave the result set because it will interfere with the
+                    // final build result, so we reset it to the original value unless
+                    // the actual value changed inside of the post condition. However,
+                    // if the build result is set to the logical build result manually,
+                    // then after the post condition it will be set back to the original
+                    // value. This seems ok since the logical result is the same and so
+                    // will be reset for any later post conditions.
+                    if (currentResult == logicalResult && logicalResult != originalResult) {
+                        runWrapper.rawBuild.@result = originalResult // Intentionally using .@ to bypass the setter which does not allow nulls.
+                    }
                 }
             }
         }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/PostStageTest.java
@@ -239,6 +239,24 @@ public class PostStageTest extends AbstractModelDefTest {
                 .go();
     }
 
+    @Test
+    public void parallelCatchErrorSiblingPostCondition() throws Exception {
+        // When a parallel stage fails (caught by catchError with buildResult: SUCCESS),
+        // sibling stages that succeed should run their 'success' post block, not
+        // 'failure'. The sibling's post-condition evaluation must not be affected by
+        // the failing stage's result polluting the global build/execution result.
+        expect("parallelCatchErrorSiblingPostCondition")
+                .logContains(
+                        "Stage 1 post: SUCCESS",
+                        "Stage 1 post: ALWAYS",
+                        "Stage 2 post: FAILURE",
+                        "Stage 2 post: ALWAYS")
+                .logNotContains(
+                        "Stage 1 post: FAILURE",
+                        "Stage 2 post: SUCCESS")
+                .go();
+    }
+
     @Issue("JENKINS-52114")
     @Test
     public void abortedShouldNotTriggerFailure() throws Exception {
@@ -332,10 +350,13 @@ public class PostStageTest extends AbstractModelDefTest {
     @Issue("JENKINS-57826")
     @Test
     public void catchErrorStageUnstableBuildFailure() throws Exception {
+        // When catchError sets stageResult: "UNSTABLE" and buildResult: "FAILURE",
+        // the stage post block should see the stage result (UNSTABLE), not the
+        // build result (FAILURE). The build-level post block should see FAILURE.
         expect(Result.FAILURE, "catchErrorStageUnstableBuildFailure")
-                .logContains("This should happen",
+                .logContains("Stage unstable should happen",
                         "The build should be a failure")
-                .logNotContains("This shouldn't happen",
+                .logNotContains("Stage failure should not happen",
                         "The build shouldn't be unstable")
                 .go();
     }

--- a/pipeline-model-definition/src/test/resources/postStage/catchErrorStageUnstableBuildFailure.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/catchErrorStageUnstableBuildFailure.groovy
@@ -36,10 +36,10 @@ pipeline {
             }
             post {
                 failure {
-                    echo "This should happen"
+                    echo "Stage failure should not happen"
                 }
                 unstable {
-                    echo "This shouldn't happen"
+                    echo "Stage unstable should happen"
                 }
             }
         }

--- a/pipeline-model-definition/src/test/resources/postStage/parallelCatchErrorSiblingPostCondition.groovy
+++ b/pipeline-model-definition/src/test/resources/postStage/parallelCatchErrorSiblingPostCondition.groovy
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2026, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Regression test for parallel stage post-condition race condition.
+// When Stage 2 fails (caught by catchError), Stage 1's post block
+// should evaluate based on Stage 1's own result, not be affected
+// by Stage 2's failure polluting the global build result.
+
+pipeline {
+    agent any
+
+    stages {
+        stage('Parallel Stages') {
+            parallel {
+                stage('Stage 1') {
+                    steps {
+                        echo "Stage 1 running"
+                    }
+                    post {
+                        success {
+                            echo 'Stage 1 post: SUCCESS'
+                        }
+                        failure {
+                            echo 'Stage 1 post: FAILURE'
+                        }
+                        always {
+                            echo 'Stage 1 post: ALWAYS'
+                        }
+                    }
+                }
+
+                stage('Stage 2') {
+                    steps {
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            error('Stage 2 intentional failure')
+                        }
+                    }
+                    post {
+                        success {
+                            echo 'Stage 2 post: SUCCESS'
+                        }
+                        failure {
+                            echo 'Stage 2 post: FAILURE'
+                        }
+                        always {
+                            echo 'Stage 2 post: ALWAYS'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
+++ b/pipeline-model-extensions/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/model/BuildCondition.java
@@ -168,6 +168,29 @@ public abstract class BuildCondition implements Serializable, ExtensionPoint {
                 }
             }
         }
+        if (error != null) {
+            if (error instanceof FlowInterruptedException) {
+                errorResult = ((FlowInterruptedException)error).getResult();
+            } else {
+                errorResult = Result.FAILURE;
+            }
+        }
+        // When evaluating a stage-level post condition (context is the stage name)
+        // and we have explicit stage-scoped result information (from WarningAction
+        // set by catchError/warnError, or from a stage error), use only the
+        // stage-scoped result. Do not combine with the global execution/build result,
+        // because during parallel execution the global result may reflect failures
+        // from sibling stages that have nothing to do with this stage's own outcome.
+        // This avoids a race condition where a sibling's failure taints the global
+        // result before this stage's post-condition evaluation, causing the wrong
+        // post block to run.
+        //
+        // When no stage-scoped result information is available (errorResult is
+        // SUCCESS), fall back to the global result for backwards compatibility with
+        // stages that set currentBuild.result directly.
+        if (context instanceof String && errorResult != Result.SUCCESS) {
+            return errorResult;
+        }
         Result execResult = getFlowExecutionResult(run);
         Result prevResult = run.getResult();
         if (prevResult == null) {
@@ -175,13 +198,6 @@ public abstract class BuildCondition implements Serializable, ExtensionPoint {
         }
         if (execResult == null) {
             execResult = Result.SUCCESS;
-        }
-        if (error != null) {
-            if (error instanceof FlowInterruptedException) {
-                errorResult = ((FlowInterruptedException)error).getResult();
-            } else {
-                errorResult = Result.FAILURE;
-            }
         }
         return execResult.combine(prevResult).combine(errorResult);
     }


### PR DESCRIPTION
Stage-level post blocks (success, failure, etc.) were evaluating based on the global build/execution result, which during parallel execution could be tainted by a sibling stage's failure. This caused a successful parallel stage to incorrectly run its 'failure' post block instead of 'success'.

The fix isolates stage-level post-condition evaluation: when a stage has explicit stage-scoped result information (from catchError/warnError via WarningAction, or from a stage error), getCombinedResult() now returns only that stage-scoped result without combining it with the global result.

Additionally, runPostConditions() no longer temporarily mutates the global WorkflowRun.result for stage-level post blocks, eliminating a second race vector where sibling stages could read a dirty global result during concurrent post-block execution.

Includes a new test (parallelCatchErrorSiblingPostCondition) that verifies a successful parallel sibling correctly runs its 'success' post block when another sibling fails with catchError.

* JENKINS issue(s):
    * https://github.com/jenkinsci/workflow-cps-plugin/issues/1750
