### PR TITLE
`Restart from stage` - should appear after Jenkins restart

### DIFF
--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
@@ -93,8 +93,15 @@ public class RestartDeclarativePipelineAction implements Action {
         if (owner == null) {
             return null;
         }
-        FlowExecution exec = owner.getOrNull();
-        return exec instanceof CpsFlowExecution ? (CpsFlowExecution) exec : null;
+        // Use get() rather than getOrNull(): for a completed build loaded from disk (e.g. after restart),
+        // the FlowExecution is not in memory, but this action is rendered on the build's own page where
+        // loading the execution is appropriate.
+        try {
+            FlowExecution exec = owner.get();
+            return exec instanceof CpsFlowExecution ? (CpsFlowExecution) exec : null;
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @Exported

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
@@ -104,7 +104,7 @@ public class RestartDeclarativePipelineAction implements Action {
             FlowExecution exec = owner.get();
             return exec instanceof CpsFlowExecution cfe ? cfe : null;
         } catch (IOException e) {
-            LOGGER.log(Level.FINE, "Exception while fetching FlowExecution for " + run + ", returning null", e);
+            LOGGER.log(Level.WARNING, e, () -> "Failed to load metadata of " + run);
             return null;
         }
     }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
@@ -98,7 +98,7 @@ public class RestartDeclarativePipelineAction implements Action {
         // loading the execution is appropriate.
         try {
             FlowExecution exec = owner.get();
-            return exec instanceof CpsFlowExecution ? (CpsFlowExecution) exec : null;
+            return exec instanceof CpsFlowExecution cfe ? cfe : null;
         } catch (IOException e) {
             return null;
         }

--- a/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
+++ b/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineAction.java
@@ -61,9 +61,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @ExportedBean
 public class RestartDeclarativePipelineAction implements Action {
+
+    private static final Logger LOGGER = Logger.getLogger(RestartDeclarativePipelineAction.class.getName());
 
     private final Run run;
 
@@ -100,6 +104,7 @@ public class RestartDeclarativePipelineAction implements Action {
             FlowExecution exec = owner.get();
             return exec instanceof CpsFlowExecution cfe ? cfe : null;
         } catch (IOException e) {
+            LOGGER.log(Level.FINE, "Exception while fetching FlowExecution for " + run + ", returning null", e);
             return null;
         }
     }

--- a/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineActionRestartTest.java
+++ b/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineActionRestartTest.java
@@ -1,0 +1,33 @@
+package org.jenkinsci.plugins.pipeline.modeldefinition.actions;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsSessionRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class RestartDeclarativePipelineActionRestartTest {
+
+    @Rule public JenkinsSessionRule jsr = new JenkinsSessionRule();
+
+    @Test
+    public void restartEnabledAfterJenkinsRestart() throws Throwable {
+        jsr.then(r -> {
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                    "pipeline { agent any; stages { stage('s') { steps { echo 'hi' } } } }", true));
+            r.buildAndAssertSuccess(p);
+        });
+        jsr.then(r -> {
+            WorkflowJob p = r.jenkins.getItemByFullName("p", WorkflowJob.class);
+            WorkflowRun b = p.getBuildByNumber(1);
+            RestartDeclarativePipelineAction action = b.getAction(RestartDeclarativePipelineAction.class);
+            assertNotNull("action should be present", action);
+            assertTrue("restart should be enabled after Jenkins restart", action.isRestartEnabled());
+        });
+    }
+}


### PR DESCRIPTION
`Restart from stage` button is missing after restart.

Originally noticed in CloudBees High availability environment - where 1 replica executed the build and notified another replica to load it from the disk.

Same problem is able to reproduce in a standalone open source Jenkins instance by a simple restart.
`getOrNull` has a check on a promise which is only present in the JVM where the build ran - https://github.com/jenkinsci/workflow-job-plugin/blob/e4bd0dbfcbbb7f21d942fe84c817811c51100758/src/main/java/org/jenkinsci/plugins/workflow/job/WorkflowRun.java#L1025-L1026

|Description|Before restart|After restart|
|---|---|---|
|Before fix|<img width="1060" height="602" alt="image" src="https://github.com/user-attachments/assets/129f6d77-918c-4080-b32e-45059f8b0484" />|<img width="843" height="587" alt="image" src="https://github.com/user-attachments/assets/d4625d71-c21f-4244-9d5c-5f99781ae784" />|
|After fix|<img width="870" height="611" alt="image" src="https://github.com/user-attachments/assets/f11339c7-60fd-4f61-904b-854a46608e97" />|<img width="850" height="570" alt="image" src="https://github.com/user-attachments/assets/4fd777ff-345c-4a7d-94d1-ffaf73c2960e" />|