### PR TITLE
Allow plugin to compile with Java 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,4 +8,5 @@ buildPlugin(
   configurations: [
     [platform: 'linux', jdk: 25],
     [platform: 'windows', jdk: 21],
+    [platform: 'linux', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2185.v41f4290b_a_458</version>
+    <version>6.2189.v695a_c41f5249</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Allow plugin to compile with Java 17

Plugin parent pom 6.2185.v41f4290b_a_458 unintentionally broke Java 17 compilation with the ban dependency overrides improvement.  The issue is fixed in plugin parent pom 6.2189.v695a_c41f5249.  The plugin needs to still compile with Java 17 so that it can be included in the plugin BOM for release lines 2.528.x and 2.541.x.  We can't require Java 21 as a miminimum Java version for plugins that support LTS lines older than 2.555.x.

Refer to the 2.555.1 changelog at:

* https://www.jenkins.io/changelog/2.555.1/

Detected by plugin BOM:

* https://github.com/jenkinsci/bom/issues/6871

The plugin needs a new release that includes this change before it can be upgraded in the plugin BOM.

## Testing done:

* Confirmed that `mvn clean verify` passes with Java 17 with these changes
